### PR TITLE
Guru interface v2 1h joakim

### DIFF
--- a/examples/simple1d1cf.c
+++ b/examples/simple1d1cf.c
@@ -1,5 +1,5 @@
 // this is all you must include...
-#include <finufftf.h>
+#include <finufft.h>
 // also needed for this example...
 #include <stdlib.h>
 #include <math.h>

--- a/include/dataTypes.h
+++ b/include/dataTypes.h
@@ -19,8 +19,10 @@ typedef int64_t BIGINT;
 // decide which kind of complex numbers to use in interface...
 #ifdef __cplusplus
 #include <complex>          // C++ type
+#define COMPLEXIFY(X) std::complex<X>
 #else
 #include <complex.h>        // C99 type
+#define COMPLEXIFY(X) X complex
 #endif
 
 #undef FLT
@@ -29,18 +31,10 @@ typedef int64_t BIGINT;
 // Precision-independent real and complex types for interfacing...
 #ifdef SINGLE
   #define FLT float
-  #ifdef __cplusplus
-    #define CPX std::complex<float>
-  #else
-    #define CPX float complex
-  #endif
 #else
   #define FLT double
-  #ifdef __cplusplus
-    #define CPX std::complex<double>
-  #else
-    #define CPX double complex
-  #endif
 #endif
+
+#define CPX COMPLEXIFY(FLT)
 
 #endif  // DATATYPE_H or DATATYPEF_H

--- a/include/dataTypes.h
+++ b/include/dataTypes.h
@@ -1,5 +1,11 @@
-#ifndef DATATYPE_H
-#define DATATYPE_H
+#if (!defined(DATATYPES_H) && !defined(SINGLE)) || (!defined(DATATYPESF_H) && defined(SINGLE))
+// Make sure we only include once per precision (see finufft_eitherprec.h).
+#ifndef SINGLE
+#define DATATYPES_H
+#else
+#define DATATYPESF_H
+#endif
+
 
 // ------------ FINUFFT data type definitions ----------------------------------
 
@@ -17,21 +23,24 @@ typedef int64_t BIGINT;
 #include <complex.h>        // C99 type
 #endif
 
+#undef FLT
+#undef CPX
+
 // Precision-independent real and complex types for interfacing...
 #ifdef SINGLE
-  typedef float FLT;
+  #define FLT float
   #ifdef __cplusplus
-    typedef std::complex<float> CPX;
+    #define CPX std::complex<float>
   #else
-    typedef float complex CPX;
+    #define CPX float complex
   #endif
 #else
-  typedef double FLT;
+  #define FLT double
   #ifdef __cplusplus
-    typedef std::complex<double> CPX;
+    #define CPX std::complex<double>
   #else
-    typedef double complex CPX;
+    #define CPX double complex
   #endif
 #endif
 
-#endif  // DATATYPE_H
+#endif  // DATATYPE_H or DATATYPEF_H


### PR DESCRIPTION
Give dataTypes.h the same treatment as finufft.h, with #ifdef guards that check for the SINGLE flag. To fix the redefinition of typedefs (which is not allowed), these are replaced by macros. As a bonus, we can simplify the definitions of complex types using a COMPLEXIFY macro.