### PR TITLE
Fix free / delete mismatch

### DIFF
--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -1106,6 +1106,6 @@ int FINUFFT_DESTROY(FINUFFT_PLAN p)
     free(p->prephase);
     free(p->deconv);
   }
-  free(p);
+  delete p;
   return 0;              // success
 }


### PR DESCRIPTION
Fixes bug where `free` was used to deallocate memory allocated with `new` (see allocation [here](https://github.com/wendazhou/finufft/blob/567e1f4f05cc8c03e750c19dc6265fad163359ec/src/finufft.cpp#L548))