### PR TITLE
makefile for power9 cpu.

### DIFF
--- a/make.inc.power9
+++ b/make.inc.power9
@@ -1,0 +1,42 @@
+# makefile overrides to use Intel ICC compiler, double prec only.
+# This makefile is greatly inspired from AMReX (amrex/Tools/GNUMake/comps
+
+## Compiler choice
+ifeq ($(COMP),ibm)
+OMPFLAGS = -qsmp=omp
+ifneq ($(OMP),OFF)
+  CXX = xlC_r
+  CC  = xlc_r
+  FC  = xlf_r
+else
+  CXX = xlC
+  CC  = xlc
+  FC  = xlf
+endif
+ifneq ($(DEBUG),TRUE)
+  CXXFLAGS = -qsimd=auto -qmaxmem=-1
+  CFLAGS   = -qsimd=auto -qmaxmem=-1
+endif
+else#DEFAULT is gnu compiler
+CXX = g++
+CC  = gcc
+FC=gfortran
+OMPFLAGS = -fopenmp
+CFLAGS = -funroll-loops -mcpu=powerpc64 -fcx-limited-range
+endif
+
+FFLAGS   = $(CFLAGS)
+CXXFLAGS = $(CFLAGS) -DNEED_EXTERN_C
+
+## shared library
+CFLAGS += -fPIC
+
+ifeq ($(DEBUG),TRUE)
+  CXXFLAGS += -g -O0
+  CFLAGS   += -g -O0
+else
+  CXXFLAGS += -g -O3
+  CFLAGS   += -g -O3
+endif
+CLINK=-lstdc++
+FLINK=$(CLINK)


### PR DESCRIPTION
2 different compiler options: GNU or XL
 COMP=ibm for xl, by default GNU compiler is used.