### PR TITLE
prevent deprecated warnings for nufft_type 3

### DIFF
--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -102,7 +102,7 @@ class Plan:
         # setting n_modes and dim for makeplan
         n_modes = np.ones([3], dtype=np.int64)
         if nufft_type==3:
-            npdim = np.asarray(n_modes_or_dim, dtype=np.int)
+            npdim = np.asarray(n_modes_or_dim, dtype=np.int64)
             if npdim.size != 1:
                 raise RuntimeError('FINUFFT type 3 plan n_modes_or_dim must be one number, the dimension')
             dim = int(npdim)


### PR DESCRIPTION
When running nufft type 3 transforms the following warning is displayed when running with numpy versions > 1.20.0: 

```/somedir/finufft/python/finufft/_interfaces.py:105: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations```