### PR TITLE
avoid 'inv' array in bin_sort

### DIFF
--- a/makefile
+++ b/makefile
@@ -380,7 +380,7 @@ endif
 
 # python ---------------------------------------------------------------------
 python: $(STATICLIB) $(DYNLIB)
-	FINUFFT_DIR=$(FINUFFT) $(PYTHON) -m pip -v install --break-system-packages -e ./python/finufft
+	FINUFFT_DIR=$(FINUFFT) $(PYTHON) -m pip -v install -e ./python/finufft
 # note to devs: if trouble w/ NumPy, use: pip install ./python --no-deps
 	$(PYTHON) python/finufft/test/run_accuracy_tests.py
 	$(PYTHON) python/finufft/examples/simple1d1.py

--- a/makefile
+++ b/makefile
@@ -380,7 +380,7 @@ endif
 
 # python ---------------------------------------------------------------------
 python: $(STATICLIB) $(DYNLIB)
-	FINUFFT_DIR=$(FINUFFT) $(PYTHON) -m pip -v install -e ./python/finufft
+	FINUFFT_DIR=$(FINUFFT) $(PYTHON) -m pip -v install --break-system-packages -e ./python/finufft
 # note to devs: if trouble w/ NumPy, use: pip install ./python --no-deps
 	$(PYTHON) python/finufft/test/run_accuracy_tests.py
 	$(PYTHON) python/finufft/examples/simple1d1.py


### PR DESCRIPTION
Unless I'm missing something, it should be possible to perform the bin sorting without the additional `inv` vector. The resulting code is shorter and should also be faster, since it avoids the writing and subsequent reading of `inv`, and the times for random memory accesses may be partially overlapped with the bin index computations.
I didn't do any benchmarking however ...