### PR TITLE
safe private library symbol namespace using finufft::

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 List of features / changes made / release notes, in reverse chronological order
 
+* library private namespacing via finufft::* of all symbols that do not already
+  begin with finufft{f}. This addresses clash with linking against cufinufft
+  (their Issue #138).
 * spreadinterp evaluate_kernel_vector uses single arith when FLT=single.
 * spread_opts.h fix duplication for FLT=single/double by making FLT->double.
 * examples/simulplans1d1 demos ability to to wield independent plans.

--- a/contrib/legendre_rule_fast.cpp
+++ b/contrib/legendre_rule_fast.cpp
@@ -11,7 +11,8 @@
 #include <cmath>
 #include <cstdlib>
 
-namespace finufft::quadrature {
+namespace finufft {
+  namespace quadrature {
   
 void legendre_compute_glr ( int n, double x[], double w[] );
 void legendre_compute_glr0 ( int n, double *p, double *pp );
@@ -507,4 +508,5 @@ double ts_mult ( double *u, double h, int n )
 }
 /******************************************************************************/
 
+  } // namespace
 } // namespace

--- a/contrib/legendre_rule_fast.cpp
+++ b/contrib/legendre_rule_fast.cpp
@@ -1,10 +1,18 @@
-/* edited down to be a library func for Gauss-Legendre nodes & weights
-   on [-1,1], by Alex Barnett 2/7/17
+/* Burkardt's implementation of GLR method.
+
+   Edited down to be a library func for Gauss-Legendre nodes & weights
+   on [-1,1], by Alex Barnett 2/7/17.
+
+   Repackaged as .cpp to allow namespacing, Barnett 5/18/22.
+   (Note: could equally well have used Burkardt's C++ version:
+   https://people.math.sc.edu/Burkardt/cpp_src/legendre_rule_fast/legendre_rule_fast.cpp
 */
 
-#include <math.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdlib>
 
+namespace finufft::quadrature {
+  
 void legendre_compute_glr ( int n, double x[], double w[] );
 void legendre_compute_glr0 ( int n, double *p, double *pp );
 void legendre_compute_glr1 ( int n, double *roots, double *ders );
@@ -498,3 +506,5 @@ double ts_mult ( double *u, double h, int n )
   return ts;
 }
 /******************************************************************************/
+
+} // namespace

--- a/contrib/legendre_rule_fast.h
+++ b/contrib/legendre_rule_fast.h
@@ -1,8 +1,10 @@
 #ifndef GAUSSQUAD_H
 #define GAUSSQUAD_H
 
-namespace finufft::quadrature {
+namespace finufft {
+  namespace quadrature {
   void legendre_compute_glr ( int n, double x[], double w[] );
-}
+  }  // namespace
+}  // namespace
 
 #endif

--- a/contrib/legendre_rule_fast.h
+++ b/contrib/legendre_rule_fast.h
@@ -1,6 +1,8 @@
 #ifndef GAUSSQUAD_H
 #define GAUSSQUAD_H
 
-void legendre_compute_glr ( int n, double x[], double w[] );
+namespace finufft::quadrature {
+  void legendre_compute_glr ( int n, double x[], double w[] );
+}
 
 #endif

--- a/include/spreadinterp.h
+++ b/include/spreadinterp.h
@@ -23,7 +23,8 @@
 #define TF_OMIT_EVALUATE_EXPONENTIAL 4 // omit exp() in kernel (kereval=0 only)
 #define TF_OMIT_SPREADING            8 // don't interp/spread (dir=1: to subgrids)
 
-namespace finufft::spreadinterp {
+namespace finufft {
+  namespace spreadinterp {
 
 // things external (spreadinterp) interface needs...
 int spreadinterp(BIGINT N1, BIGINT N2, BIGINT N3, FLT *data_uniform,
@@ -46,6 +47,7 @@ FLT evaluate_kernel(FLT x,const spread_opts &opts);
 FLT evaluate_kernel_noexp(FLT x,const spread_opts &opts);
 int setup_spreader(spread_opts &opts,FLT eps,double upsampfac,int kerevalmeth, int debug, int showwarn, int dim);
 
+  }    // namespace
 }    // namespace
  
 #endif  // SPREADINTERP_H

--- a/include/spreadinterp.h
+++ b/include/spreadinterp.h
@@ -23,6 +23,8 @@
 #define TF_OMIT_EVALUATE_EXPONENTIAL 4 // omit exp() in kernel (kereval=0 only)
 #define TF_OMIT_SPREADING            8 // don't interp/spread (dir=1: to subgrids)
 
+namespace finufft::spreadinterp {
+
 // things external (spreadinterp) interface needs...
 int spreadinterp(BIGINT N1, BIGINT N2, BIGINT N3, FLT *data_uniform,
 		 BIGINT M, FLT *kx, FLT *ky, FLT *kz,
@@ -44,4 +46,6 @@ FLT evaluate_kernel(FLT x,const spread_opts &opts);
 FLT evaluate_kernel_noexp(FLT x,const spread_opts &opts);
 int setup_spreader(spread_opts &opts,FLT eps,double upsampfac,int kerevalmeth, int debug, int showwarn, int dim);
 
+}    // namespace
+ 
 #endif  // SPREADINTERP_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,8 @@
 
 #include "dataTypes.h"
 
-namespace finufft::utils {
+namespace finufft {
+  namespace utils {
 
 // ahb's low-level array helpers
 FLT relerrtwonorm(BIGINT n, CPX* a, CPX* b);
@@ -17,6 +18,7 @@ void arrayrange(BIGINT n, FLT* a, FLT *lo, FLT *hi);
 void indexedarrayrange(BIGINT n, BIGINT* i, FLT* a, FLT *lo, FLT *hi);
 void arraywidcen(BIGINT n, FLT* a, FLT *w, FLT *c);
 
+  }    // namespace
 }    // namespace
  
 #endif  // UTILS_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,6 +6,8 @@
 
 #include "dataTypes.h"
 
+namespace finufft::utils {
+
 // ahb's low-level array helpers
 FLT relerrtwonorm(BIGINT n, CPX* a, CPX* b);
 FLT errtwonorm(BIGINT n, CPX* a, CPX* b);
@@ -15,4 +17,6 @@ void arrayrange(BIGINT n, FLT* a, FLT *lo, FLT *hi);
 void indexedarrayrange(BIGINT n, BIGINT* i, FLT* a, FLT *lo, FLT *hi);
 void arraywidcen(BIGINT n, FLT* a, FLT *w, FLT *c);
 
+}    // namespace
+ 
 #endif  // UTILS_H

--- a/include/utils_precindep.h
+++ b/include/utils_precindep.h
@@ -8,7 +8,9 @@
 
 BIGINT next235even(BIGINT n);
 
-// jfm's timer class
+namespace finufft{
+
+  // jfm's timer class
 #include <sys/time.h>
 class CNTime {
  public:
@@ -19,6 +21,8 @@ class CNTime {
   struct timeval initial;
 };
 
+}
+  
 // openmp helpers
 int get_num_threads_parallel_block();
 

--- a/include/utils_precindep.h
+++ b/include/utils_precindep.h
@@ -5,31 +5,31 @@
 #define UTILS_PRECINDEP_H
 
 #include "dataTypes.h"
+// for CNTime...
+#include <sys/time.h>
 
-BIGINT next235even(BIGINT n);
-
-namespace finufft{
+namespace finufft::utils {
+  
+  BIGINT next235even(BIGINT n);
 
   // jfm's timer class
-#include <sys/time.h>
-class CNTime {
- public:
-  void start();
-  double restart();
-  double elapsedsec();
- private:
-  struct timeval initial;
-};
+  class CNTime {
+  public:
+    void start();
+    double restart();
+    double elapsedsec();
+  private:
+    struct timeval initial;
+  };
 
+  // openmp helpers
+  int get_num_threads_parallel_block();
 }
   
-// openmp helpers
-int get_num_threads_parallel_block();
-
 // thread-safe rand number generator for Windows platform
 #ifdef _WIN32
 #include <random>
-int rand_r(unsigned int *seedp);
+int finufft::utils::rand_r(unsigned int *seedp);
 #endif
 
 #endif  // UTILS_PRECINDEP_H

--- a/include/utils_precindep.h
+++ b/include/utils_precindep.h
@@ -29,7 +29,9 @@ namespace finufft::utils {
 // thread-safe rand number generator for Windows platform
 #ifdef _WIN32
 #include <random>
-int finufft::utils::rand_r(unsigned int *seedp);
+namespace finufft::utils {
+  int rand_r(unsigned int *seedp);
+}
 #endif
 
 #endif  // UTILS_PRECINDEP_H

--- a/include/utils_precindep.h
+++ b/include/utils_precindep.h
@@ -8,7 +8,8 @@
 // for CNTime...
 #include <sys/time.h>
 
-namespace finufft::utils {
+namespace finufft {
+  namespace utils {
   
   BIGINT next235even(BIGINT n);
 
@@ -24,14 +25,18 @@ namespace finufft::utils {
 
   // openmp helpers
   int get_num_threads_parallel_block();
-}
+    
+  } //namespace
+} //namespace
   
 // thread-safe rand number generator for Windows platform
 #ifdef _WIN32
 #include <random>
-namespace finufft::utils {
+namespace finufft {
+  namespace utils {
   int rand_r(unsigned int *seedp);
-}
+  }   // namespace
+}   // namespace
 #endif
 
 #endif  // UTILS_PRECINDEP_H

--- a/perftest/guru_timing_test.cpp
+++ b/perftest/guru_timing_test.cpp
@@ -2,6 +2,7 @@
 // for sleep call
 #include <unistd.h>
 using namespace std;
+using namespace finufft;
 
 // forward declaration of helper to (repeatedly if needed) call finufft?d?
 double many_simple_calls(CPX *c,CPX *F,FLT*x, FLT*y, FLT*z,FINUFFT_PLAN plan);

--- a/perftest/manysmallprobs.cpp
+++ b/perftest/manysmallprobs.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 using namespace std;
+using namespace finufft;
 
 int main(int argc, char* argv[])
 /* What is small-problem cost of FINUFFT library from C++, using plain

--- a/perftest/spreadtestnd.cpp
+++ b/perftest/spreadtestnd.cpp
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+using namespace finufft;
+
 void usage()
 {
   printf("usage: spreadtestnd dims [M N [tol [sort [flags [debug [kerpad [kerevalmeth [upsampfac]]]]]]]]\n\twhere dims=1,2 or 3\n\tM=# nonuniform pts\n\tN=# uniform pts\n\ttol=requested accuracy\n\tsort=0 (don't sort NU pts), 1 (do), or 2 (maybe sort; default)\n\tflags: expert timing flags, 0 is default (see spreadinterp.h)\n\tdebug=0 (less text out), 1 (more), 2 (lots)\n\tkerpad=0 (no pad to mult of 4), 1 (do, for kerevalmeth=0 only)\n\tkerevalmeth=0 (direct), 1 (Horner ppval)\n\tupsampfac>1; 2 or 1.25 for Horner\n\nexample: ./spreadtestnd 1 1e6 1e6 1e-6 2 0 1\n");

--- a/perftest/spreadtestnd.cpp
+++ b/perftest/spreadtestnd.cpp
@@ -8,7 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-using namespace finufft;
+using namespace finufft::spreadinterp;
+using namespace finufft::utils;              // for timer
 
 void usage()
 {

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -18,7 +18,8 @@ extern "C" {
   #include "../contrib/legendre_rule_fast.h"
 }
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
+
 
 /* Computational core for FINUFFT.
 
@@ -84,6 +85,8 @@ Design notes for guru interface implementation:
 
 
 // ---------- local math routines (were in common.cpp; no need now): --------
+
+// *** to do:   namespace finufft::internal {
 
 // We macro because it has no FLT args but gets compiled for both prec's...
 #ifdef SINGLE
@@ -497,10 +500,14 @@ int* GRIDSIZE_FOR_FFTW(FINUFFT_PLAN p){
 }
 
 
+//  *** }   // internal namespace
 
 
-// --------------- rest is the 5 user guru (plan) interface drivers: -----------
 
+
+
+// --------------- rest is the 5 user guru (plan) interface drivers: ---------
+// (not namespaced since have safe names finufft{f}_* )
 
 
 // OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -88,7 +88,8 @@ Design notes for guru interface implementation:
 
 // ---------- local math routines (were in common.cpp; no need now): --------
 
-namespace finufft::common {
+namespace finufft {
+  namespace common {
 
   // We macro because it has no FLT args but gets compiled for both prec's...
 #ifdef SINGLE
@@ -502,7 +503,8 @@ int* GRIDSIZE_FOR_FFTW(FINUFFT_PLAN p){
 }
 
 
-}   // namespace common
+  }   // namespace
+}   // namespace
 
 
 

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -14,13 +14,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
-extern "C" {
+//extern "C" {
   #include "../contrib/legendre_rule_fast.h"
-}
+//}
 using namespace std;
 using namespace finufft;
 using namespace finufft::utils;
 using namespace finufft::spreadinterp;
+using namespace finufft::quadrature;
 
 
 /* Computational core for FINUFFT.

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -14,9 +14,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
-//extern "C" {
-  #include "../contrib/legendre_rule_fast.h"
-//}
+#include "../contrib/legendre_rule_fast.h"
+
 using namespace std;
 using namespace finufft;
 using namespace finufft::utils;

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -18,7 +18,7 @@ extern "C" {
   #include "../contrib/legendre_rule_fast.h"
 }
 using namespace std;
-
+using namespace finufft;
 
 /* Computational core for FINUFFT.
 

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -20,6 +20,7 @@ extern "C" {
 using namespace std;
 using namespace finufft;
 using namespace finufft::utils;
+using namespace finufft::spreadinterp;
 
 
 /* Computational core for FINUFFT.

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -18,6 +18,7 @@ extern "C" {
   #include "../contrib/legendre_rule_fast.h"
 }
 using namespace std;
+using namespace finufft;
 using namespace finufft::utils;
 
 
@@ -86,9 +87,9 @@ Design notes for guru interface implementation:
 
 // ---------- local math routines (were in common.cpp; no need now): --------
 
-// *** to do:   namespace finufft::internal {
+namespace finufft::common {
 
-// We macro because it has no FLT args but gets compiled for both prec's...
+  // We macro because it has no FLT args but gets compiled for both prec's...
 #ifdef SINGLE
 #define SET_NF_TYPE12 set_nf_type12f
 #else
@@ -355,9 +356,9 @@ void deconvolveshuffle2d(int dir,FLT prefac,FLT *ker1, FLT *ker2,
       fw[j][0] = fw[j][1] = 0.0;
   for (BIGINT k2=0;k2<=k2max;++k2, pp+=2*ms)          // non-neg y-freqs
     // point fk and fw to the start of this y value's row (2* is for complex):
-    deconvolveshuffle1d(dir,prefac/ker2[k2],ker1,ms,fk + pp,nf1,&fw[nf1*k2],modeord);
+    common::deconvolveshuffle1d(dir,prefac/ker2[k2],ker1,ms,fk + pp,nf1,&fw[nf1*k2],modeord);
   for (BIGINT k2=k2min;k2<0;++k2, pn+=2*ms)           // neg y-freqs
-    deconvolveshuffle1d(dir,prefac/ker2[-k2],ker1,ms,fk + pn,nf1,&fw[nf1*(nf2+k2)],modeord);
+    common::deconvolveshuffle1d(dir,prefac/ker2[-k2],ker1,ms,fk + pn,nf1,&fw[nf1*(nf2+k2)],modeord);
 }
 
 void deconvolveshuffle3d(int dir,FLT prefac,FLT *ker1, FLT *ker2,
@@ -394,10 +395,10 @@ void deconvolveshuffle3d(int dir,FLT prefac,FLT *ker1, FLT *ker2,
       fw[j][0] = fw[j][1] = 0.0;
   for (BIGINT k3=0;k3<=k3max;++k3, pp+=2*ms*mt)      // non-neg z-freqs
     // point fk and fw to the start of this z value's plane (2* is for complex):
-    deconvolveshuffle2d(dir,prefac/ker3[k3],ker1,ker2,ms,mt,
+    common::deconvolveshuffle2d(dir,prefac/ker3[k3],ker1,ker2,ms,mt,
 			fk + pp,nf1,nf2,&fw[np*k3],modeord);
   for (BIGINT k3=k3min;k3<0;++k3, pn+=2*ms*mt)       // neg z-freqs
-    deconvolveshuffle2d(dir,prefac/ker3[-k3],ker1,ker2,ms,mt,
+    common::deconvolveshuffle2d(dir,prefac/ker3[-k3],ker1,ker2,ms,mt,
 			fk + pn,nf1,nf2,&fw[np*(nf3+k3)],modeord);
 }
 
@@ -500,15 +501,14 @@ int* GRIDSIZE_FOR_FFTW(FINUFFT_PLAN p){
 }
 
 
-//  *** }   // internal namespace
-
+}   // namespace common
 
 
 
 
 // --------------- rest is the 5 user guru (plan) interface drivers: ---------
 // (not namespaced since have safe names finufft{f}_* )
-
+using namespace finufft::common;  // accesses routines defined above
 
 // OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO
 void FINUFFT_DEFAULT_OPTS(nufft_opts *o)

--- a/src/simpleinterfaces.cpp
+++ b/src/simpleinterfaces.cpp
@@ -19,6 +19,8 @@ using namespace std;
 
 // Helper layer ...........................................................
 
+namespace finufft::common {
+
 int invokeGuruInterface(int n_dims, int type, int n_transf, BIGINT nj, FLT* xj,
                         FLT *yj, FLT *zj, CPX* cj,int iflag, FLT eps,
                         BIGINT *n_modes, BIGINT nk, FLT *s, FLT *t,  FLT *u,
@@ -50,6 +52,9 @@ int invokeGuruInterface(int n_dims, int type, int n_transf, BIGINT nj, FLT* xj,
   return max(max(ier,ier2),ier3);  // in case any one gave a (positive!) warning
 }
 
+}       // namespace
+
+using namespace finufft::common;
 
 
 // Dimension 1111111111111111111111111111111111111111111111111111111111111111

--- a/src/simpleinterfaces.cpp
+++ b/src/simpleinterfaces.cpp
@@ -19,7 +19,8 @@ using namespace std;
 
 // Helper layer ...........................................................
 
-namespace finufft::common {
+namespace finufft {
+  namespace common {
 
 int invokeGuruInterface(int n_dims, int type, int n_transf, BIGINT nj, FLT* xj,
                         FLT *yj, FLT *zj, CPX* cj,int iflag, FLT eps,
@@ -52,6 +53,7 @@ int invokeGuruInterface(int n_dims, int type, int n_transf, BIGINT nj, FLT* xj,
   return max(max(ier,ier2),ier3);  // in case any one gave a (positive!) warning
 }
 
+  }       // namespace
 }       // namespace
 
 using namespace finufft::common;

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -27,7 +27,8 @@
 using namespace std;
 using namespace finufft::utils;              // access to timer
 
-namespace finufft::spreadinterp {
+namespace finufft {
+  namespace spreadinterp {
   
 // declarations of purely internal functions... (need not be in .h)
 static inline void set_kernel_args(FLT *args, FLT x, const spread_opts& opts);
@@ -1357,4 +1358,5 @@ void get_subgrid(BIGINT &offset1,BIGINT &offset2,BIGINT &offset3,BIGINT &size1,B
   }
 }
 
+  }   // namespace
 }   // namespace

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -9,6 +9,7 @@
 #include <math.h>
 #include <stdio.h>
 using namespace std;
+using namespace finufft;
 
 // declarations of purely internal functions...
 static inline void set_kernel_args(FLT *args, FLT x, const spread_opts& opts);

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -9,7 +9,7 @@
 #include <math.h>
 #include <stdio.h>
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
 
 // declarations of purely internal functions...
 static inline void set_kernel_args(FLT *args, FLT x, const spread_opts& opts);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -7,6 +7,7 @@
 #include "dataTypes.h"
 #include "defs.h"
 
+namespace finufft::utils {
 
 // ------------ complex array utils ---------------------------------
 
@@ -80,3 +81,5 @@ void arraywidcen(BIGINT n, FLT* a, FLT *w, FLT *c)
     *c = 0.0;
   }
 }
+
+}  // namespace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -7,7 +7,8 @@
 #include "dataTypes.h"
 #include "defs.h"
 
-namespace finufft::utils {
+namespace finufft {
+  namespace utils {
 
 // ------------ complex array utils ---------------------------------
 
@@ -82,4 +83,5 @@ void arraywidcen(BIGINT n, FLT* a, FLT *w, FLT *c)
   }
 }
 
+  }  // namespace
 }  // namespace

--- a/src/utils_precindep.cpp
+++ b/src/utils_precindep.cpp
@@ -31,6 +31,8 @@ BIGINT next235even(BIGINT n)
 // ----------------------- helpers for timing (always stay double prec) ------
 using namespace std;
 
+namespace finufft
+{
 void CNTime::start()
 {
   gettimeofday(&initial, 0);
@@ -54,6 +56,7 @@ double CNTime::elapsedsec()
   return nowsec - initialsec;
 }
 
+}
 
 // -------------------------- openmp helpers -------------------------------
 int get_num_threads_parallel_block()

--- a/src/utils_precindep.cpp
+++ b/src/utils_precindep.cpp
@@ -9,7 +9,8 @@
 #include "defs.h"
 using namespace std;
 
-namespace finufft::utils {
+namespace finufft {
+  namespace utils {
 
 BIGINT next235even(BIGINT n)
 // finds even integer not less than n, with prime factors no larger than 5
@@ -85,4 +86,5 @@ int rand_r(unsigned int *seedp)
 }
 #endif
 
+  } // namespace
 } // namespace

--- a/src/utils_precindep.cpp
+++ b/src/utils_precindep.cpp
@@ -7,7 +7,9 @@
 #include "utils_precindep.h"
 #include "dataTypes.h"
 #include "defs.h"
+using namespace std;
 
+namespace finufft::utils {
 
 BIGINT next235even(BIGINT n)
 // finds even integer not less than n, with prime factors no larger than 5
@@ -29,10 +31,7 @@ BIGINT next235even(BIGINT n)
 }
 
 // ----------------------- helpers for timing (always stay double prec) ------
-using namespace std;
-
-namespace finufft
-{
+  
 void CNTime::start()
 {
   gettimeofday(&initial, 0);
@@ -56,7 +55,6 @@ double CNTime::elapsedsec()
   return nowsec - initialsec;
 }
 
-}
 
 // -------------------------- openmp helpers -------------------------------
 int get_num_threads_parallel_block()
@@ -86,3 +84,5 @@ int rand_r(unsigned int *seedp)
     return distribution(generator);
 }
 #endif
+
+} // namespace

--- a/test/dumbinputs.cpp
+++ b/test/dumbinputs.cpp
@@ -4,6 +4,7 @@
 #include "directft/dirft2d.cpp"
 #include "directft/dirft3d.cpp"
 using namespace std;
+using namespace finufft::utils;        // for twonorm, etc
 
 int main(int argc, char* argv[])
 /* calling the FINUFFT library from C++ using all manner of crazy inputs that

--- a/test/finufft1d_test.cpp
+++ b/test/finufft1d_test.cpp
@@ -2,7 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft1d.cpp"
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
 
 const char* help[]={
   "Tester for FINUFFT in 1d, all 3 types, either precision.",

--- a/test/finufft1d_test.cpp
+++ b/test/finufft1d_test.cpp
@@ -2,6 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft1d.cpp"
 using namespace std;
+using namespace finufft;
 
 const char* help[]={
   "Tester for FINUFFT in 1d, all 3 types, either precision.",

--- a/test/finufft1dmany_test.cpp
+++ b/test/finufft1dmany_test.cpp
@@ -2,6 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft1d.cpp"
 using namespace std;
+using namespace finufft;
 
 const char* help[]={
   "Tester for FINUFFT in 1d, vectorized, all 3 types, either precision.",

--- a/test/finufft1dmany_test.cpp
+++ b/test/finufft1dmany_test.cpp
@@ -2,7 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft1d.cpp"
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
 
 const char* help[]={
   "Tester for FINUFFT in 1d, vectorized, all 3 types, either precision.",

--- a/test/finufft2d_test.cpp
+++ b/test/finufft2d_test.cpp
@@ -2,7 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft2d.cpp"
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
 
 const char* help[]={
   "Tester for FINUFFT in 2d, all 3 types, either precision.",

--- a/test/finufft2d_test.cpp
+++ b/test/finufft2d_test.cpp
@@ -2,6 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft2d.cpp"
 using namespace std;
+using namespace finufft;
 
 const char* help[]={
   "Tester for FINUFFT in 2d, all 3 types, either precision.",

--- a/test/finufft2dmany_test.cpp
+++ b/test/finufft2dmany_test.cpp
@@ -2,7 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft2d.cpp"
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
 
 const char* help[]={
   "Tester for FINUFFT in 2d, vectorized, all 3 types, either precision.",

--- a/test/finufft2dmany_test.cpp
+++ b/test/finufft2dmany_test.cpp
@@ -2,6 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft2d.cpp"
 using namespace std;
+using namespace finufft;
 
 const char* help[]={
   "Tester for FINUFFT in 2d, vectorized, all 3 types, either precision.",

--- a/test/finufft3d_test.cpp
+++ b/test/finufft3d_test.cpp
@@ -2,7 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft3d.cpp"
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
 
 const char* help[]={
   "Tester for FINUFFT in 3d, all 3 types, either precision.",

--- a/test/finufft3d_test.cpp
+++ b/test/finufft3d_test.cpp
@@ -2,6 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft3d.cpp"
 using namespace std;
+using namespace finufft;
 
 const char* help[]={
   "Tester for FINUFFT in 3d, all 3 types, either precision.",

--- a/test/finufft3dmany_test.cpp
+++ b/test/finufft3dmany_test.cpp
@@ -2,7 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft3d.cpp"
 using namespace std;
-using namespace finufft;
+using namespace finufft::utils;
 
 const char* help[]={
   "Tester for FINUFFT in 3d, vectorized, all 3 types, either precision.",

--- a/test/finufft3dmany_test.cpp
+++ b/test/finufft3dmany_test.cpp
@@ -2,6 +2,7 @@
 // this enforces recompilation, responding to SINGLE...
 #include "directft/dirft3d.cpp"
 using namespace std;
+using namespace finufft;
 
 const char* help[]={
   "Tester for FINUFFT in 3d, vectorized, all 3 types, either precision.",

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -8,6 +8,7 @@
 #include <utils_precindep.h>
 #include <stdio.h>
 #include <vector>
+using namespace finufft::utils;
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
only tested with executable
`perftest/spreadtestnd`
so far, works.

need to try out for all private functions in the library (non-user-facing), and the whole library including all examples in C++, C, Fortran.

The idea is to protect non-user-facing functions wtih a finufft:: namespace, yet leave the API unchanged (since it's designed to stay C-compatible).

This seems to be the only way to deal with static linking of finufft + cufinufft clash in
https://github.com/flatironinstitute/cufinufft/issues/138

So, I am not a C++ style expert. I want to keep it as simple as possible. I would love feedback if this is the way to continue.  (As that Issue discussion shows, using -fvisibility=hidden cannot help with static libs).

One question is: is having `using namespace finufft;` at top of all .cpp and .h ok style?
And having another layer of curly brackets for `namespace finufft {  ... } ` around large code blocks ?