### PR TITLE
Revert "Moved finufftpy_cpp as a submodule (interface unchanged)."

### DIFF
--- a/finufftpy/_interfaces.py
+++ b/finufftpy/_interfaces.py
@@ -9,7 +9,7 @@
 
 # google-style docstrings for napoleon
 
-import finufftpy.finufftpy_cpp as finufftpy_cpp
+import finufftpy_cpp
 import numpy as np
 
 ## 1-d

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ elif sys.platform == "darwin":
         #extra_link_args=['-static -fPIC']
 
 ext_modules = [Extension(
-        'finufftpy.finufftpy_cpp',
+        'finufftpy_cpp',
         ['finufftpy/finufftpy.cpp'],
         include_dirs=[
             # Path to pybind11 headers


### PR DESCRIPTION
Reverts flatironinstitute/finufft#66.

Vineet, your PR broke the python tests:

   import finufftpy.finufftpy_cpp as finufftpy_cpp
ModuleNotFoundError: No module named 'finufftpy.finufftpy_cpp'
