### PR TITLE
Fix some issues with setup.py

### DIFF
--- a/makefile
+++ b/makefile
@@ -376,8 +376,6 @@ docker-wheel:
 
 docs: finufft-manual.pdf
 finufft-manual.pdf: docs/conf.py docs/*.doc docs/*.sh docs/*.rst docs/tutorial/*.rst $(STATICLIB) $(DYNLIB) CHANGELOG docs/*.src
-# rebuild python module so autodoc updates code-generated docstrings there...
-	(export FINUFFT_DIR=$(shell pwd); cd python; $(PYTHON) -m pip -v install .)
 # also builds a local html for local browser check too...
 	(cd docs; ./makecdocs.sh; make html && ./genpdfmanual.sh)
 docs/matlabhelp.doc: docs/genmatlabhelp.sh matlab/*.sh matlab/*.docsrc matlab/*.docbit matlab/*.m

--- a/makefile
+++ b/makefile
@@ -351,7 +351,7 @@ endif
 
 # python ---------------------------------------------------------------------
 python: $(STATICLIB) $(DYNLIB)
-	(export FINUFFT_DIR=$(shell pwd); cd python; $(PYTHON) -m pip -v install .)
+	FINUFFT_DIR=$(FINUFFT) $(PYTHON) -m pip -v install ./python
 # note to devs: if trouble w/ NumPy, use: pip install . --no-deps
 	$(PYTHON) python/test/run_accuracy_tests.py
 	$(PYTHON) python/examples/simple1d1.py

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,13 @@
+# Flatiron Institute Nonuniform Fast Fourier Transform library: FINUFFT
+
+Principal author **Alex H. Barnett**, main co-developers Jeremy F. Magland, Ludvig af Klinteberg, Yu-hsuan "Melody" Shih, Andrea Malleo, Libin Lu, and Joakim Andén.
+
+This package provides a Python interface to the library, enabling fast computation of nonuniform discrete Fourier transforms to specified precision in one, two, and three dimensions.
+It supports transforms of type 1 (nonuniform to uniform), type 2 (uniform to nonuniform) and type 3 (nonuniform to nonuniform).
+For more information, see the [online documentation](https://finufft.readthedocs.io/en/latest/python.html).
+
+If you find FINUFFT useful in your work, please cite this package and our paper:
+
+    A parallel non-uniform fast Fourier transform library based on an ``exponential of semicircle'' kernel.
+    A. H. Barnett, J. F. Magland, and L. af Klinteberg.
+    SIAM J. Sci. Comput. 41(5), C479–C504 (2019).

--- a/python/setup.py
+++ b/python/setup.py
@@ -72,6 +72,7 @@ setup(
     license="Apache 2",
     packages=['finufft'],
     install_requires=['numpy'],
+    python_requires='>=3.6',
     zip_safe=False,
     py_modules=['finufft/finufftc'],
     ext_modules=[

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,6 +24,10 @@ if finufft_dir == None or finufft_dir == '':
 inc_dir = os.path.join(finufft_dir, 'include')
 lib_dir = os.path.join(finufft_dir, 'lib')
 
+# Read in long description from README.md.
+with open(os.path.join(finufft_dir, 'python', 'README.md'), 'r') as f:
+        long_description = f.read()
+
 # We specifically link to the dynamic library here through its absolute path
 # (that is not through -lfinufft) to ensure that the absolute path of the
 # library is encoded in the DT_NEEDED tag. This way, we won't need to have
@@ -63,7 +67,8 @@ setup(
     author_email='abarnett@flatironinstitute.org',
     url='https://github.com/flatironinstitute/finufft',
     description='Python interface to FINUFFT',
-    long_description='Python interface to FINUFFT (Flatiron Institute Nonuniform Fast Fourier Transform) library.',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     license="Apache 2",
     packages=['finufft'],
     install_requires=['numpy'],

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,57 +1,36 @@
-# This defines the python module installation.
-# Only for double-prec, multi-threaded for now.
+# This defines the Python module installation.
 
 # Barnett 3/1/18. Updates by Yu-Hsuan Shih, June 2018.
 # win32 mingw patch by Vineet Bansal, Feb 2019.
 # attempt ../make.inc reading (failed) and default finufftdir. 2/25/20
 # Barnett trying to get sphinx.ext.autodoc to work w/ this, 10/5/20
 
-# Max OSX users: please edit as per below comments, and docs/install.rst
-
 __version__ = '2.0.1'
 
 from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-import sys
-import setuptools
 import os
-import ctypes
 
 from tempfile import mkstemp
 
-# libin to change to python-dotenv or whatever's simplest:
-import dotenv   # is this part of standard python? (install_requires fails) ?
+finufft_dir = os.environ.get('FINUFFT_DIR')
 
-finufftdir = os.environ.get('FINUFFT_DIR')
+# Note: This will not work if run through pip install since setup.py is copied
+# to a different location.
+if finufft_dir == None or finufft_dir == '':
+    current_path = os.path.abspath(__file__)
+    finufft_dir = os.path.dirname(os.path.dirname(current_path))
 
-# since people might not set it, set to the parent of this script's dir...
-if finufftdir==None or finufftdir=='':
-    finufftdir = os.path.dirname(os.path.dirname(__file__))
-# removed: this fails because pip copies this file to /tmp/pip-req-build-*** !
+# Set include and library paths relative to FINUFFT root directory.
+inc_dir = os.path.join(finufft_dir, 'include')
+lib_dir = os.path.join(finufft_dir, 'lib')
 
-# default compiler choice (note g++ = clang in mac-osx):
-os.environ['CC'] = 'gcc'
-os.environ['CXX'] = 'g++'
-
-# attempt override compiler choice using ../make.inc to match your C++ build
-makeinc = finufftdir+"/make.inc"
-dotenv.load_dotenv(makeinc, override=True)   # modifies os.environ
-print('checking CXX var supposedly read from ../make.inc: ',os.environ['CXX'])
-
-# in the end avoided code from https://stackoverflow.com/questions/3503719/emulating-bash-source-in-python
-#if os.path.isfile(makeinc):
-#    command = 'env -i bash -c "source %s"' % (makeinc)
-#    for line in subprocess.getoutput(command).split("\n"):
-#        if line!='':
-#            key, value = line.split("=")
-#            print(key, value)
-#            os.environ[key] = value
-
-inc_dir = finufftdir+"/include"
-src_dir = finufftdir+"/src"
-lib_dir = finufftdir+"/lib"
-finufft_dlib = finufftdir+"/lib/finufft"
-finufft_lib = finufftdir+"/lib-static/finufft"
+# We specifically link to the dynamic library here through its absolute path
+# (that is not through -lfinufft) to ensure that the absolute path of the
+# library is encoded in the DT_NEEDED tag. This way, we won't need to have
+# libfinufft.so in the LD_LIBRARY_PATH at runtime. The risk with this is that
+# if the libfinufft.so is deleted or moved, the Python module will break
+# unless LD_LIBRARY_PATH is updated.
+finufft_dlib = os.path.join(lib_dir, 'finufft')
 
 # For certain platforms (e.g. Ubuntu 20.04), we need to create a dummy source
 # that calls one of the functions in the FINUFFT dynamic library. The reason
@@ -80,14 +59,14 @@ void _dummy() {
 setup(
     name='finufft',
     version=__version__,
-    author='python interfaces by: Jeremy Magland, Daniel Foreman-Mackey, Joakim Anden, Libin Lu, and Alex Barnett',
+    author='Python interfaces by: Jeremy Magland, Daniel Foreman-Mackey, Joakim Anden, Libin Lu, and Alex Barnett',
     author_email='abarnett@flatironinstitute.org',
-    url='http://github.com/ahbarnett/finufft',
-    description='python interface to FINUFFT',
-    long_description='python interface to FINUFFT (Flatiron Institute Nonuniform Fast Fourier Transform) library.',
+    url='https://github.com/flatironinstitute/finufft',
+    description='Python interface to FINUFFT',
+    long_description='Python interface to FINUFFT (Flatiron Institute Nonuniform Fast Fourier Transform) library.',
     license="Apache 2",
     packages=['finufft'],
-    install_requires=['numpy','python-dotenv'],
+    install_requires=['numpy'],
     zip_safe=False,
     py_modules=['finufft/finufftc'],
     ext_modules=[

--- a/python/setup.py
+++ b/python/setup.py
@@ -71,7 +71,7 @@ setup(
     long_description_content_type='text/markdown',
     license="Apache 2",
     packages=['finufft'],
-    install_requires=['numpy'],
+    install_requires=['numpy>=1.12.0'],
     python_requires='>=3.6',
     zip_safe=False,
     py_modules=['finufft/finufftc'],

--- a/python/setup.py
+++ b/python/setup.py
@@ -71,6 +71,13 @@ setup(
     long_description_content_type='text/markdown',
     license="Apache 2",
     packages=['finufft'],
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: C++',
+        'Operating System :: POSIX :: Linux',
+        'Operating System :: MacOS :: MacOS X',
+    ],
     install_requires=['numpy>=1.12.0'],
     python_requires='>=3.6',
     zip_safe=False,


### PR DESCRIPTION
This reapplies some of the cleanup in #147, but doesn't break the explicit dynamic library linking that we're keeping. It solves the `finufftc` linking issue (#151), fixes the path detection when run as `setup.py install`, adds a Python `README` and includes this in the package description, and specifies minimum requirements for Python and NumPy. Also simplifies the `python` target in the `Makefile`.