### PR TITLE
Add basic requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pybind11
+numpy


### PR DESCRIPTION
This lists the dependencies needed for installing building the
`finufftpy` packages. Fixes #59.