### PR TITLE
Try to make Python docs run again

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('../python'))
 # since _finufft extension is mocked, shouldn't need this...
 os.environ['FINUFFT_DIR'] = os.path.abspath('..')
 
-autodoc_mock_imports = ['_finufft', 'numpy']
+autodoc_mock_imports = ['finufft._finufft', 'numpy']
 # The above is not enough for nested import -- forcibly mock them out ahead of time:
 #for name in autodoc_mock_imports:
 #    sys.modules[name] = sphinx.ext.autodoc._MockModule(name, None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,11 +21,8 @@ import sphinx.ext.autodoc
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('../python'))
 
-# since _finufft extension is mocked, shouldn't need this...
-os.environ['FINUFFT_DIR'] = os.path.abspath('..')
 
 autodoc_mock_imports = ['finufft._finufft', 'numpy']
 # The above is not enough for nested import -- forcibly mock them out ahead of time:


### PR DESCRIPTION
The issue is perhaps that we need to mock `finufft._finufft` not `_finufft`. I also removed some of the other config options that we don't need.

This seems to work on my fork: https://finufft-janden.readthedocs.io/en/latest/python.html.