### PR TITLE
Cleanup setup.py

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,0 @@
-numpy
-python-dotenv

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,8 +10,18 @@
 __version__ = '2.0.1'
 
 import os
+import ctypes
 
 from setuptools import setup, Extension
+
+# Sanity check that we can find the finufft library before we get too far.
+try:
+    lib = ctypes.cdll.LoadLibrary('libfinufft.so')
+except Exception as e:
+    print('FINUFFT shared libraries not found in library path.')
+    raise(e)
+print('FINUFFT shared libraries found, continuing...')
+
 
 finufft_dir = os.environ.get('FINUFFT_DIR')
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,4 @@
 # This defines the python module installation.
-# Only for double-prec, multi-threaded for now.
 
 # Barnett 3/1/18. Updates by Yu-Hsuan Shih, June 2018.
 # win32 mingw patch by Vineet Bansal, Feb 2019.
@@ -10,65 +9,33 @@
 
 __version__ = '2.0.1'
 
-from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-import sys
-import setuptools
 import os
-import ctypes
 
-# libin to change to python-dotenv or whatever's simplest:
-import dotenv   # is this part of standard python? (install_requires fails) ?
+from setuptools import setup, Extension
 
-finufftdir = os.environ.get('FINUFFT_DIR')
+finufft_dir = os.environ.get('FINUFFT_DIR')
 
-# since people might not set it, set to the parent of this script's dir...
-#if finufftdir==None or finufftdir=='':
-#    finufftdir = os.path.dirname(os.path.dirname(__file__))
-# removed: this fails because pip copies this file to /tmp/pip-req-build-*** !
-
-# default compiler choice (note g++ = clang in mac-osx):
-os.environ['CC'] = 'gcc'
-os.environ['CXX'] = 'g++'
-
-# attempt override compiler choice using ../make.inc to match your C++ build
-makeinc = finufftdir+"/make.inc"
-dotenv.load_dotenv(makeinc, override=True)   # modifies os.environ
-print('checking CXX var supposedly read from ../make.inc: '+os.environ['CXX'])
-
-# in the end avoided code from https://stackoverflow.com/questions/3503719/emulating-bash-source-in-python
-#if os.path.isfile(makeinc):
-#    command = 'env -i bash -c "source %s"' % (makeinc)
-#    for line in subprocess.getoutput(command).split("\n"):
-#        if line!='':
-#            key, value = line.split("=")
-#            print(key, value)
-#            os.environ[key] = value
-
-inc_dir = finufftdir+"/include"
-src_dir = finufftdir+"/src"
-lib_dir = finufftdir+"/lib"
-finufft_dlib = finufftdir+"/lib/finufft"
-finufft_lib = finufftdir+"/lib-static/finufft"
+lib_dir = os.path.join(finufft_dir, 'lib')
 
 ########## SETUP ###########
 setup(
     name='finufft',
     version=__version__,
-    author='python interfaces by: Jeremy Magland, Daniel Foreman-Mackey, Joakim Anden, Libin Lu, and Alex Barnett',
+    author='Python interfaces by: Jeremy Magland, Daniel Foreman-Mackey, Joakim Anden, Libin Lu, and Alex Barnett',
     author_email='abarnett@flatironinstitute.org',
-    url='http://github.com/ahbarnett/finufft',
-    description='python interface to FINUFFT',
-    long_description='python interface to FINUFFT (Flatiron Institute Nonuniform Fast Fourier Transform) library.',
+    url='https://github.com/flatironinstitute/finufft',
+    description='Python interface to FINUFFT',
+    long_description='Python interface to FINUFFT (Flatiron Institute Nonuniform Fast Fourier Transform) library.',
     license="Apache 2",
     packages=['finufft'],
-    install_requires=['numpy','python-dotenv'],
+    install_requires=['numpy'],
     zip_safe=False,
     py_modules=['finufft/finufftc'],
     ext_modules=[
         Extension(name='finufft/finufftc',
                   sources=[],
-                  libraries=[finufft_dlib])
+                  libraries=['finufft'],
+                  library_dirs=[lib_dir])
         ]
 )
 


### PR DESCRIPTION
Lots of old code there that is no longer needed. Also removed `requirements.txt` since the dependencies are already listed in `setup.py`. Finally add a check to make sure `libfinufft.so` is loadable from `ctypes` before proceeding with install.