### PR TITLE
Improved type-2 parallellization

### DIFF
--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -377,7 +377,7 @@ int spreadwithsortidx(BIGINT* sort_indices,BIGINT N1, BIGINT N2, BIGINT N3,
       FLT *ker3 = kernel_values + 2*ns;       
 
       // Loop over interpolation chunks
-#pragma omp for schedule(dynamic,10000) // (dynamic not needed) assign threads to NU targ pts:
+#pragma omp for schedule(dynamic) // assign threads to NU targ pts:
       for (BIGINT i=0; i<M; i+=CHUNKSIZE)  // main loop over NU targs, interp each from U
       {
         // Setup buffers for this chunk

--- a/test/spreadbenchmark.py
+++ b/test/spreadbenchmark.py
@@ -58,14 +58,24 @@ def runTests():
     results = []
     for params in tests:
         cmd = cmdtemplate % params
-        output = runCommand(cmd).rstrip()
-        ms = spreadre.search(output)
-        mi = interpre.search(output)
+        # Best of 3
+        interp_speed = 0
+        interp_err = 0
+        spread_speed = 0
+        spread_err = 0
+        for i in [1,2,3]:
+            output = runCommand(cmd).rstrip()
+            ms = spreadre.search(output)
+            mi = interpre.search(output)
+            interp_speed = max(interp_speed, mi.group("speed"))
+            interp_err = max(interp_err, mi.group("err"))
+            spread_speed = max(spread_speed, ms.group("speed"))
+            spread_err = max(spread_err, ms.group("err"))            
         results.append({"cmd":cmd,
-                        "interp_speed":mi.group("speed"),
-                        "interp_err":mi.group("err"),
-                        "spread_speed":ms.group("speed"),
-                        "spread_err":ms.group("err")})
+                        "interp_speed":interp_speed,
+                        "interp_err":interp_err,
+                        "spread_speed":spread_speed,
+                        "spread_err":spread_err })
     return results
 
 # Code checkout machinery

--- a/test/spreadbenchmark.py
+++ b/test/spreadbenchmark.py
@@ -11,6 +11,9 @@ tests = []
 
 #tests.append({"dim":3, "M":1e7, "N":1e7, "tol":1e-3})
 #tests.append({"dim":3, "M":1e7, "N":1e7, "tol":1e-8})
+
+tests.append({"dim":3, "M":1e5, "N":1e5, "tol":1e-15})
+tests.append({"dim":3, "M":1e6, "N":1e6, "tol":1e-15})
 tests.append({"dim":3, "M":1e7, "N":1e7, "tol":1e-15})
 
 
@@ -18,7 +21,7 @@ tests.append({"dim":3, "M":1e7, "N":1e7, "tol":1e-15})
 flags = "1"
 
 # Make flags (eg OMP=OFF)
-makeflags = "OMP=OFF"
+makeflags = ""
 
 # Command template
 cmdtemplate = "test/spreadtestnd %(dim)d %(M)g %(N)g %(tol)g " + flags


### PR DESCRIPTION
It seems like the performance gap between type-1 and type-2 spreading was due to an explicitly set chunk size in the OpenMP dynamic scheduling. I found this by chance, when I noticed that threading had no positive effect on type-2 spreading for small problems.

Removing the explicit chunk size gives the following speedup on my machine:
```
gcc version 7.3.0
Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
4 cores / 8 threads (hyperthreading)

=== Test: dim=3, M=100000, N=100000, tol=1e-15
Commit          | Spread spd      | Interp spd      | Spread err      | Interp err      
v1.0            | 1.4e+06 pts/s   | 2.39e+05 pts/s  | 7.57e-15        | 1.98e-14        
type2schedule   | 1.52e+06 pts/s  | 1.36e+06 pts/s  | 8.05e-15        | 1.98e-14        
                | +8.6%           | +469.0%         |                 |                 

=== Test: dim=3, M=1e+06, N=1e+06, tol=1e-15
Commit          | Spread spd      | Interp spd      | Spread err      | Interp err      
v1.0            | 1.44e+06 pts/s  | 9.89e+05 pts/s  | 8.37e-14        | 2.1e-14         
type2schedule   | 1.4e+06 pts/s   | 1.31e+06 pts/s  | 3.81e-14        | 2.1e-14         
                | -2.8%           | +32.5%          |                 |                 

=== Test: dim=3, M=1e+07, N=1e+07, tol=1e-15
Commit          | Spread spd      | Interp spd      | Spread err      | Interp err      
v1.0            | 1.19e+06 pts/s  | 9.73e+05 pts/s  | 6.36e-14        | 1.51e-14        
type2schedule   | 1.19e+06 pts/s  | 1.21e+06 pts/s  | 6.51e-14        | 1.53e-14        
                | 0.0%            | +24.4%          |                 |                 

```