### PR TITLE
Make the time interface windows compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,11 @@ function(set_finufft_options target)
     target_include_directories(${target} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
     if (FINUFFT_USE_OPENMP)
         target_link_libraries(${target} PRIVATE OpenMP::OpenMP_CXX)
+        # there are issues on windows with OpenMP and CMake, so we need to manually add the flags
+        # otherwise there are link errors
+        if(WIN32)
+            target_link_options(${target} PRIVATE ${OpenMP_CXX_FLAGS})
+        endif()
     else ()
         if (CMAKE_CXX_COMPILER_ID IN_LIST FINUFFT_GNU_LIKE_COMPILERS)
             # OpenMP disabled, suppress unknown pragma warnings to avoid spam.
@@ -120,12 +125,20 @@ target_link_libraries(finufft_f64 PUBLIC ${FINUFFT_FFTW_LIBRARIES})
 
 add_library(finufft SHARED src/utils_precindep.cpp contrib/legendre_rule_fast.cpp)
 set_finufft_options(finufft)
-target_link_libraries(finufft PUBLIC finufft_f32 finufft_f64 m)
+target_link_libraries(finufft PUBLIC finufft_f32 finufft_f64)
+# windows does not have a math library, so we need to exclude it
+if(NOT WIN32)
+    target_link_libraries(finufft PUBLIC m)
+endif()
 target_include_directories(finufft PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_library(finufft_static STATIC src/utils_precindep.cpp contrib/legendre_rule_fast.cpp)
 set_finufft_options(finufft)
-target_link_libraries(finufft_static PUBLIC finufft_f32 finufft_f64 m)
+target_link_libraries(finufft_static PUBLIC finufft_f32 finufft_f64)
+# windows does not have a math library, so we need to exclude it
+if(NOT WIN32)
+    target_link_libraries(finufft_static PUBLIC m)
+endif()
 target_include_directories(finufft_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 # Add tests defined in their own directory

--- a/include/finufft/utils_precindep.h
+++ b/include/finufft/utils_precindep.h
@@ -6,7 +6,8 @@
 
 #include "defs.h"
 // for CNTime...
-#include <sys/time.h>
+// using chrono since the interface is portable between linux and windows
+#include <chrono>
 
 namespace finufft {
   namespace utils {
@@ -20,7 +21,7 @@ namespace finufft {
     double restart();
     double elapsedsec();
   private:
-    struct timeval initial;
+    double initial;
   };
 
   // openmp helpers

--- a/src/utils_precindep.cpp
+++ b/src/utils_precindep.cpp
@@ -3,6 +3,7 @@
 
 // For self-test see ../test/testutils.cpp.      Barnett 2017-2020.
 
+#include <cstdint>
 
 #include "finufft/utils_precindep.h"
 #include "finufft/defs.h"
@@ -34,25 +35,25 @@ BIGINT next235even(BIGINT n)
   
 void CNTime::start()
 {
-  gettimeofday(&initial, 0);
+  initial = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()).count()*1e-6;
 }
 
 double CNTime::restart()
 // Barnett changed to returning in sec
 {
-  double delta = this->elapsedsec();
-  this->start();
+  double delta = elapsedsec();
+  start();
   return delta;
 }
 
 double CNTime::elapsedsec()
 // returns answers as double, in seconds, to microsec accuracy. Barnett 5/22/18
 {
-  struct timeval now;
-  gettimeofday(&now, 0);
-  double nowsec = (double)now.tv_sec + 1e-6*now.tv_usec;
-  double initialsec = (double)initial.tv_sec + 1e-6*initial.tv_usec;
-  return nowsec - initialsec;
+  std::uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(
+                        std::chrono::steady_clock::now().time_since_epoch()).count();
+  const double nowsec = now*1e-6;
+  return nowsec - initial;
 }
 
 


### PR DESCRIPTION
Hi all,

The time interface was using linux specific API that did not work on windows.
I replaced it using chrono since it is portable. Chrono accuracy is implementation dependent so if we want the highest accuracy we should query the performance counters on windows.

Now it is possible to build finufft with cmake on windows without minGW or similars.

Thanks,
Marco