### PR TITLE
Update py docs

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -144,7 +144,7 @@ All interfaces support both single and double precision, but for the plan, this 
     c = c.astype('complex64')
 
     # instantiate the plan and set the points
-    plan = finufft.Plan(nufft_type, (N1, N2), n_trans=K, dtype='float32')
+    plan = finufft.Plan(nufft_type, (N1, N2), n_trans=K, dtype='complex64')
     plan.setpts(x, y)
 
     # execute the plan, giving single-precision output

--- a/makefile
+++ b/makefile
@@ -406,7 +406,7 @@ docker-wheel:
 # =============================== DOCUMENTATION =============================
 
 docs: finufft-manual.pdf
-finufft-manual.pdf: docs/conf.py docs/*.doc docs/*.sh docs/*.rst docs/tutorial/*.rst $(STATICLIB) $(DYNLIB) CHANGELOG docs/*.src
+finufft-manual.pdf: docs/conf.py docs/*.doc docs/*.sh docs/*.rst docs/tutorial/*.rst $(STATICLIB) $(DYNLIB) CHANGELOG docs/*.src python/finufft/*.py
 # also builds a local html for local browser check too...
 	(cd docs; ./makecdocs.sh; make html && ./genpdfmanual.sh)
 docs/matlabhelp.doc: docs/genmatlabhelp.sh matlab/*.sh matlab/*.docsrc matlab/*.docbit matlab/*.m

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -585,9 +585,9 @@ def invoke_guru(dim,tp,x,y,z,c,s,t,u,f,isign,eps,n_modes,**kwargs):
 
     #plan
     if tp==3:
-        plan = Plan(tp,dim,n_trans,eps,isign,**dict(kwargs,dtype=pdtype))
+        plan = Plan(tp,dim,n_trans,eps,isign,pdtype,**kwargs)
     else:
-        plan = Plan(tp,n_modes,n_trans,eps,isign,**dict(kwargs,dtype=pdtype))
+        plan = Plan(tp,n_modes,n_trans,eps,isign,pdtype,*kwargs)
 
     #setpts
     plan.setpts(x,y,z,s,t,u)

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -74,7 +74,7 @@ class Plan:
         n_modes_or_dim  (int or tuple of ints): if ``nufft_type`` is 1 or 2,
                         this should be a tuple specifying the number of modes
                         in each dimension (for example, ``(50, 100)``),
-                        otherwise, if `nufft_type`` is 3, this should be the
+                        otherwise, if ``nufft_type`` is 3, this should be the
                         number of dimensions (between 1 and 3).
         n_trans         (int, optional): number of transforms to compute
                         simultaneously.

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -79,8 +79,9 @@ class Plan:
         n_trans         (int, optional): number of transforms to compute
                         simultaneously.
         eps             (float, optional): precision requested (>1e-16).
-        isign           (int, optional): if non-negative, uses positive sign
-                        exponential, otherwise negative sign.
+        isign           (int, optional): if +1, uses the positive sign
+                        exponential, otherwise the negative sign exponential;
+                        defaults to +1 for types 1 and 3 and to -1 for type 2.
         dtype           (string, optional): the precision of the transform,
                         'complex64' or 'complex128'.
         **kwargs        (optional): for more options, see :ref:`opts`.

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -41,6 +41,7 @@ class Plan:
 
     Example:
     ::
+
         import numpy as np
         import finufft
 
@@ -55,7 +56,7 @@ class Plan:
         y = 2 * np.pi * np.random.uniform(size=n_pts)
 
         # generate source strengths
-        c = (np.random.standard_normal(size=(n_trans, n_pts)),
+        c = (np.random.standard_normal(size=(n_trans, n_pts))
              + 1J * np.random.standard_normal(size=(n_trans, n_pts)))
 
         # initialize the plan

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -81,6 +81,8 @@ class Plan:
         eps             (float, optional): precision requested (>1e-16).
         isign           (int, optional): if non-negative, uses positive sign
                         exponential, otherwise negative sign.
+        dtype           (string, optional): the precision of the transform,
+                        'complex64' or 'complex128'.
         **kwargs        (optional): for more options, see :ref:`opts`.
     """
     def __init__(self,nufft_type,n_modes_or_dim,n_trans=1,eps=1e-6,isign=None,**kwargs):

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -86,7 +86,7 @@ class Plan:
                         'complex64' or 'complex128'.
         **kwargs        (optional): for more options, see :ref:`opts`.
     """
-    def __init__(self,nufft_type,n_modes_or_dim,n_trans=1,eps=1e-6,isign=None,**kwargs):
+    def __init__(self,nufft_type,n_modes_or_dim,n_trans=1,eps=1e-6,isign=None,dtype='complex128',**kwargs):
         # set default isign based on if isign is None
         if isign==None:
             if nufft_type==2:
@@ -97,7 +97,9 @@ class Plan:
         # set opts and check precision type
         opts = _finufft.NufftOpts()
         _finufft._default_opts(opts)
-        is_single = setkwopts(opts,**kwargs)
+        setkwopts(opts,**kwargs)
+
+        is_single = is_single_dtype(dtype)
 
         # construct plan based on precision type and eps default value
         plan = c_void_p(None)
@@ -525,18 +527,13 @@ def is_single_dtype(dtype):
 def setkwopts(opt,**kwargs):
     warnings.simplefilter('always')
 
-    dtype = 'double'
     for key,value in kwargs.items():
         if hasattr(opt,key):
             setattr(opt,key,value)
-        elif key == 'dtype':
-            dtype = value
         else:
             warnings.warn('Warning: nufft_opts does not have attribute "' + key + '"', Warning)
 
     warnings.simplefilter('default')
-
-    return is_single_dtype(dtype)
 
 
 ### destroy

--- a/python/finufft/_interfaces.py
+++ b/python/finufft/_interfaces.py
@@ -660,7 +660,6 @@ def _set_nufft_doc(f, dim, tp, example='python/test/accuracy_speed_tests.py'):
       complex[{modes}] or complex[ntransf, {modes}]: The resulting array.
 
     Example:
-
     ::
 
       # number of nonuniform points
@@ -712,7 +711,6 @@ def _set_nufft_doc(f, dim, tp, example='python/test/accuracy_speed_tests.py'):
       complex[M] or complex[ntransf, M]: The resulting array.
 
     Example:
-
     ::
 
       # number of nonuniform points
@@ -764,7 +762,6 @@ def _set_nufft_doc(f, dim, tp, example='python/test/accuracy_speed_tests.py'):
       complex[M] or complex[ntransf, M]: The resulting array.
 
     Example:
-
     ::
 
       # number of source points


### PR DESCRIPTION
Fixes #216 and some other docs issues.

@lu1and10 Can you remind me why the dtype handling was in `setkwopts` in the first place? I had to move it out to make the default argument visible in the docs, but if I understand correctly, everything should still work.