### PR TITLE
Fix some incorrect types in the 2.0.4 chk util method updates

### DIFF
--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -323,10 +323,12 @@ def _cchk(x):
     Check if array x is of the appropriate type
     (complex128, C-contiguous in memory)
     If not, produce a copy
+
+    Will raise if provided a real input array.
     """
-    if x is not None and (x.dtype is not np.dtype('complex128') and x.dtype is not np.dtype('float64')):
+    if x is not None and x.dtype is not np.dtype('complex128'):
         raise RuntimeError('FINUFFT data type must be complex128 for double precision, data may have mixed precision types')
-    if x is not None and x.flags['C_CONTIGUOUS'] and x.dtype is np.dtype('complex128'):
+    if x is not None and x.flags['C_CONTIGUOUS']:
         return x
     else:
         return np.array(x, dtype=np.complex128, order='C')
@@ -347,10 +349,12 @@ def _cchkf(x):
     Check if array x is of the appropriate type
     (complex64, C-contiguous in memory)
     If not, produce a copy
+
+    Will raise if provided a real input array.
     """
-    if x is not None and (x.dtype is not np.dtype('complex64') and x.dtype is not np.dtype('float32')):
+    if x is not None and x.dtype is not np.dtype('complex64'):
         raise RuntimeError('FINUFFT data type must be complex64 for single precision, data may have mixed precision types')
-    if x is not None and x.flags['C_CONTIGUOUS'] and x.dtype is np.dtype('complex64'):
+    if x is not None and x.flags['C_CONTIGUOUS']:
         return x
     else:
         return np.array(x, dtype=np.complex64, order='C')

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -326,14 +326,14 @@ def _cchk(x):
     """
     if x is not None and (x.dtype is not np.dtype('complex128') and x.dtype is not np.dtype('float64')):
         raise RuntimeError('FINUFFT data type must be complex128 for double precision, data may have mixed precision types')
-    if x is not None and x.flags['C_CONTIGUOUS']:
+    if x is not None and x.flags['C_CONTIGUOUS'] and x.dtype is np.dtype('complex128'):
         return x
     else:
         return np.array(x, dtype=np.complex128, order='C')
 def _rchkf(x):
     """
     Check if array x is of the appropriate type
-    (float64, C-contiguous in memory)
+    (float32, C-contiguous in memory)
     If not, produce a copy
     """
     if x is not None and x.dtype is not np.dtype('float32'):
@@ -345,12 +345,12 @@ def _rchkf(x):
 def _cchkf(x):
     """
     Check if array x is of the appropriate type
-    (complex128, C-contiguous in memory)
+    (complex64, C-contiguous in memory)
     If not, produce a copy
     """
     if x is not None and (x.dtype is not np.dtype('complex64') and x.dtype is not np.dtype('float32')):
         raise RuntimeError('FINUFFT data type must be complex64 for single precision, data may have mixed precision types')
-    if x is not None and x.flags['C_CONTIGUOUS']:
+    if x is not None and x.flags['C_CONTIGUOUS'] and x.dtype is np.dtype('complex64'):
         return x
     else:
         return np.array(x, dtype=np.complex64, order='C')


### PR DESCRIPTION
Here is a patch to potentially close #202 .

I should remark that I feel the prior code was cleaner, though I suppose it wasn't guarding against contiguousness...

Anyway, this should push things along now.  @janden , could you confirm?