### PR TITLE
Singcrash: fix (single-prec) segfaults due to inconsistent rounding in spreading

### DIFF
--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -626,6 +626,15 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
     FFTW_PLAN_TH(nthr_fft); // " (not batchSize since can be 1 but want mul-thr)
     FFTW_PLAN_SF();         // make planner thread-safe
     p->spopts.spread_direction = type;
+
+    if (p->opts.showwarn) {  // user warn round-off error...
+      if (EPSILON*p->ms>1.0)
+        fprintf(stderr,"%s warning: rounding err predicted eps_mach*N1 = %.3g > 1 !\n",__func__,(double)(EPSILON*p->ms));
+      if (EPSILON*p->mt>1.0)
+        fprintf(stderr,"%s warning: rounding err predicted eps_mach*N2 = %.3g > 1 !\n",__func__,(double)(EPSILON*p->mt));
+      if (EPSILON*p->mu>1.0)
+        fprintf(stderr,"%s warning: rounding err predicted eps_mach*N3 = %.3g > 1 !\n",__func__,(double)(EPSILON*p->mu));
+    }
     
     // determine fine grid sizes, sanity check..
     int nfier = SET_NF_TYPE12(p->ms, p->opts, p->spopts, &(p->nf1));

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -862,7 +862,7 @@ void spread_subproblem_1d(BIGINT off1, BIGINT size1,FLT *du,BIGINT M,
    This needed off1 as extra arg. AHB 11/30/20.
 */
 {
-  int ns=opts.nspread;
+  int ns=opts.nspread;          // a.k.a. w
   FLT ns2 = (FLT)ns/2;          // half spread width
   for (BIGINT i=0;i<2*size1;++i)         // zero output
     du[i] = 0.0;
@@ -877,6 +877,8 @@ void spread_subproblem_1d(BIGINT off1, BIGINT size1,FLT *du,BIGINT M,
     // However if N1*epsmach>O(1) then can cause O(1) errors in x1, hence ppoly
     // kernel evaluation will fall outside their designed domains, >>1 errors.
     // This can only happen if the overall error would be O(1) anyway. Clip x1??
+    if (x1<-ns2) x1=-ns2;
+    if (x1>-ns2+1) x1=-ns2+1;   // ***
     if (opts.kerevalmeth==0) {          // faster Horner poly method
       set_kernel_args(kernel_args, x1, opts);
       evaluate_kernel_vector(ker, kernel_args, opts, ns);

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -379,11 +379,6 @@ int spreadSorted(BIGINT* sort_indices,BIGINT N1, BIGINT N2, BIGINT N3,
           else
             printf("\tsubgrid: off %lld,%lld,%lld\t siz %lld,%lld,%lld\t #NU %lld\n",(long long)offset1,(long long)offset2,(long long)offset3,(long long)size1,(long long)size2,(long long)size3,(long long)M0);
 	}
-        //   for (BIGINT j=0; j<M0; j++) {  // make k{x,y,z}0 rel to subgrid corner
-    //kx0[j]-=(FLT)offset1;
-        //    if (N2>1) ky0[j]-=(FLT)offset2;  // only accessed if 2D or 3D
-        // if (N3>1) kz0[j]-=(FLT)offset3;  // only access if 3D
-        // }
         // allocate output data for this subgrid
         FLT *du0=(FLT*)malloc(sizeof(FLT)*2*size1*size2*size3); // complex
         


### PR DESCRIPTION
This fixes #167.
This could only happen when epsmach*N > O(1), which is only poss in single-prec.
The cause was twofold: get_subgrid adding ns-1 before converting to BIGINT (hence its rounding differed from the index calc in spead_subproblem), and different rounding due to origin shift occurring with k{x,y,z}0 arrays.  This allowed spreading to overwrite the du array bounds.

Fix:
spreadSorted no longer shifts the subproblem k{x,y,z}0 arrays. Instead, the offsets from get_subgrid are now passed into spread_subproblem_{1,2,3}d.
This allows consistent rounding, according to int(ceil(kx - ns/2)), for all NU pts, where kx (or ky, kz) is always relative to the fine grid corner (after rescale and folding macro).
Assuming that max() and ceil() commute exactly in the floating-point implementation (which we believe is true), segfaults from this cause are now impossible.

A warning (in finufft, but not the spreader) when excessive round-off error is expected is added.

Docs for spreading routines in spreadinterp.cpp are improved.

Test of fix:
perftest/spreadtestndf 1 1e7 1e8 1e-3
works without crashing (even though errors reported are O(1)).