### PR TITLE
windows compatibility for v2.0, focusing on WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Convert to LF line endings on checkout.
+*.sh text eol=lf

--- a/examples/guru1d1c.c
+++ b/examples/guru1d1c.c
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
 
   // rest is math checking and reporting...
   int n = 142519;   // check the answer just for this mode
-  Ftest = CMPLX(0.0,0.0);
+  Ftest = 0.0 + 0.0*I;
   for (j=0; j<M; ++j)
     Ftest += c[j] * cexp(I*(double)n*x[j]);
   nout = n+N/2;            // index in output array for freq mode n

--- a/examples/simple1d1c.c
+++ b/examples/simple1d1c.c
@@ -44,7 +44,7 @@ int main(int argc, char* argv[])
 
   int k = 142519;            // check the answer just for this mode...
   assert(k>=-(double)N/2 && k<(double)N/2);
-  double complex Ftest = CMPLX(0.0,0.0);   // defined in complex.h (I too)
+  double complex Ftest = 0.0 + 0.0*I;   // defined in complex.h (I too)
   for (int j=0; j<M; ++j)
     Ftest += c[j] * cexp(I*(double)k*x[j]);
   double Fmax = 0.0;         // compute inf norm of F

--- a/examples/simple1d1cf.c
+++ b/examples/simple1d1cf.c
@@ -44,7 +44,7 @@ int main(int argc, char* argv[])
 
   int k = 14251;          // check the answer just for this mode...
   assert(k>=-(double)N/2 && k<(double)N/2);
-  float complex Ftest = CMPLXF(0.0,0.0);    // defined in complex.h (I too)
+  float complex Ftest = 0.0f + 0.0f*I;    // defined in complex.h (I too)
   for (int j=0; j<M; ++j)
     Ftest += c[j] * cexpf(I*(float)k*x[j]);
   float Fmax = 0.0;       // compute inf norm of F

--- a/include/dataTypes.h
+++ b/include/dataTypes.h
@@ -17,6 +17,7 @@ typedef int64_t BIGINT;
 
 // decide which kind of complex numbers to use in interface...
 #ifdef __cplusplus
+#define _USE_MATH_DEFINES
 #include <complex>          // C++ type
 #define COMPLEXIFY(X) std::complex<X>
 #else

--- a/makefile
+++ b/makefile
@@ -219,11 +219,21 @@ TESTS := $(basename $(wildcard test/*.cpp))
 # also need single-prec
 TESTS += $(TESTS:%=%f)
 test: $(TESTS)
+ifneq ($(MINGW),ON)
 # it will fail if either of these return nonzero exit code...
 	test/basicpassfail
 	test/basicpassfailf
 # accuracy tests done in prec-switchable bash script...
 	(cd test; ./check_finufft.sh; ./check_finufft.sh SINGLE)
+else
+# it will fail if either of these return nonzero exit code... Windows does not find the dynamic libraries, so we make a temporary copy
+	copy $(DYNLIB).so test
+	test/basicpassfail
+	test/basicpassfailf
+# accuracy tests done in prec-switchable bash script... Windows does not feature a bash shell so we use WSL. Since gnu-make is a 32bit executable and WSL runs only in x64 environments, we have to refer to 64bit powershell explicitly
+	$(windir)\Sysnative\WindowsPowerShell\v1.0\powershell.exe "cd ./test; bash check_finufft.sh DOUBLE $(MINGW); bash check_finufft.sh SINGLE $(MINGW)"
+	del test\$(LIBNAME).so
+endif
 
 
 # perftest (performance/developer tests) -------------------------------------

--- a/test/check_finufft.sh
+++ b/test/check_finufft.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Main validation tests for FINUFFT library.
+# Main validation tests for FINUFFT library. On Windows, we append .exe to the names of the executables.
 # Usage:   To do double-precision tests:   ./check_finufft.sh
 #          To do single-precision tests:   ./check_finufft.sh SINGLE
+#          To run test on Windows (WSL):   ./check_finufft.sh (DUMMY or SINGLE) ON
 # Exit code is 0 for success, otherwise failure
 
 # In total these tests take about 5 seconds on a modern machine with the
@@ -52,6 +53,7 @@ T=testutils$PRECSUF
 ./$T$FEX 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}          # exit code of the tested cmd (not the tee cmd!)
 if [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); fi
+# Disregard the OS-dependent line endings with --strip-trailing-cr
 diff --strip-trailing-cr $DIR/$T.out $DIR/$T.refout
 if [[ $? -eq 0 ]]; then echo passed; else echo failed; ((FAILS++)); fi
 

--- a/test/check_finufft.sh
+++ b/test/check_finufft.sh
@@ -27,6 +27,11 @@ else
     CHECK_TOL=1e-11
     export PRECSUF=
 fi
+if [[ $2 == "ON" ]]; then
+    export FEX=".exe"
+else
+    export FEX=
+fi
 # Note that bash cannot handle floating-point arithmetic, and bc cannot read
 # exponent notation. Thus the exponent notation above is purely string in nature
 
@@ -44,54 +49,54 @@ echo "pass-fail FINUFFT library $PREC-precision check with tol=$FINUFFT_REQ_TOL 
 ((N++))
 T=testutils$PRECSUF
 # stdout to screen and file; stderr to different file
-./$T 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}          # exit code of the tested cmd (not the tee cmd!)
 if [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); fi
-diff $DIR/$T.out $DIR/$T.refout
+diff --strip-trailing-cr $DIR/$T.out $DIR/$T.refout
 if [[ $? -eq 0 ]]; then echo passed; else echo failed; ((FAILS++)); fi
 
 ((N++))
 T=finufft1d_test$PRECSUF
-./$T 1e2 2e2 $FINUFFT_REQ_TOL 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 1e2 2e2 $FINUFFT_REQ_TOL 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}
 if [[ $E -eq 0 ]]; then echo passed; elif [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); else echo failed; ((FAILS++)); fi
 
 ((N++))
 T=finufft1dmany_test$PRECSUF
-./$T 3 1e2 1e3 $FINUFFT_REQ_TOL 0 0 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 3 1e2 1e3 $FINUFFT_REQ_TOL 0 0 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}
 if [[ $E -eq 0 ]]; then echo passed; elif [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); else echo failed; ((FAILS++)); fi
 
 ((N++))
 T=finufft2d_test$PRECSUF
-./$T 1e2 1e1 1e3 $FINUFFT_REQ_TOL 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 1e2 1e1 1e3 $FINUFFT_REQ_TOL 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}
 if [[ $E -eq 0 ]]; then echo passed; elif [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); else echo failed; ((FAILS++)); fi
 
 ((N++))
 T=finufft2dmany_test$PRECSUF
-./$T 3 1e2 1e1 1e3 $FINUFFT_REQ_TOL 0 0 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 3 1e2 1e1 1e3 $FINUFFT_REQ_TOL 0 0 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}
 if [[ $E -eq 0 ]]; then echo passed; elif [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); else echo failed; ((FAILS++)); fi
 
 ((N++))
 T=finufft3d_test$PRECSUF
-./$T 5 10 20 1e2 $FINUFFT_REQ_TOL 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 5 10 20 1e2 $FINUFFT_REQ_TOL 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}
 if [[ $E -eq 0 ]]; then echo passed; elif [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); else echo failed; ((FAILS++)); fi
 
 ((N++))
 T=finufft3dmany_test$PRECSUF
-./$T 2 10 50 20 1e2 $FINUFFT_REQ_TOL 0 0 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 2 10 50 20 1e2 $FINUFFT_REQ_TOL 0 0 0 2 0.0 $CHECK_TOL 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}
 if [[ $E -eq 0 ]]; then echo passed; elif [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); else echo failed; ((FAILS++)); fi
 
 ((N++))
 T=dumbinputs$PRECSUF
-./$T 2>$DIR/$T.err.out | tee $DIR/$T.out
+./$T$FEX 2>$DIR/$T.err.out | tee $DIR/$T.out
 E=${PIPESTATUS[0]}
 if [[ $E -eq $SIGSEGV ]]; then echo crashed; ((CRASHES++)); fi
-diff $DIR/$T.out $DIR/$T.refout
+diff --strip-trailing-cr $DIR/$T.out $DIR/$T.refout
 if [[ $? -eq 0 ]]; then echo passed; else echo failed; ((FAILS++)); fi
 
 # END TESTS ---------------------------------------------------------


### PR DESCRIPTION
This brings in Jonas's fixes to v2.0.0 for WSL:
- makefile switches (via MINGW) to windows versions of tasks: test, examples, clean, mex
- fixes to examples and test sources for complex math headers of windows
- check_finufft.sh bash script has 2nd arg switching to windows compat
This is most of it, I may have forgotten a couple.