### PR TITLE
Moved finufftpy_cpp as a submodule (interface unchanged).

### DIFF
--- a/finufftpy/_interfaces.py
+++ b/finufftpy/_interfaces.py
@@ -9,7 +9,7 @@
 
 # google-style docstrings for napoleon
 
-import finufftpy_cpp
+import finufftpy.finufftpy_cpp as finufftpy_cpp
 import numpy as np
 
 ## 1-d

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ elif sys.platform == "darwin":
         #extra_link_args=['-static -fPIC']
 
 ext_modules = [Extension(
-        'finufftpy_cpp',
+        'finufftpy.finufftpy_cpp',
         ['finufftpy/finufftpy.cpp'],
         include_dirs=[
             # Path to pybind11 headers


### PR DESCRIPTION
Moved the module `finufft_cpp` (implemented as an extension, so visible as a .so/.pyd file) *inside* the top-level `finufftpy` module.

Having the `finufftpy_cpp` extension as a top-level module instead of a submodule of a "regular" python module is undesirable on two counts:

- It litters the users 'site-packages' folder with an isolated `finufftpy_cpp.so` (or `.pyd` in the case of Windows), with no obvious association with the `finufftpy` package. (Though it will get removed on `pip uninstall` automatically). So it's not considered best practice.
- It is not supported by tools such as `delocate` on mac os x (a tool that inspects the module for calls to shared libraries and packages them inside the `pip` package), and possibly other tools in the future that rely on modules following best practices. `delocate` is an essential tool for mac os x packaging and `finufftpy` will almost certainly use it in the future.

See more discussion at:
https://github.com/matthew-brett/delocate/issues/12

This change is entirely internal (since all public functions are exposed through `_interfaces.py`, which has also been changed to reflect this restructuring).