### PR TITLE
Make FFTW planner thread-safe

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -87,6 +87,7 @@ using namespace std;        // means std:: not needed for cout, max, etc
   typedef fftwf_plan FFTW_PLAN;
   #define FFTW_INIT fftwf_init_threads
   #define FFTW_PLAN_TH fftwf_plan_with_nthreads
+  #define FFTW_PLAN_SF fftwf_make_planner_thread_safe
   #define FFTW_ALLOC_RE fftwf_alloc_real
   #define FFTW_ALLOC_CPX fftwf_alloc_complex
   #define FFTW_PLAN_1D fftwf_plan_dft_1d
@@ -105,6 +106,7 @@ using namespace std;        // means std:: not needed for cout, max, etc
   typedef fftw_plan FFTW_PLAN;
   #define FFTW_INIT fftw_init_threads
   #define FFTW_PLAN_TH fftw_plan_with_nthreads
+  #define FFTW_PLAN_SF fftw_make_planner_thread_safe
   #define FFTW_ALLOC_RE fftw_alloc_real
   #define FFTW_ALLOC_CPX fftw_alloc_complex
   #define FFTW_PLAN_1D fftw_plan_dft_1d
@@ -142,6 +144,8 @@ using namespace std;        // means std:: not needed for cout, max, etc
   #define FFTW_INIT()
   #undef FFTW_PLAN_TH
   #define FFTW_PLAN_TH(x)
+  #undef FFTW_PLAN_SF
+  #define FFTW_PLAN_SF()
 #endif
 
 #endif  // DEFS_H

--- a/src/defs.h
+++ b/src/defs.h
@@ -144,8 +144,6 @@ using namespace std;        // means std:: not needed for cout, max, etc
   #define FFTW_INIT()
   #undef FFTW_PLAN_TH
   #define FFTW_PLAN_TH(x)
-  #undef FFTW_PLAN_SF
-  #define FFTW_PLAN_SF()
 #endif
 
 #endif  // DEFS_H

--- a/src/finufft1d.cpp
+++ b/src/finufft1d.cpp
@@ -58,6 +58,7 @@ int finufft1d1(BIGINT nj,FLT* xj,CPX* cj,int iflag,FLT eps,BIGINT ms,
     FFTW_INIT();           // (these do nothing anyway when OMP=OFF)
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1);    // working upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;
   FFTW_PLAN p = FFTW_PLAN_1D(nf1,fw,fw,fftsign, opts.fftw);  // in-place
@@ -153,6 +154,7 @@ int finufft1d2(BIGINT nj,FLT* xj,CPX* cj,int iflag,FLT eps,BIGINT ms,
     FFTW_INIT();
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
   timer.restart();
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1);    // working upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;

--- a/src/finufft2d.cpp
+++ b/src/finufft2d.cpp
@@ -74,6 +74,7 @@ int finufft2d1(BIGINT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,
     FFTW_INIT();
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
   timer.restart();
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1*nf2);  // working upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;
@@ -172,6 +173,7 @@ int finufft2d1many(int ndata, BIGINT nj, FLT* xj, FLT *yj, CPX* c,
     FFTW_INIT();
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
 
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1*nf2*nth);  // nthreads copies of upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;
@@ -317,6 +319,7 @@ int finufft2d2(BIGINT nj,FLT* xj,FLT *yj,CPX* cj,int iflag,FLT eps,
     FFTW_INIT();
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
   timer.restart();
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1*nf2);  // working upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;
@@ -414,6 +417,7 @@ int finufft2d2many(int ndata, BIGINT nj, FLT* xj, FLT *yj, CPX* c, int iflag,
     FFTW_INIT();
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
 
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1*nf2*nth);  // nthreads copies of upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;

--- a/src/finufft3d.cpp
+++ b/src/finufft3d.cpp
@@ -79,6 +79,7 @@ int finufft3d1(BIGINT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,int iflag,
     FFTW_INIT();
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
   timer.restart();
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1*nf2*nf3);  // working upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;
@@ -177,6 +178,7 @@ int finufft3d2(BIGINT nj,FLT* xj,FLT *yj,FLT *zj,CPX* cj,
     FFTW_INIT();
     FFTW_PLAN_TH(nth);
   }
+  FFTW_PLAN_SF();
   timer.restart();
   FFTW_CPX *fw = FFTW_ALLOC_CPX(nf1*nf2*nf3); // working upsampled array
   int fftsign = (iflag>=0) ? 1 : -1;


### PR DESCRIPTION
Due to the missing thread safety of the FFTW planner stage, running multiple FINUFFT instances in parallel previously lead to segfaults.

This fix might also be related to issue #72.