### PR TITLE
Fix prototype in dummy C extension

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -51,7 +51,7 @@ with open(fd, 'w') as f:
 """
 #include <finufft.h>
 
-void _dummy() {
+void _dummy(void) {
     nufft_opts opt;
 
     finufft_default_opts(&opt);


### PR DESCRIPTION
Since it has no arguments, we need to specify `void` to avoid complaints
from `-Wstrict-prototypes`.