### PR TITLE
Change python target to editable install

### DIFF
--- a/makefile
+++ b/makefile
@@ -351,7 +351,7 @@ endif
 
 # python ---------------------------------------------------------------------
 python: $(STATICLIB) $(DYNLIB)
-	FINUFFT_DIR=$(FINUFFT) $(PYTHON) -m pip -v install ./python
+	FINUFFT_DIR=$(FINUFFT) $(PYTHON) -m pip -v install -e ./python
 # note to devs: if trouble w/ NumPy, use: pip install ./python --no-deps
 	$(PYTHON) python/test/run_accuracy_tests.py
 	$(PYTHON) python/examples/simple1d1.py

--- a/python/setup.py
+++ b/python/setup.py
@@ -81,9 +81,9 @@ setup(
     install_requires=['numpy>=1.12.0'],
     python_requires='>=3.6',
     zip_safe=False,
-    py_modules=['finufft/finufftc'],
+    py_modules=['finufft.finufftc'],
     ext_modules=[
-        Extension(name='finufft/finufftc',
+        Extension(name='finufft.finufftc',
                   sources=[source_filename],
                   include_dirs=[inc_dir],
                   libraries=[finufft_dlib])


### PR DESCRIPTION
Since the Python library effectively hardcodes the path to the dynamic library, it makes more sense to keep it in the same directory instead of “installing” it into a system-specific directory. This is done by running `pip install -e` instead of just `pip install`. For this to work, we had to resolve an issue with the dummy C extension, which needs to be specified as a module name (that is, with dots) instead of a filename.

Closes #150.