### PR TITLE
Privplan: made finufft_plan_s object private

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 List of features / changes made / release notes, in reverse chronological order
 
+* made the C++ plan object (finufft_plan_s) private; only opaque pointer
+  remains public, as should be (PR #233). Allows plan to have C++ constructs.
 * fixed single-thread (OMP=OFF) build which failed due to fftw_defs.h/defs.h
 
 V 2.1.0 (6/10/22)

--- a/docs/c.rst
+++ b/docs/c.rst
@@ -85,5 +85,9 @@ followed by more ``execute`` calls, as long as the transform sizes (and number o
 consistent with those that have been set in the ``plan`` and in ``setpts``.
 Keep in mind that ``setpts`` retains *pointers* to the user's list of nonuniform points, rather than copying these points; thus the user must not change their nonuniform point arrays until after any ``execute`` calls that use them.
 
+.. note::
+
+  The ``plan`` object (type ``finufft{f}_plan``) is an opaque pointer; the public interface specifies no more details that that. Under the hood in our library the plan happens to point to a C++ object of type ``finufft{f}_plan_s``, whose internal details the library user should not attempt to access, nor to rely on.
+
 .. include:: cguru.doc
                     

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -27,7 +27,7 @@ and also add them to github's Used By feature):
 Other wrappers to (cu)FINUFFT
 ------------------------------
    
-#. `FINUFFT.jl <https://github.com/ludvigak/FINUFFT.jl>`_: a `julia <https://julialang.org/>`_ language wrapper by Ludvig af Klinteberg, Libin Lu, and others, now using pure Julia, and fully featured (rather than via Python).
+#. `FINUFFT.jl <https://github.com/ludvigak/FINUFFT.jl>`_: a `julia <https://julialang.org/>`_ language wrapper by Ludvig af Klinteberg, Libin Lu, and others, now using pure Julia, and fully featured (rather than via Python). This is itself wrapped by `AbstractNFFTs.jl` in `NFFT.jl <https://juliamath.github.io/NFFT.jl/dev/performance/>`_.
 
 #. `TensorFlow NUFFT <https://github.com/mrphys/tensorflow-nufft>`_: a wrapper to the differentiable machine learning Python tool TensorFlow, for the CPU (via FINUFFT) and GPU (via cuFINUFFT). By Javier Montalt Tordera (UCL).
 
@@ -72,7 +72,12 @@ Papers or codes using our new ES window (spreading) function but not the whole F
 
 #. Martin Reinecke: codes for radio astronomy reconstruction including https://gitlab.mpcdf.mpg.de/mtr/ducc
 
+   
+Papers influenced by other aspects of FINUFFT:
 
+1. NFFT.jl: Generic and Fast Julia Implementation of the Nonequidistant Fast Fourier Transform, by Tobias Knopp, Marija Boberg, Mirco Grosser (2022). https://arxiv.org/abs/2208.00049  They use our blocked spreading and piecewise polynomial ideas, and beat our type 1 and 2 performance by a factor of 1-2 in some cases.
+
+   
    
 Citations to FINUFFT that do not appear to be actual users
 ----------------------------------------------------------

--- a/include/finufft/defs.h
+++ b/include/finufft/defs.h
@@ -204,21 +204,21 @@ typedef struct FINUFFT_PLAN_S {  // the main plan object, fully C++
   int type;        // transform type (Rokhlin naming): 1,2 or 3
   int dim;         // overall dimension: 1,2 or 3
   int ntrans;      // how many transforms to do at once (vector or "many" mode)
-  BIGINT nj;  // num of NU pts in type 1,2 (for type 3, num input x pts)
-  BIGINT nk;  // number of NU freq pts (type 3 only)
-  FLT tol; // relative user tolerance
+  BIGINT nj;       // num of NU pts in type 1,2 (for type 3, num input x pts)
+  BIGINT nk;       // number of NU freq pts (type 3 only)
+  FLT tol;         // relative user tolerance
   int batchSize;   // # strength vectors to group together for FFTW, etc
   int nbatch;      // how many batches done to cover all ntrans vectors
   
-  BIGINT ms; // number of modes in x (1) dir (historical CMCL name) = N1
-  BIGINT mt; // number of modes in y (2) direction = N2
-  BIGINT mu; // number of modes in z (3) direction = N3
-  BIGINT N;  // total # modes (prod of above three)
+  BIGINT ms;       // number of modes in x (1) dir (historical CMCL name) = N1
+  BIGINT mt;       // number of modes in y (2) direction = N2
+  BIGINT mu;       // number of modes in z (3) direction = N3
+  BIGINT N;        // total # modes (prod of above three)
   
-  BIGINT nf1;   // size of internal fine grid in x (1) direction
-  BIGINT nf2;   // " y
-  BIGINT nf3;   // " z
-  BIGINT nf;    // total # fine grid points (product of the above three)
+  BIGINT nf1;      // size of internal fine grid in x (1) direction
+  BIGINT nf2;      // " y (2)
+  BIGINT nf3;      // " z (3)
+  BIGINT nf;       // total # fine grid points (product of the above three)
   
   int fftSign;     // sign in exponential for NUFFT defn, guaranteed to be +-1
 
@@ -227,7 +227,7 @@ typedef struct FINUFFT_PLAN_S {  // the main plan object, fully C++
   FLT* phiHat3;    // " z-axis.
   
   FFTW_CPX* fwBatch;    // (batches of) fine grid(s) for FFTW to plan
-                                // & act on. Usually the largest working array
+                        // & act on. Usually the largest working array
   
   BIGINT *sortIndices;  // precomputed NU pt permutation, speeds spread/interp
   bool didSort;         // whether binsorting used (false: identity perm used)
@@ -240,13 +240,13 @@ typedef struct FINUFFT_PLAN_S {  // the main plan object, fully C++
   CPX* prephase;   // pre-phase, for all input NU pts
   CPX* deconv;     // reciprocal of kernel FT, phase, all output NU pts
   CPX* CpBatch;    // working array of prephased strengths
-  FLT *Sp, *Tp, *Up;  // internal primed targs (s'_k, etc), allocated
+  FLT *Sp, *Tp, *Up;    // internal primed targs (s'_k, etc), allocated
   TYPE3PARAMS t3P; // groups together type 3 shift, scale, phase, parameters
   FINUFFT_PLAN innerT2plan;   // ptr used for type 2 in step 2 of type 3
   
   // other internal structs; each is C-compatible of course
   FFTW_PLAN fftwPlan;
-  finufft_opts opts;     // this and spopts could be made ptrs
+  finufft_opts opts;    // this and spopts could be made ptrs
   finufft_spread_opts spopts;
   
 } FINUFFT_PLAN_S;

--- a/include/finufft/defs.h
+++ b/include/finufft/defs.h
@@ -1,19 +1,23 @@
 // Library private definitions & macros; also used by some test routines.
 // If SINGLE defined, chooses single prec, otherwise double prec.
 // Must be #included *after* finufft.h which clobbers FINUFFT* macros
-// (see discussion at end of this file).
+// (see discussion near line 145 of this file).
 
 // Split out by Joakim Anden, Alex Barnett 9/20/18-9/24/18.
 // Merged in dataTypes, private/public header split, clean. Barnett 6/7/22.
+// finufft_plan_s made private, Wenda's idea.  Barnett 8/8/22.
 
 /* Devnotes:
-   1) Only need work in C++ since that's how compiled.
+   1) Only need work for C++ since that's how compiled, including f_plan_s.
    (But we use C-style templating, following fftw, etc.)
 */
 
 #ifndef DEFS_H
 #define DEFS_H
 
+// public header gives access to f_opts, f_spread_opts, f_plan...
+// (and clobbers FINUFFT* macros; watch out!)
+#include <finufft.h>
 
 
 // ---------- Global error/warning output codes for the library ---------------
@@ -130,7 +134,7 @@
   #define MY_OMP_GET_THREAD_NUM() omp_get_thread_num()
   #define MY_OMP_SET_NUM_THREADS(x) omp_set_num_threads(x)
 #else
-  // non-omp safe dummy versions of omp utils, and dummy fftw threads calls...
+  // non-omp safe dummy versions of omp utils...
   #define MY_OMP_GET_NUM_THREADS() 1
   #define MY_OMP_GET_MAX_THREADS() 1
   #define MY_OMP_GET_THREAD_NUM() 0
@@ -138,12 +142,13 @@
 #endif
 
 
-// Prec-switching name macros (respond to SINGLE), used in lib & test sources:
+// Prec-switching name macros (respond to SINGLE), used in lib & test sources
+// and the plan object below.
 // Note: crucially, these are now indep of macros used to gen public finufft.h!
 // However, some overlap in name (FINUFFTIFY*, FINUFFT_PLAN*), meaning
 // finufft.h cannot be included after defs.h since it undefs these overlaps :(
 #ifdef SINGLE
-// macro to prepend finufft or finufftf to a string without a space.
+// a macro to prepend finufft or finufftf to a string without a space.
 // The 2nd level of indirection is needed for safety, see:
 // https://isocpp.org/wiki/faq/misc-technical-issues#macros-with-token-pasting
 #define FINUFFTIFY_UNSAFE(x) finufftf##x
@@ -151,7 +156,7 @@
 #define FINUFFTIFY_UNSAFE(x) finufft##x
 #endif
 #define FINUFFTIFY(x) FINUFFTIFY_UNSAFE(x)
-// Now use the tool to set up 2020-style macros used in tester source...
+// Now use the above tool to set up 2020-style macros used in tester source...
 #define FINUFFT_PLAN FINUFFTIFY(_plan)
 #define FINUFFT_PLAN_S FINUFFTIFY(_plan_s)
 #define FINUFFT_DEFAULT_OPTS FINUFFTIFY(_default_opts)
@@ -177,6 +182,76 @@
 #define FINUFFT3D1MANY FINUFFTIFY(3d1many)
 #define FINUFFT3D2MANY FINUFFTIFY(3d2many)
 #define FINUFFT3D3MANY FINUFFTIFY(3d3many)
+
+
+// --------  FINUFFT's plan object, prec-switching version ------------------
+// NB: now private (the public C++ or C etc user sees an opaque pointer to it)
+
+// FFTW is needed since we include a FFTW plan in the FINUFFT plan...
+#include <finufft/fftw_defs.h>          // (must come after complex.h)
+// (other FFT lib headers eg MKL could be here...)
+
+// group together a bunch of type 3 rescaling/centering/phasing parameters:
+#define TYPE3PARAMS FINUFFTIFY(_type3Params)
+typedef struct {
+  FLT X1,C1,D1,h1,gam1;  // x dim: X=halfwid C=center D=freqcen h,gam=rescale
+  FLT X2,C2,D2,h2,gam2;  // y
+  FLT X3,C3,D3,h3,gam3;  // z
+} TYPE3PARAMS;
+
+typedef struct FINUFFT_PLAN_S {  // the main plan object, fully C++
+  
+  int type;        // transform type (Rokhlin naming): 1,2 or 3
+  int dim;         // overall dimension: 1,2 or 3
+  int ntrans;      // how many transforms to do at once (vector or "many" mode)
+  BIGINT nj;  // num of NU pts in type 1,2 (for type 3, num input x pts)
+  BIGINT nk;  // number of NU freq pts (type 3 only)
+  FLT tol; // relative user tolerance
+  int batchSize;   // # strength vectors to group together for FFTW, etc
+  int nbatch;      // how many batches done to cover all ntrans vectors
+  
+  BIGINT ms; // number of modes in x (1) dir (historical CMCL name) = N1
+  BIGINT mt; // number of modes in y (2) direction = N2
+  BIGINT mu; // number of modes in z (3) direction = N3
+  BIGINT N;  // total # modes (prod of above three)
+  
+  BIGINT nf1;   // size of internal fine grid in x (1) direction
+  BIGINT nf2;   // " y
+  BIGINT nf3;   // " z
+  BIGINT nf;    // total # fine grid points (product of the above three)
+  
+  int fftSign;     // sign in exponential for NUFFT defn, guaranteed to be +-1
+
+  FLT* phiHat1;    // FT of kernel in t1,2, on x-axis mode grid
+  FLT* phiHat2;    // " y-axis.
+  FLT* phiHat3;    // " z-axis.
+  
+  FFTW_CPX* fwBatch;    // (batches of) fine grid(s) for FFTW to plan
+                                // & act on. Usually the largest working array
+  
+  BIGINT *sortIndices;  // precomputed NU pt permutation, speeds spread/interp
+  bool didSort;         // whether binsorting used (false: identity perm used)
+
+  FLT *X, *Y, *Z;  // for t1,2: ptr to user-supplied NU pts (no new allocs).
+                   // for t3: allocated as "primed" (scaled) src pts x'_j, etc
+
+  // type 3 specific
+  FLT *S, *T, *U;  // pointers to user's target NU pts arrays (no new allocs)
+  CPX* prephase;   // pre-phase, for all input NU pts
+  CPX* deconv;     // reciprocal of kernel FT, phase, all output NU pts
+  CPX* CpBatch;    // working array of prephased strengths
+  FLT *Sp, *Tp, *Up;  // internal primed targs (s'_k, etc), allocated
+  TYPE3PARAMS t3P; // groups together type 3 shift, scale, phase, parameters
+  FINUFFT_PLAN innerT2plan;   // ptr used for type 2 in step 2 of type 3
+  
+  // other internal structs; each is C-compatible of course
+  FFTW_PLAN fftwPlan;
+  finufft_opts opts;     // this and spopts could be made ptrs
+  finufft_spread_opts spopts;
+  
+} FINUFFT_PLAN_S;
+
+#undef TYPE3PARAMS
 
 
 #endif  // DEFS_H

--- a/include/finufft/fftw_defs.h
+++ b/include/finufft/fftw_defs.h
@@ -1,3 +1,5 @@
+// all FFTW-related private FINUFFT headers
+
 #ifndef FFTW_DEFS_H
 #define FFTW_DEFS_H
 
@@ -7,7 +9,7 @@
 
 #include <fftw3.h>          // (after complex.h) needed so can typedef FFTW_CPX
 
-// precision-switching for names of interfaces of FFTW...
+// precision-switching names for interfaces to FFTW...
 #ifdef SINGLE
   // macro to prepend fftw_ (for double) or fftwf_ (for single) to a string
   // without a space. The 2nd level of indirection is needed for safety, see:
@@ -17,7 +19,7 @@
   #define FFTWIFY_UNSAFE(x) fftw_##x
 #endif
 #define FFTWIFY(x) FFTWIFY_UNSAFE(x)
-// now use this tool (note we removed any typedefs in favor of macros):
+// now use this tool (note we replaced typedefs v<=2.0.4, in favor of macros):
 #define FFTW_CPX FFTWIFY(complex)
 #define FFTW_PLAN FFTWIFY(plan)
 #define FFTW_ALLOC_RE FFTWIFY(alloc_real)
@@ -31,6 +33,7 @@
 #define FFTW_FR FFTWIFY(free)
 #define FFTW_FORGET_WISDOM FFTWIFY(forget_wisdom)
 #define FFTW_CLEANUP FFTWIFY(cleanup)
+// the following OMP switch could be done in the src code instead...
 #ifdef _OPENMP
   #define FFTW_INIT FFTWIFY(init_threads)
   #define FFTW_PLAN_TH FFTWIFY(plan_with_nthreads)

--- a/include/finufft/finufft_eitherprec.h
+++ b/include/finufft/finufft_eitherprec.h
@@ -6,7 +6,7 @@
  safe, eg FINUFFTsomething.
  2)  They will clobber any prior macros starting FINUFFT*, so in the lib/test
  sources finufft.h must be included before defs.h
- 3) for debug, see finufft.h
+ 3) for debug of header macros, see finufft.h
 */
 
 // Local precision-switching macros to make the public interface...
@@ -33,87 +33,10 @@
 #endif
 #define FINUFFT_CPX FINUFFT_COMPLEXIFY(FINUFFT_FLT)
 
-
-//////////////////////////////////////////////////////////////////////
-// finufft_plan struct (plan C-style) for this precision...
+// opaque pointer to finufft_plan private object, for this precision...
 #define FINUFFT_PLAN FINUFFTIFY(_plan)
+// the plan object pointed to... (doesn't need to be even defined here)
 #define FINUFFT_PLAN_S FINUFFTIFY(_plan_s)
-#define FINUFFT_TYPE3PARAMS FINUFFTIFY(_type3Params)
-
-// the plan handle that we pass around is just a pointer to the struct that
-// contains all the info
-typedef struct FINUFFT_PLAN_S * FINUFFT_PLAN;
-
-// group together a bunch of type 3 rescaling/centering/phasing parameters:
-typedef struct {
-  FINUFFT_FLT X1,C1,D1,h1,gam1;  // x dim: X=halfwid C=center D=freqcen h,gam=rescale
-  FINUFFT_FLT X2,C2,D2,h2,gam2;  // y
-  FINUFFT_FLT X3,C3,D3,h3,gam3;  // z
-} FINUFFT_TYPE3PARAMS;
-
-// only the aspects of FFTW needed in this public-facing header...
-#include <fftw3.h>          // (must come after complex.h)
-// (following were typedefed in v<=2.0.4, which seems bad for plain macros)
-#ifdef FINUFFT_SINGLE
-#define FINUFFT_FFTW_CPX fftwf_complex
-#define FINUFFT_FFTW_PLAN fftwf_plan
-#else
-#define FINUFFT_FFTW_CPX fftw_complex
-#define FINUFFT_FFTW_PLAN fftw_plan
-#endif
-
-typedef struct FINUFFT_PLAN_S {  // the main plan struct; note C-compatible struct
-  
-  int type;        // transform type (Rokhlin naming): 1,2 or 3
-  int dim;         // overall dimension: 1,2 or 3
-  int ntrans;      // how many transforms to do at once (vector or "many" mode)
-  FINUFFT_BIGINT nj;  // num of NU pts in type 1,2 (for type 3, num input x pts)
-  FINUFFT_BIGINT nk;  // number of NU freq pts (type 3 only)
-  FINUFFT_FLT tol; // relative user tolerance
-  int batchSize;   // # strength vectors to group together for FFTW, etc
-  int nbatch;      // how many batches done to cover all ntrans vectors
-  
-  FINUFFT_BIGINT ms; // number of modes in x (1) dir (historical CMCL name) = N1
-  FINUFFT_BIGINT mt; // number of modes in y (2) direction = N2
-  FINUFFT_BIGINT mu; // number of modes in z (3) direction = N3
-  FINUFFT_BIGINT N;  // total # modes (prod of above three)
-  
-  FINUFFT_BIGINT nf1;   // size of internal fine grid in x (1) direction
-  FINUFFT_BIGINT nf2;   // " y
-  FINUFFT_BIGINT nf3;   // " z
-  FINUFFT_BIGINT nf;    // total # fine grid points (product of the above three)
-  
-  int fftSign;     // sign in exponential for NUFFT defn, guaranteed to be +-1
-
-  FINUFFT_FLT* phiHat1;    // FT of kernel in t1,2, on x-axis mode grid
-  FINUFFT_FLT* phiHat2;    // " y-axis.
-  FINUFFT_FLT* phiHat3;    // " z-axis.
-  
-  FINUFFT_FFTW_CPX* fwBatch;    // (batches of) fine grid(s) for FFTW to plan
-                                // & act on. Usually the largest working array
-  
-  FINUFFT_BIGINT *sortIndices;  // precomputed NU pt permutation, speeds spread/interp
-  bool didSort;         // whether binsorting used (false: identity perm used)
-
-  FINUFFT_FLT *X, *Y, *Z;  // for t1,2: ptr to user-supplied NU pts (no new allocs).
-                   // for t3: allocated as "primed" (scaled) src pts x'_j, etc
-
-  // type 3 specific
-  FINUFFT_FLT *S, *T, *U;  // pointers to user's target NU pts arrays (no new allocs)
-  FINUFFT_CPX* prephase;   // pre-phase, for all input NU pts
-  FINUFFT_CPX* deconv;     // reciprocal of kernel FT, phase, all output NU pts
-  FINUFFT_CPX* CpBatch;    // working array of prephased strengths
-  FINUFFT_FLT *Sp, *Tp, *Up;  // internal primed targs (s'_k, etc), allocated
-  FINUFFT_TYPE3PARAMS t3P; // groups together type 3 shift, scale, phase, parameters
-  FINUFFT_PLAN innerT2plan;   // ptr used for type 2 in step 2 of type 3
-  
-  // other internal structs; each is C-compatible of course
-  FINUFFT_FFTW_PLAN fftwPlan;
-  finufft_opts opts;     // this and spopts could be made ptrs
-  finufft_spread_opts spopts;
-  
-} FINUFFT_PLAN_S;
-
 
 
 ////////////////////////////////////////////////////////////////////
@@ -123,6 +46,12 @@ extern "C"
 {
 #endif
 
+// ----------------- the plan ----------------------------------------------- 
+// the plan handle that we pass around is just a pointer to the plan object
+// that contains all the info. The latter is invisible to the public user.
+typedef struct FINUFFT_PLAN_S * FINUFFT_PLAN;
+
+  
 // ------------------ the guru interface ------------------------------------
 // (sources in finufft.cpp)
   

--- a/include/finufft/test_defs.h
+++ b/include/finufft/test_defs.h
@@ -21,6 +21,7 @@
 // prec-switching (via SINGLE) to set up FLT, CPX, BIGINT, FINUFFT1D1, etc...
 #include <finufft/defs.h>
 // since "many" (vector) tests need direct access to FFTW commands...
+// (although this now happens to be included in defs.h too)
 #include <finufft/fftw_defs.h>
 
 // std stuff for tester src

--- a/makefile
+++ b/makefile
@@ -136,7 +136,7 @@ usage:
 	@echo " make python - compile and test python interfaces"
 	@echo " make all - do all the above (around 1 minute; assumes you have MATLAB, etc)"
 	@echo " make spreadtest - compile & run spreader-only tests (no FFTW)"
-	@echo " make spreadtestall - set of spreader-only tests for CI use"
+	@echo " make spreadtestall - small set spreader-only tests for CI use"
 	@echo " make objclean - remove all object files, preserving libs & MEX"
 	@echo " make clean - also remove all lib, MEX, py, and demo executables"
 	@echo "For faster (multicore) making, append, for example, -j8"


### PR DESCRIPTION
finufft_plan was already a pointer to the finufft_plan_s object, since we needed that for the high-level language interfaces (Joakim's idea).
However, finufft_plan_s was still defined in the public header.
Per Wenda's request, this PR makes finufft_plan_s private. Advantages:
* no user can become dependent on finufft_plan_s internals, which they should not
* fftw3.h is no longer in the public finufft.h
* finufft_plan_s can now use C++ mem mgmt and objects instead of restricted to C malloc/free. This will help Wenda.

Rather than create another header, I decided to add the plan definition to defs.h.
This also simplified the FFTW headers so that the only FFTW headers are in fftw_defs.h, no longer having a subset also in defs.h

Tests all work, but I'd appreciate confirmation.
