### PR TITLE
Fix up build-wheels script

### DIFF
--- a/make.inc.manylinux
+++ b/make.inc.manylinux
@@ -1,0 +1,2 @@
+CFLAGS = -O3 -funroll-loops -march=x86-64 -mtune=generic -msse4 -fcx-limited-range
+CXXFLAGS = $(CFLAGS)

--- a/python/ci/build-wheels.sh
+++ b/python/ci/build-wheels.sh
@@ -11,6 +11,7 @@
 set -e -x
 
 cd /io/
+make clean
 make lib
 make test
 

--- a/python/ci/build-wheels.sh
+++ b/python/ci/build-wheels.sh
@@ -24,7 +24,7 @@ export LD_LIBRARY_PATH=${FINUFFT_DIR}/lib:${LD_LIBRARY_PATH}
 
 pys=(/opt/python/*/bin)
 
-# Filter out Python 3.4
+# Filter out old Python versions
 pys=(${pys[@]//*27*/})
 pys=(${pys[@]//*34*/})
 pys=(${pys[@]//*35*/})

--- a/python/ci/build-wheels.sh
+++ b/python/ci/build-wheels.sh
@@ -11,9 +11,11 @@
 set -e -x
 
 cd /io/
+cp make.inc.manylinux make.inc
 make clean
 make lib
 make test
+rm make.inc
 
 # Needed for pip install to work
 export FINUFFT_DIR=$(pwd)

--- a/python/ci/build-wheels.sh
+++ b/python/ci/build-wheels.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Copyright (c) 2019, Henry Schreiner.
-#
-# Distributed under the 3-clause BSD license, see accompanying file LICENSE
-# or https://github.com/scikit-hep/azure-wheel-helpers for details.
-
-# Based on https://github.com/pypa/python-manylinux-demo/blob/master/travis/build-wheels.sh
-# with CC0 license here: https://github.com/pypa/python-manylinux-demo/blob/master/LICENSE
-
 set -e -x
 
 cd /io/

--- a/python/ci/build-wheels.sh
+++ b/python/ci/build-wheels.sh
@@ -11,10 +11,18 @@
 set -e -x
 
 cd /io/
+
+# Replace native compilation flags with more generic ones.
 cp make.inc.manylinux make.inc
+
+# Clean up the build and make the library.
 make clean
 make lib
+
+# Test to make sure everything is ok.
 make test
+
+# Remove make.inc now that we're done.
 rm make.inc
 
 # Needed for pip install to work


### PR DESCRIPTION
This fixes a couple of issues:
- It runs `make clean` to remove any remnants of already built libraries.
- It adds a `make.inc.manylinux` for greater compatibility with older chips (non-AVX).
- It updates and adds some comments.

Somehow I had written these a while ago and they never got into a PR.