### PR TITLE
Fix RESCALE macro in spreadinterp

### DIFF
--- a/include/spreadinterp.h
+++ b/include/spreadinterp.h
@@ -14,7 +14,7 @@
 // NU coord handling macro: if p is true, rescales from [-pi,pi] to [0,N], then
 // folds *only* one period below and above, ie [-N,2N], into the domain [0,N]...
 #define RESCALE(x,N,p) (p ? \
-		     ((x*M_1_2PI + (x<-PI ? 1.5 : (x>PI ? -0.5 : 0.5)))*N) : \
+		     (x*M_1_2PI*N + (x*M_1_2PI*N<-N/2 ? 1.5 : (x*M_1_2PI*N>N/2 ? -0.5 : 0.5))*N) : \
 		     (x<0 ? x+N : (x>N ? x-N : x)))
 // yuk! But this is *so* much faster than slow std::fmod that we stick to it.
 // *** todo: replace w/ C++ function; apparently will be as fast


### PR DESCRIPTION
This macro introduces cancellation errors when the frequencies are close
to –π or π. These errors then blow up after multiplying by N. By first
multiplying by N and then adding the correction term, we avoid this
problem at the cost of a slightly less transparent macro.

Fixes #103.