### PR TITLE
Fixed #62 - Improve large thread count handling in spreadSorted

### DIFF
--- a/include/spread_opts.h
+++ b/include/spread_opts.h
@@ -22,6 +22,7 @@ typedef struct spread_opts {  // see spreadinterp:setup_spreader for defaults.
   int flags;              // binary flags for timing only (may give wrong ans
                           // if changed from 0!). See spreadinterp.h
   int debug;              // 0: silent, 1: small text output, 2: verbose
+  int atomic_threshold;   // num threads before switching spreadSorted to using atomic ops
   double upsampfac;       // sigma, upsampling factor
   // ES kernel specific consts used in fast eval, depend on precision FLT...
   FLT ES_beta;

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -28,6 +28,9 @@ void spread_subproblem_3d(BIGINT N1,BIGINT N2,BIGINT N3,FLT *du0,BIGINT M0,
 void add_wrapped_subgrid(BIGINT offset1,BIGINT offset2,BIGINT offset3,
 			 BIGINT size1,BIGINT size2,BIGINT size3,BIGINT N1,
 			 BIGINT N2,BIGINT N3,FLT *data_uniform, FLT *du0);
+void add_wrapped_subgrid_thread_safe(BIGINT offset1,BIGINT offset2,BIGINT offset3,
+                                     BIGINT size1,BIGINT size2,BIGINT size3,BIGINT N1,
+                                     BIGINT N2,BIGINT N3,FLT *data_uniform, FLT *du0);
 void bin_sort_singlethread(BIGINT *ret, BIGINT M, FLT *kx, FLT *ky, FLT *kz,
 	      BIGINT N1,BIGINT N2,BIGINT N3,int pirange,
 	      double bin_size_x,double bin_size_y,double bin_size_z, int debug);
@@ -395,11 +398,15 @@ int spreadSorted(BIGINT* sort_indices,BIGINT N1, BIGINT N2, BIGINT N3,
             spread_subproblem_3d(size1,size2,size3,du0,M0,kx0,ky0,kz0,dd0,opts);
 	}
         
+        // do the adding of subgrid to output
+        if (!(opts.flags & TF_OMIT_WRITE_TO_GRID)) {
+            if (nthr > opts.atomic_threshold)
+              add_wrapped_subgrid_thread_safe(offset1,offset2,offset3,size1,size2,size3,N1,N2,N3,data_uniform,du0);
+            else {
 #pragma omp critical
-        {  // do the adding of subgrid to output; only here threads cannot clash
-          if (!(opts.flags & TF_OMIT_WRITE_TO_GRID))
-            add_wrapped_subgrid(offset1,offset2,offset3,size1,size2,size3,N1,N2,N3,data_uniform,du0);
-        }  // end critical block
+              add_wrapped_subgrid(offset1,offset2,offset3,size1,size2,size3,N1,N2,N3,data_uniform,du0);
+            }
+        }
 
         // free up stuff from this subprob... (that was malloc'ed by hand)
         free(dd0);
@@ -572,6 +579,7 @@ int setup_spreader(spread_opts &opts, FLT eps, double upsampfac,
   opts.max_subproblem_size = (BIGINT)1e4;   // was larger (1e5 bit worse in 1D)
   opts.flags = 0;               // 0:no timing flags (>0 for experts only)
   opts.debug = 0;               // 0:no debug output
+  opts.atomic_threshold = 10;   // heuristic for when performance degrades using critical to add back subgrids
 
   int ns, ier = 0;  // Set kernel width w (aka ns, nspread) then copy to opts...
   if (eps<EPSILON) {            // safety; there's no hope of beating e_mach
@@ -998,7 +1006,7 @@ void add_wrapped_subgrid(BIGINT offset1,BIGINT offset2,BIGINT offset3,
    with periodic wrapping to N1,N2,N3 box.
    offset1,2,3 give the offset of the subgrid from the lowest corner of output.
    size1,2,3 give the size of subgrid.
-   Works in all dims. Thread-safe since must be called inside omp critical.
+   Works in all dims. Not thread-safe and must be called inside omp critical.
    Barnett 3/27/18 made separate routine, tried to speed up inner loop.
 */
 {
@@ -1035,6 +1043,57 @@ void add_wrapped_subgrid(BIGINT offset1,BIGINT offset2,BIGINT offset3,
     }
   }
 }
+
+void add_wrapped_subgrid_thread_safe(BIGINT offset1,BIGINT offset2,BIGINT offset3,
+                                    BIGINT size1,BIGINT size2,BIGINT size3,BIGINT N1,
+                                    BIGINT N2,BIGINT N3,FLT *data_uniform, FLT *du0)
+/* Add a large subgrid (du0) to output grid (data_uniform),
+   with periodic wrapping to N1,N2,N3 box.
+   offset1,2,3 give the offset of the subgrid from the lowest corner of output.
+   size1,2,3 give the size of subgrid.
+   Works in all dims. Thread-safe variant
+*/
+{
+  std::vector<BIGINT> o2(size2), o3(size3);
+  BIGINT y=offset2, z=offset3;    // fill wrapped ptr lists in slower dims y,z...
+  for (int i=0; i<size2; ++i) {
+    if (y<0) y+=N2;
+    if (y>=N2) y-=N2;
+    o2[i] = y++;
+  }
+  for (int i=0; i<size3; ++i) {
+    if (z<0) z+=N3;
+    if (z>=N3) z-=N3;
+    o3[i] = z++;
+  }
+  BIGINT nlo = (offset1<0) ? -offset1 : 0;          // # wrapping below in x
+  BIGINT nhi = (offset1+size1>N1) ? offset1+size1-N1 : 0;    // " above in x
+  // this triple loop works in all dims
+  for (int dz=0; dz<size3; dz++) {       // use ptr lists in each axis
+    BIGINT oz = N1*N2*o3[dz];            // offset due to z (0 in <3D)
+    for (int dy=0; dy<size2; dy++) {
+      BIGINT oy = oz + N1*o2[dy];        // off due to y & z (0 in 1D)
+      FLT *out = data_uniform + 2*oy;
+      FLT *in  = du0 + 2*size1*(dy + size2*dz);   // ptr to subgrid array
+      BIGINT o = 2*(offset1+N1);         // 1d offset for output
+      for (int j=0; j<2*nlo; j++) { // j is really dx/2 (since re,im parts)
+#pragma omp atomic
+        out[j + o] += in[j];
+      }
+      o = 2*offset1;
+      for (int j=2*nlo; j<2*(size1-nhi); j++) {
+#pragma omp atomic
+        out[j + o] += in[j];
+      }
+      o = 2*(offset1-N1);
+      for (int j=2*(size1-nhi); j<2*size1; j++) {
+#pragma omp atomic
+        out[j+o] += in[j];
+      }
+    }
+  }
+}
+
 
 void bin_sort_singlethread(BIGINT *ret, BIGINT M, FLT *kx, FLT *ky, FLT *kz,
 	      BIGINT N1,BIGINT N2,BIGINT N3,int pirange,

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -1045,8 +1045,8 @@ void add_wrapped_subgrid(BIGINT offset1,BIGINT offset2,BIGINT offset3,
 }
 
 void add_wrapped_subgrid_thread_safe(BIGINT offset1,BIGINT offset2,BIGINT offset3,
-                                    BIGINT size1,BIGINT size2,BIGINT size3,BIGINT N1,
-                                    BIGINT N2,BIGINT N3,FLT *data_uniform, FLT *du0)
+                                     BIGINT size1,BIGINT size2,BIGINT size3,BIGINT N1,
+                                     BIGINT N2,BIGINT N3,FLT *data_uniform, FLT *du0)
 /* Add a large subgrid (du0) to output grid (data_uniform),
    with periodic wrapping to N1,N2,N3 box.
    offset1,2,3 give the offset of the subgrid from the lowest corner of output.


### PR DESCRIPTION
The spreadSorted routine is largely thread safe, except in one section where the subgrid is
added back to the data_uniform array. Previously, a critical section was exclusively used to
block all entry into this routine from more than one thread at a time. While this routine is
relatively fast compared to other operations, this would lead to large queues when using large
numbers of threads.

As a simple "first-pass" way to address this issue, I tried using atomic operations on the
array entries in data_uniform that were being modified, rather than a blunt critical
section. Unfortunately, while atomic operations have better scaling behavior with large numbers
of threads, they are _very_ slow, and so hurt performance considerably with small thread
counts. This commit both adds an atomic variant of add_wrapped_subgrid, and adds the option
spread_opts.atomic_threshold which defines when to switch to using the thread-safe
routine. Heuristically I've set this to a default of 10. On 40-core skylake nodes this gives a
~37% reduction in cost with 1e8 points.

```
% lscpu | egrep -i "model name|core\(s\)|socket\(s\)";
Core(s) per socket:    20
Socket(s):             2
Model name:            Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz
```

This commit:
```
% perftest/spreadtestnd 3 1e8 1e8 1e-3 2 0
making random data...
spreadinterp 3D, 9.99e+07 U pts, dir=1, tol=0.001: nspread=4
    1e+08 NU pts in 1.98 s 	5.05e+07 pts/s 	3.23e+09 spread pts/s
    rel err in total over grid:      0.000449
making more random NU pts...
spreadinterp 3D, 9.99e+07 U pts, dir=2, tol=0.001: nspread=4
    1e+08 NU pts in 1.45 s 	6.89e+07 pts/s 	4.41e+09 spread pts/s
    max rel err in values at NU pts: 0.00149
```
Previously:
```
% perftest/spreadtestnd_orig 3 1e8 1e8 1e-3 2 0
making random data...
spreadinterp 3D, 9.99e+07 U pts, dir=1, tol=0.001: nspread=4
    1e+08 NU pts in 3.18 s 	3.14e+07 pts/s 	2.01e+09 spread pts/s
    rel err in total over grid:      0.000678
making more random NU pts...
spreadinterp 3D, 9.99e+07 U pts, dir=2, tol=0.001: nspread=4
    1e+08 NU pts in 1.45 s 	6.89e+07 pts/s 	4.41e+09 spread pts/s
    max rel err in values at NU pts: 0.00149
```