### PR TITLE
Fix cuda tests that give NaN results and pass anyway

### DIFF
--- a/include/cufinufft/spreadinterp.h
+++ b/include/cufinufft/spreadinterp.h
@@ -7,8 +7,11 @@
 // NU coord handling macro: if p is true, rescales from [-pi,pi] to [0,N], then
 // folds *only* one period below and above, ie [-N,2N], into the domain [0,N]...
 // FIXME: SO MUCH BRANCHING
+#ifndef M_1_2PI
+#define M_1_2PI 0.159154943091895336
+#endif
 #define RESCALE(x, N, p)                                                                                               \
-    (p ? ((x * M_1_2PI + (x < -PI ? 1.5 : (x >= PI ? -0.5 : 0.5))) * N) : (x < 0 ? x + N : (x >= N ? x - N : x)))
+    (p ? ((x * M_1_2PI + (x < -M_PI ? 1.5 : (x >= M_PI ? -0.5 : 0.5))) * N) : (x < 0 ? x + N : (x >= N ? x - N : x)))
 // yuk! But this is *so* much faster than slow std::fmod that we stick to it.
 
 namespace cufinufft {

--- a/src/cuda/1d/spread1d_wrapper.cu
+++ b/src/cuda/1d/spread1d_wrapper.cu
@@ -165,7 +165,7 @@ int CUSPREAD1D_NUPTSDRIVEN_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan) {
         checkCudaErrors(cudaMemcpy(h_kx, d_kx, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
         for (int i = 0; i < M; i++) {
             std::cout << "[debug ] ";
-            std::cout << "(" << setw(3) << h_kx[i] << ")" << std::endl;
+            std::cout << "(" << std::setw(3) << h_kx[i] << ")" << std::endl;
         }
 #endif
         int *d_binsize = d_plan->binsize;
@@ -195,7 +195,7 @@ int CUSPREAD1D_NUPTSDRIVEN_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan) {
         for (int i = 0; i < numbins; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << "bin[" << setw(1) << i << "]=" << h_binsize[i];
+            std::cout << "bin[" << std::setw(1) << i << "]=" << h_binsize[i];
         }
         std::cout << std::endl;
         free(h_binsize);
@@ -209,7 +209,7 @@ int CUSPREAD1D_NUPTSDRIVEN_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan) {
         for (int i = 0; i < M; i++) {
             if (h_sortidx[i] < 0) {
                 std::cout << "[debug ] ";
-                std::cout << "point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+                std::cout << "point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
                 std::cout << "[debug ] ";
                 printf("(%10.10f) ", RESCALE(h_kx[i], nf1, pirange));
                 printf("(%10.10f) ", RESCALE(h_kx[i], nf1, pirange) / 32);
@@ -237,7 +237,7 @@ int CUSPREAD1D_NUPTSDRIVEN_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan) {
         for (int i = 0; i < numbins; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << "bin[" << setw(1) << i << "]=" << h_binstartpts[i];
+            std::cout << "bin[" << std::setw(1) << i << "]=" << h_binstartpts[i];
         }
         std::cout << std::endl;
         free(h_binstartpts);
@@ -355,7 +355,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
     checkCudaErrors(cudaMemcpy(h_kx, d_kx, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
     for (int i = 0; i < M; i++) {
         std::cout << "[debug ]";
-        std::cout << "(" << setw(3) << h_kx[i] << ")" << std::endl;
+        std::cout << "(" << std::setw(3) << h_kx[i] << ")" << std::endl;
     }
 #endif
     int *d_binsize = d_plan->binsize;
@@ -389,7 +389,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
     for (int i = 0; i < numbins; i++) {
         if (i != 0)
             std::cout << " ";
-        std::cout << "bin[" << setw(3) << i << "]=" << h_binsize[i];
+        std::cout << "bin[" << std::setw(3) << i << "]=" << h_binsize[i];
     }
     free(h_binsize);
     std::cout << "[debug ] ----------------------------------------------------" << std::endl;
@@ -400,7 +400,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
     checkCudaErrors(cudaMemcpy(h_sortidx, d_sortidx, M * sizeof(int), cudaMemcpyDeviceToHost));
     std::cout << "[debug ]";
     for (int i = 0; i < M; i++) {
-        std::cout << "[debug] point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+        std::cout << "[debug] point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
     }
 
 #endif
@@ -425,7 +425,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
     for (int i = 0; i < numbins; i++) {
         if (i != 0)
             std::cout << " ";
-        std::cout << "bin[" << setw(3) << i << "] = " << setw(2) << h_binstartpts[i];
+        std::cout << "bin[" << std::setw(3) << i << "] = " << std::setw(2) << h_binstartpts[i];
     }
     free(h_binstartpts);
     std::cout << "[debug ] ---------------------------------------------------" << std::endl;
@@ -458,7 +458,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
     for (int i = 0; i < numbins; i++) {
         if (i != 0)
             std::cout << " ";
-        std::cout << "nsub[" << setw(3) << i << "] = " << setw(2) << h_numsubprob[i];
+        std::cout << "nsub[" << std::setw(3) << i << "] = " << std::setw(2) << h_numsubprob[i];
     }
     std::cout << std::endl;
     free(h_numsubprob);
@@ -483,7 +483,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
     for (int i = 0; i < numbins; i++) {
         if (i != 0)
             std::cout << " ";
-        std::cout << "nsub[" << setw(3) << i << "] = " << setw(2) << h_subprobstartpts[i];
+        std::cout << "nsub[" << std::setw(3) << i << "] = " << std::setw(2) << h_subprobstartpts[i];
     }
     std::cout << std::endl;
     printf("[debug ] Total number of subproblems = %d\n", h_subprobstartpts[n]);
@@ -509,7 +509,7 @@ int CUSPREAD1D_SUBPROB_PROP(int nf1, int M, CUFINUFFT_PLAN d_plan)
         cudaMemcpy(h_subprob_to_bin, d_subprob_to_bin, (totalnumsubprob) * sizeof(int), cudaMemcpyDeviceToHost));
     for (int j = 0; j < totalnumsubprob; j++) {
         std::cout << "[debug ] ";
-        std::cout << "nsub[" << j << "] = " << setw(2) << h_subprob_to_bin[j];
+        std::cout << "nsub[" << j << "] = " << std::setw(2) << h_subprob_to_bin[j];
         std::cout << std::endl;
     }
     free(h_subprob_to_bin);

--- a/src/cuda/2d/spread2d_wrapper.cu
+++ b/src/cuda/2d/spread2d_wrapper.cu
@@ -194,7 +194,7 @@ int CUSPREAD2D_NUPTSDRIVEN_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) 
         checkCudaErrors(cudaMemcpy(h_ky, d_ky, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
         for (int i = M - 10; i < M; i++) {
             std::cout << "[debug ] ";
-            std::cout << "(" << setw(3) << h_kx[i] << "," << setw(3) << h_ky[i] << ")" << std::endl;
+            std::cout << "(" << std::setw(3) << h_kx[i] << "," << std::setw(3) << h_ky[i] << ")" << std::endl;
         }
 #endif
         int *d_binsize = d_plan->binsize;
@@ -226,7 +226,7 @@ int CUSPREAD2D_NUPTSDRIVEN_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) 
             for (int i = 0; i < numbins[0]; i++) {
                 if (i != 0)
                     std::cout << " ";
-                std::cout << " bin[" << setw(1) << i << "," << setw(1) << j << "]=" << h_binsize[i + j * numbins[0]];
+                std::cout << " bin[" << std::setw(1) << i << "," << std::setw(1) << j << "]=" << h_binsize[i + j * numbins[0]];
             }
             std::cout << std::endl;
         }
@@ -241,7 +241,7 @@ int CUSPREAD2D_NUPTSDRIVEN_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) 
         for (int i = 0; i < M; i++) {
             if (h_sortidx[i] < 0) {
                 std::cout << "[debug ] ";
-                std::cout << "point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+                std::cout << "point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
                 std::cout << "[debug ] ";
                 printf("(%10.10f, %10.10f) ", RESCALE(h_kx[i], nf1, pirange), RESCALE(h_ky[i], nf1, pirange));
                 printf("(%10.10f, %10.10f) ", RESCALE(h_kx[i], nf1, pirange) / 32, RESCALE(h_ky[i], nf1, pirange) / 32);
@@ -272,7 +272,7 @@ int CUSPREAD2D_NUPTSDRIVEN_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) 
             for (int i = 0; i < numbins[0]; i++) {
                 if (i != 0)
                     std::cout << " ";
-                std::cout << " bin[" << setw(1) << i << "," << setw(1) << j
+                std::cout << " bin[" << std::setw(1) << i << "," << std::setw(1) << j
                           << "]=" << h_binstartpts[i + j * numbins[0]];
             }
             std::cout << std::endl;
@@ -402,7 +402,7 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
     checkCudaErrors(cudaMemcpy(h_ky, d_ky, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
     for (int i = 0; i < M; i++) {
         std::cout << "[debug ]";
-        std::cout << "(" << setw(3) << h_kx[i] << "," << setw(3) << h_ky[i] << ")" << std::endl;
+        std::cout << "(" << std::setw(3) << h_kx[i] << "," << std::setw(3) << h_ky[i] << ")" << std::endl;
     }
 #endif
     int *d_binsize = d_plan->binsize;
@@ -437,7 +437,7 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
         for (int i = 0; i < numbins[0]; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << " bin[" << setw(3) << i << "," << setw(3) << j << "]=" << h_binsize[i + j * numbins[0]];
+            std::cout << " bin[" << std::setw(3) << i << "," << std::setw(3) << j << "]=" << h_binsize[i + j * numbins[0]];
         }
         std::cout << std::endl;
     }
@@ -450,7 +450,7 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
     checkCudaErrors(cudaMemcpy(h_sortidx, d_sortidx, M * sizeof(int), cudaMemcpyDeviceToHost));
     std::cout << "[debug ]";
     for (int i = 0; i < M; i++) {
-        std::cout << "[debug] point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+        std::cout << "[debug] point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
     }
 
 #endif
@@ -477,7 +477,7 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
         for (int i = 0; i < numbins[0]; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << "bin[" << setw(3) << i << "," << setw(3) << j << "] = " << setw(2)
+            std::cout << "bin[" << std::setw(3) << i << "," << std::setw(3) << j << "] = " << std::setw(2)
                       << h_binstartpts[i + j * numbins[0]];
         }
         std::cout << std::endl;
@@ -516,7 +516,7 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
         for (int i = 0; i < numbins[0]; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << "nsub[" << setw(3) << i << "," << setw(3) << j << "] = " << setw(2)
+            std::cout << "nsub[" << std::setw(3) << i << "," << std::setw(3) << j << "] = " << std::setw(2)
                       << h_numsubprob[i + j * numbins[0]];
         }
         std::cout << std::endl;
@@ -544,7 +544,7 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
         for (int i = 0; i < numbins[0]; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << "nsub[" << setw(3) << i << "," << setw(3) << j << "] = " << setw(2)
+            std::cout << "nsub[" << std::setw(3) << i << "," << std::setw(3) << j << "] = " << std::setw(2)
                       << h_subprobstartpts[i + j * numbins[0]];
         }
         std::cout << std::endl;
@@ -572,7 +572,7 @@ int CUSPREAD2D_SUBPROB_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan)
         cudaMemcpy(h_subprob_to_bin, d_subprob_to_bin, (totalnumsubprob) * sizeof(int), cudaMemcpyDeviceToHost));
     for (int j = 0; j < totalnumsubprob; j++) {
         std::cout << "[debug ] ";
-        std::cout << "nsub[" << j << "] = " << setw(2) << h_subprob_to_bin[j];
+        std::cout << "nsub[" << j << "] = " << std::setw(2) << h_subprob_to_bin[j];
         std::cout << std::endl;
     }
     free(h_subprob_to_bin);

--- a/src/cuda/2d/spread2d_wrapper_paul.cu
+++ b/src/cuda/2d/spread2d_wrapper_paul.cu
@@ -44,7 +44,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
     checkCudaErrors(cudaMemcpy(h_ky, d_ky, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
     for (int i = 0; i < M; i++) {
         std::cout << "[debug ]";
-        std::cout << " (" << setw(3) << h_kx[i] << "," << setw(3) << h_ky[i] << ")" << std::endl;
+        std::cout << " (" << std::setw(3) << h_kx[i] << "," << std::setw(3) << h_ky[i] << ")" << std::endl;
     }
 #endif
     int *d_binsize = d_plan->binsize;
@@ -89,7 +89,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
             binidx = binx + biny * numbins[0];
             if (i != 0)
                 std::cout << " ";
-            std::cout << setw(2)
+            std::cout << std::setw(2)
                       << h_finegridsize[binidx * bin_size_x * bin_size_y + (i - binx * bin_size_x) +
                                         (j - bin_size_y * biny) * bin_size_x];
         }
@@ -109,7 +109,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
         for (int i = 0; i < numbins[0]; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << " bin[" << setw(3) << i << "," << setw(3) << j << "]=" << h_binsize[i + j * numbins[0]];
+            std::cout << " bin[" << std::setw(3) << i << "," << std::setw(3) << j << "]=" << h_binsize[i + j * numbins[0]];
         }
         std::cout << std::endl;
     }
@@ -123,7 +123,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
     checkCudaErrors(cudaMemcpy(h_sortidx, d_sortidx, M * sizeof(int), cudaMemcpyDeviceToHost));
     std::cout << "[debug ]";
     for (int i = 0; i < M; i++) {
-        std::cout << "point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+        std::cout << "point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
     }
 #endif
     int n = nf1 * nf2;
@@ -154,7 +154,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
             binidx = binx + biny * numbins[0];
             if (i != 0)
                 std::cout << " ";
-            std::cout << setw(2)
+            std::cout << std::setw(2)
                       << h_fgstartpts[binidx * bin_size_x * bin_size_y + (i - binx * bin_size_x) +
                                       (j - bin_size_y * biny) * bin_size_x];
         }
@@ -205,7 +205,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
         for (int i = 0; i < numbins[0]; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << "nsub[" << setw(3) << i << "," << setw(3) << j << "] = " << setw(2)
+            std::cout << "nsub[" << std::setw(3) << i << "," << std::setw(3) << j << "] = " << std::setw(2)
                       << h_numsubprob[i + j * numbins[0]];
         }
         std::cout << std::endl;
@@ -236,7 +236,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
         for (int i = 0; i < numbins[0]; i++) {
             if (i != 0)
                 std::cout << " ";
-            std::cout << "nsub[" << setw(3) << i << "," << setw(3) << j << "] = " << setw(2)
+            std::cout << "nsub[" << std::setw(3) << i << "," << std::setw(3) << j << "] = " << std::setw(2)
                       << h_subprobstartpts[i + j * numbins[0]];
         }
         std::cout << std::endl;
@@ -270,7 +270,7 @@ int CUSPREAD2D_PAUL_PROP(int nf1, int nf2, int M, CUFINUFFT_PLAN d_plan) {
         cudaMemcpy(h_subprob_to_bin, d_subprob_to_bin, (totalnumsubprob) * sizeof(int), cudaMemcpyDeviceToHost));
     for (int j = 0; j < totalnumsubprob; j++) {
         std::cout << "[debug ] ";
-        std::cout << "nsub[" << j << "] = " << setw(2) << h_subprob_to_bin[j];
+        std::cout << "nsub[" << j << "] = " << std::setw(2) << h_subprob_to_bin[j];
         std::cout << std::endl;
     }
 #endif

--- a/src/cuda/3d/spread3d_wrapper.cu
+++ b/src/cuda/3d/spread3d_wrapper.cu
@@ -193,7 +193,7 @@ int CUSPREAD3D_NUPTSDRIVEN_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
         checkCudaErrors(cudaMemcpy(h_kz, d_kz, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
         for (int i = 0; i < 10; i++) {
             std::cout << "[debug ] ";
-            std::cout << "(" << setw(3) << h_kx[i] << "," << setw(3) << h_ky[i] << "," << setw(3) << h_kz[i] << ")"
+            std::cout << "(" << std::setw(3) << h_kx[i] << "," << std::setw(3) << h_ky[i] << "," << std::setw(3) << h_kz[i] << ")"
                       << std::endl;
         }
 #endif
@@ -229,7 +229,7 @@ int CUSPREAD3D_NUPTSDRIVEN_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
                 for (int i = 0; i < numbins[0]; i++) {
                     if (i != 0)
                         std::cout << " ";
-                    std::cout << " bin[" << setw(1) << i << "," << setw(1) << j << "," << setw(1) << k
+                    std::cout << " bin[" << std::setw(1) << i << "," << std::setw(1) << j << "," << std::setw(1) << k
                               << "]=" << h_binsize[i + j * numbins[0] + k * numbins[0] * numbins[1]];
                 }
                 std::cout << std::endl;
@@ -245,7 +245,7 @@ int CUSPREAD3D_NUPTSDRIVEN_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
         checkCudaErrors(cudaMemcpy(h_sortidx, d_sortidx, M * sizeof(int), cudaMemcpyDeviceToHost));
         for (int i = 0; i < M; i++) {
             std::cout << "[debug ] ";
-            std::cout << "point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+            std::cout << "point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
         }
 #endif
 
@@ -272,7 +272,7 @@ int CUSPREAD3D_NUPTSDRIVEN_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
                 for (int i = 0; i < numbins[0]; i++) {
                     if (i != 0)
                         std::cout << " ";
-                    std::cout << " bin[" << setw(1) << i << "," << setw(1) << j << "," << setw(1) << k
+                    std::cout << " bin[" << std::setw(1) << i << "," << std::setw(1) << j << "," << std::setw(1) << k
                               << "]=" << h_binstartpts[i + j * numbins[0] + k * numbins[0] * numbins[1]];
                 }
                 std::cout << std::endl;
@@ -439,7 +439,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
     checkCudaErrors(cudaMemcpy(h_kz, d_kz, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
     for (int i = 0; i < M; i++) {
         std::cout << "[debug ] ";
-        std::cout << "(" << setw(3) << h_kx[i] << "," << setw(3) << h_ky[i] << "," << h_kz[i] << ")" << std::endl;
+        std::cout << "(" << std::setw(3) << h_kx[i] << "," << std::setw(3) << h_ky[i] << "," << h_kz[i] << ")" << std::endl;
     }
 #endif
     int *d_binsize = d_plan->binsize;
@@ -496,7 +496,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
 
     checkCudaErrors(cudaMemcpy(h_sortidx, d_sortidx, M * sizeof(int), cudaMemcpyDeviceToHost));
     for (int i = 0; i < M; i++) {
-        std::cout << "[debug ] point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+        std::cout << "[debug ] point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
     }
 #endif
     cudaEventRecord(start);
@@ -671,7 +671,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
             for (int i = 0; i < numobins[0]; i++) {
                 if (i != 0)
                     std::cout << " ";
-                std::cout << "s[" << setw(1) << i << "," << setw(1) << j << "," << setw(1) << k << "]= " << setw(3)
+                std::cout << "s[" << std::setw(1) << i << "," << std::setw(1) << j << "," << std::setw(1) << k << "]= " << std::setw(3)
                           << h_numsubprob[i + j * numobins[0] + k * numobins[1] * numobins[2]];
             }
             std::cout << std::endl;
@@ -705,7 +705,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
             for (int i = 0; i < numobins[0]; i++) {
                 if (i != 0)
                     std::cout << " ";
-                std::cout << "s[" << setw(1) << i << "," << setw(1) << j << "," << setw(1) << k << "]= " << setw(3)
+                std::cout << "s[" << std::setw(1) << i << "," << std::setw(1) << j << "," << std::setw(1) << k << "]= " << std::setw(3)
                           << h_subprobstartpts[i + j * numobins[0] + k * numobins[1] * numobins[2]];
             }
             std::cout << std::endl;
@@ -739,7 +739,7 @@ int CUSPREAD3D_BLOCKGATHER_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN
         cudaMemcpy(h_subprob_to_bin, d_subprob_to_bin, (totalnumsubprob) * sizeof(int), cudaMemcpyDeviceToHost));
     for (int j = 0; j < totalnumsubprob; j++) {
         std::cout << "[debug ] ";
-        std::cout << "s[" << j << "] = " << setw(2) << "b[" << h_subprob_to_bin[j] << "]";
+        std::cout << "s[" << j << "] = " << std::setw(2) << "b[" << h_subprob_to_bin[j] << "]";
         std::cout << std::endl;
     }
     free(h_subprob_to_bin);
@@ -874,7 +874,7 @@ int CUSPREAD3D_SUBPROB_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN d_p
     checkCudaErrors(cudaMemcpy(h_kz, d_kz, M * sizeof(CUFINUFFT_FLT), cudaMemcpyDeviceToHost));
     for (int i = M - 10; i < M; i++) {
         std::cout << "[debug ] ";
-        std::cout << "(" << setw(3) << h_kx[i] << "," << setw(3) << h_ky[i] << "," << setw(3) << h_kz[i] << ")"
+        std::cout << "(" << std::setw(3) << h_kx[i] << "," << std::setw(3) << h_ky[i] << "," << std::setw(3) << h_kz[i] << ")"
                   << std::endl;
     }
 #endif
@@ -929,7 +929,7 @@ int CUSPREAD3D_SUBPROB_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN d_p
     checkCudaErrors(cudaMemcpy(h_sortidx, d_sortidx, M * sizeof(int), cudaMemcpyDeviceToHost));
     for (int i = 0; i < 10; i++) {
         std::cout << "[debug ] ";
-        std::cout << "point[" << setw(3) << i << "]=" << setw(3) << h_sortidx[i] << std::endl;
+        std::cout << "point[" << std::setw(3) << i << "]=" << std::setw(3) << h_sortidx[i] << std::endl;
     }
 #endif
 
@@ -1057,7 +1057,7 @@ int CUSPREAD3D_SUBPROB_PROP(int nf1, int nf2, int nf3, int M, CUFINUFFT_PLAN d_p
     std::cout << totalnumsubprob << std::endl;
     for (int j = 0; j < min(totalnumsubprob, 10); j++) {
         std::cout << "[debug ] ";
-        std::cout << "nsub[" << j << "] = " << setw(2) << h_subprob_to_bin[j];
+        std::cout << "nsub[" << j << "] = " << std::setw(2) << h_subprob_to_bin[j];
         std::cout << std::endl;
     }
     free(h_subprob_to_bin);

--- a/test/cuda/cufinufft1d_test.cu
+++ b/test/cuda/cufinufft1d_test.cu
@@ -192,5 +192,5 @@ int main(int argc, char *argv[]) {
     cudaFree(d_x);
     cudaFree(d_c);
     cudaFree(d_fk);
-    return rel_error > checktol;
+    return std::isnan(rel_error) || rel_error > checktol;
 }

--- a/test/cuda/cufinufft1d_test.cu
+++ b/test/cuda/cufinufft1d_test.cu
@@ -13,7 +13,7 @@ using cufinufft::utils::infnorm;
 
 int main(int argc, char *argv[]) {
     if (argc != 7) {
-        fprintf(stderr, "Usage: cufinufft2d2_test method N M tol checktol\n"
+        fprintf(stderr, "Usage: cufinufft1d_test method type N1 M tol checktol\n"
                         "Arguments:\n"
                         "  method: One of\n"
                         "    1: nupts driven\n"
@@ -70,7 +70,10 @@ int main(int argc, char *argv[]) {
         return 1;
     }
     checkCudaErrors(cudaMemcpy(d_x, x, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
-    checkCudaErrors(cudaMemcpy(d_fk, fk, N1 * sizeof(CUFINUFFT_CPX), cudaMemcpyHostToDevice));
+    if (type == 1)
+        checkCudaErrors(cudaMemcpy(d_c, c, M * sizeof(CUFINUFFT_CPX), cudaMemcpyHostToDevice));
+    else if (type == 2)
+        checkCudaErrors(cudaMemcpy(d_fk, fk, N1 * sizeof(CUFINUFFT_CPX), cudaMemcpyHostToDevice));
 
     cudaEvent_t start, stop;
     float milliseconds = 0;
@@ -134,7 +137,7 @@ int main(int argc, char *argv[]) {
     cudaEventRecord(start);
     ier = CUFINUFFT_EXECUTE(d_c, d_fk, dplan);
     if (ier != 0) {
-        printf("err: cufinufft1d2_exec\n");
+        printf("err: cufinufft1d_exec\n");
         return ier;
     }
 
@@ -149,7 +152,7 @@ int main(int argc, char *argv[]) {
     PROFILE_CUDA_GROUP("cufinufft1d_destroy", 5);
     ier = CUFINUFFT_DESTROY(dplan);
     if (ier != 0) {
-        printf("err %d: cufinufft1d2_destroy\n", ier);
+        printf("err %d: cufinufft1d_destroy\n", ier);
         return ier;
     }
     cudaEventRecord(stop);
@@ -162,10 +165,9 @@ int main(int argc, char *argv[]) {
            totaltime / 1000, M / totaltime * 1000);
     printf("\t\t\t\t\t(exec-only thoughput: %.3g NU pts/s)\n", M / exec_ms * 1000);
 
-    checkCudaErrors(cudaMemcpy(c, d_c, M * sizeof(CUCPX), cudaMemcpyDeviceToHost));
-
     CUFINUFFT_FLT rel_error = std::numeric_limits<CUFINUFFT_FLT>::max();
     if (type == 1) {
+        checkCudaErrors(cudaMemcpy(fk, d_fk, N1 * sizeof(CUCPX), cudaMemcpyDeviceToHost));
         int nt1 = 0.37 * N1; // choose some mode index to check
         CUFINUFFT_CPX Ft = CUFINUFFT_CPX(0, 0), J = IMA * (CUFINUFFT_FLT)iflag;
         for (int j = 0; j < M; ++j)
@@ -176,6 +178,8 @@ int main(int argc, char *argv[]) {
         printf("[gpu   ] one mode: rel err in F[%d] is %.3g\n", nt1, rel_error);
     }
     else if (type == 2) {
+        checkCudaErrors(cudaMemcpy(c, d_c, M * sizeof(CUCPX), cudaMemcpyDeviceToHost));
+
         int jt = M / 2; // check arbitrary choice of one targ pt
         CUFINUFFT_CPX J = IMA * (CUFINUFFT_FLT)iflag;
         CUFINUFFT_CPX ct = CUFINUFFT_CPX(0, 0);

--- a/test/cuda/cufinufft2d_test.cu
+++ b/test/cuda/cufinufft2d_test.cu
@@ -77,7 +77,10 @@ int main(int argc, char *argv[]) {
 
     checkCudaErrors(cudaMemcpy(d_x, x, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
     checkCudaErrors(cudaMemcpy(d_y, y, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
-    checkCudaErrors(cudaMemcpy(d_c, c, M * sizeof(CUCPX), cudaMemcpyHostToDevice));
+    if (type == 1)
+        checkCudaErrors(cudaMemcpy(d_c, c, M * sizeof(CUCPX), cudaMemcpyHostToDevice));
+    else if (type == 2)
+        checkCudaErrors(cudaMemcpy(d_fk, c, N1 * N2 * sizeof(CUCPX), cudaMemcpyHostToDevice));
 
     cudaEvent_t start, stop;
     float milliseconds = 0;
@@ -159,7 +162,10 @@ int main(int argc, char *argv[]) {
     totaltime += milliseconds;
     printf("[time  ] cufinufft destroy:\t\t %.3g s\n", milliseconds / 1000);
 
-    checkCudaErrors(cudaMemcpy(fk, d_fk, N1 * N2 * sizeof(CUCPX), cudaMemcpyDeviceToHost));
+    if (type == 1)
+        checkCudaErrors(cudaMemcpy(fk, d_fk, N1 * N2 * sizeof(CUCPX), cudaMemcpyDeviceToHost));
+    else if (type == 2)
+        checkCudaErrors(cudaMemcpy(c, d_c, M * sizeof(CUCPX), cudaMemcpyDeviceToHost));
 
     printf("[Method %d] %d NU pts to %d U pts in %.3g s:      %.3g NU pts/s\n", opts.gpu_method, M, N1 * N2,
            totaltime / 1000, M / totaltime * 1000);

--- a/test/cuda/cufinufft2d_test.cu
+++ b/test/cuda/cufinufft2d_test.cu
@@ -195,5 +195,5 @@ int main(int argc, char *argv[]) {
     cudaFree(d_c);
     cudaFree(d_fk);
 
-    return rel_error > checktol;
+    return std::isnan(rel_error) || rel_error > checktol;
 }

--- a/test/cuda/cufinufft2dmany_test.cu
+++ b/test/cuda/cufinufft2dmany_test.cu
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
     cudaEventRecord(start);
     ier = CUFINUFFT_EXECUTE(d_c, d_fk, dplan);
     if (ier != 0) {
-        printf("err: cufinufft2d1_exec\n");
+        printf("err: cufinufft2d_exec\n");
         return ier;
     }
     cudaEventRecord(stop);

--- a/test/cuda/cufinufft2dmany_test.cu
+++ b/test/cuda/cufinufft2dmany_test.cu
@@ -69,12 +69,12 @@ int main(int argc, char *argv[]) {
         y[i] = M_PI * randm11();
     }
     if (type == 1) {
-        for (int i = 0; i < M; i++) {
+        for (int i = 0; i < ntransf * M; i++) {
             c[i].real(randm11());
             c[i].imag(randm11());
         }
     } else if (type == 2) {
-        for (int i = 0; i < N1 * N2; i++) {
+        for (int i = 0; i < ntransf * N1 * N2; i++) {
             fk[i].real(randm11());
             fk[i].imag(randm11());
         }
@@ -85,7 +85,10 @@ int main(int argc, char *argv[]) {
 
     checkCudaErrors(cudaMemcpy(d_x, x, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
     checkCudaErrors(cudaMemcpy(d_y, y, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
-    checkCudaErrors(cudaMemcpy(d_c, c, M * ntransf * sizeof(CUCPX), cudaMemcpyHostToDevice));
+    if (type == 1)
+        checkCudaErrors(cudaMemcpy(d_c, c, M * ntransf * sizeof(CUCPX), cudaMemcpyHostToDevice));
+    else if (type == 2)
+        checkCudaErrors(cudaMemcpy(d_fk, fk, N1 * N2 * ntransf * sizeof(CUCPX), cudaMemcpyHostToDevice));
 
     cudaEvent_t start, stop;
     float milliseconds = 0;
@@ -164,7 +167,10 @@ int main(int argc, char *argv[]) {
     totaltime += milliseconds;
     printf("[time  ] cufinufft destroy:\t\t %.3g s\n", milliseconds / 1000);
 
-    checkCudaErrors(cudaMemcpy(fk, d_fk, N1 * N2 * ntransf * sizeof(CUCPX), cudaMemcpyDeviceToHost));
+    if (type == 1)
+        checkCudaErrors(cudaMemcpy(fk, d_fk, N1 * N2 * ntransf * sizeof(CUCPX), cudaMemcpyDeviceToHost));
+    else if (type == 2)
+        checkCudaErrors(cudaMemcpy(c, d_c, M * ntransf * sizeof(CUCPX), cudaMemcpyDeviceToHost));
 
     CUFINUFFT_FLT rel_error = std::numeric_limits<CUFINUFFT_FLT>::max();
     if (type == 1) {

--- a/test/cuda/cufinufft2dmany_test.cu
+++ b/test/cuda/cufinufft2dmany_test.cu
@@ -199,5 +199,5 @@ int main(int argc, char *argv[]) {
     cudaFreeHost(y);
     cudaFreeHost(c);
     cudaFreeHost(fk);
-    return rel_error > checktol;
+    return std::isnan(rel_error) || rel_error > checktol;
 }

--- a/test/cuda/cufinufft3d_test.cu
+++ b/test/cuda/cufinufft3d_test.cu
@@ -85,7 +85,10 @@ int main(int argc, char *argv[]) {
     checkCudaErrors(cudaMemcpy(d_x, x, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
     checkCudaErrors(cudaMemcpy(d_y, y, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
     checkCudaErrors(cudaMemcpy(d_z, z, M * sizeof(CUFINUFFT_FLT), cudaMemcpyHostToDevice));
-    checkCudaErrors(cudaMemcpy(d_c, c, M * sizeof(CUCPX), cudaMemcpyHostToDevice));
+    if (type == 1)
+        checkCudaErrors(cudaMemcpy(d_c, c, M * sizeof(CUCPX), cudaMemcpyHostToDevice));
+    else if (type == 2)
+        checkCudaErrors(cudaMemcpy(d_fk, fk, N1 * N2 * N3 * sizeof(CUCPX), cudaMemcpyHostToDevice));
 
     cudaEvent_t start, stop;
     float milliseconds = 0;
@@ -167,7 +170,10 @@ int main(int argc, char *argv[]) {
     totaltime += milliseconds;
     printf("[time  ] cufinufft destroy:\t\t %.3g s\n", milliseconds / 1000);
 
-    checkCudaErrors(cudaMemcpy(fk, d_fk, N1 * N2 * N3 * sizeof(CUCPX), cudaMemcpyDeviceToHost));
+    if (type == 1)
+        checkCudaErrors(cudaMemcpy(fk, d_fk, N1 * N2 * N3 * sizeof(CUCPX), cudaMemcpyDeviceToHost));
+    else if (type == 2)
+        checkCudaErrors(cudaMemcpy(c, d_c, M * sizeof(CUCPX), cudaMemcpyDeviceToHost));
 
     printf("[Method %d] %d NU pts to %d U pts in %.3g s:\t%.3g NU pts/s\n", opts.gpu_method, M, N1 * N2 * N3,
            totaltime / 1000, M / totaltime * 1000);

--- a/test/cuda/cufinufft3d_test.cu
+++ b/test/cuda/cufinufft3d_test.cu
@@ -209,5 +209,5 @@ int main(int argc, char *argv[]) {
     cudaFree(d_c);
     cudaFree(d_fk);
 
-    return rel_error > checktol;
+    return std::isnan(rel_error) || rel_error > checktol;
 }


### PR DESCRIPTION
There are a number of issues with the CUDA tests. Notably they don't properly detect `NaN` results. Some of the doc is wrong as well. This PR is a WIP to rectify that. See #271 