### PR TITLE
Update cmake to allow GPU-only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,9 +161,13 @@ if(FINUFFT_USE_CUDA)
 endif()
 
 # Add tests defined in their own directory
-if (BUILD_TESTING AND FINUFFT_BUILD_TESTS)
+if (BUILD_TESTING AND FINUFFT_BUILD_TESTS AND FINUFFT_USE_CPU)
     add_subdirectory(test)
     add_subdirectory(perftest)
+endif ()
+
+if (BUILD_TESTING AND FINUFFT_BUILD_TESTS AND FINUFFT_USE_CUDA)
+    add_subdirectory(test/cuda)
 endif ()
 
 if (FINUFFT_BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,16 @@ option(FINUFFT_BUILD_MATLAB "Whether to build the FINUFFT Matlab interface" OFF)
 option(FINUFFT_ENABLE_SANITIZERS "Whether to enable sanitizers, only effective for Debug configuration." ON)
 option(FINUFFT_USE_OPENMP "Whether to use OpenMP for parallelization. If disabled, the finufft library will be single threaded. This does not affect the choice of FFTW library." ON)
 option(FINUFFT_USE_CUDA "Whether to build CUDA accelerated FINUFFT library (libcufinufft). This is completely independent of the main FINUFFT library" OFF)
+option(FINUFFT_USE_CPU "Whether to build the ordinary FINUFFT library (libfinufft)." ON)
 # sphinx tag (don't remove): @cmake_opts_end
 
-set(CPM_DOWNLOAD_VERSION 0.38.0)
-include(cmake/setupCPM.cmake)
+if(FINUFFT_USE_CPU)
+    set(CPM_DOWNLOAD_VERSION 0.38.0)
+    include(cmake/setupCPM.cmake)
 
-set(FFTW_VERSION 3.3.10)
-include(cmake/setupFFTW.cmake)
+    set(FFTW_VERSION 3.3.10)
+    include(cmake/setupFFTW.cmake)
+endif()
 
 if (FINUFFT_BUILD_MATLAB)
     # When building for matlab, we will fetch the OpenMP library used by matlab
@@ -116,33 +119,35 @@ function(set_finufft_options target)
 
 endfunction()
 
-# Main finufft libraries
-add_library(finufft_f32 OBJECT ${FINUFFT_PRECISION_DEPENDENT_SOURCES})
-target_compile_definitions(finufft_f32 PRIVATE SINGLE)
-set_finufft_options(finufft_f32)
-target_link_libraries(finufft_f32 PUBLIC ${FINUFFT_FFTW_LIBRARIES})
+if(FINUFFT_USE_CPU)
+    # Main finufft libraries
+    add_library(finufft_f32 OBJECT ${FINUFFT_PRECISION_DEPENDENT_SOURCES})
+    target_compile_definitions(finufft_f32 PRIVATE SINGLE)
+    set_finufft_options(finufft_f32)
+    target_link_libraries(finufft_f32 PUBLIC ${FINUFFT_FFTW_LIBRARIES})
 
-add_library(finufft_f64 OBJECT ${FINUFFT_PRECISION_DEPENDENT_SOURCES})
-set_finufft_options(finufft_f64)
-target_link_libraries(finufft_f64 PUBLIC ${FINUFFT_FFTW_LIBRARIES})
+    add_library(finufft_f64 OBJECT ${FINUFFT_PRECISION_DEPENDENT_SOURCES})
+    set_finufft_options(finufft_f64)
+    target_link_libraries(finufft_f64 PUBLIC ${FINUFFT_FFTW_LIBRARIES})
 
-add_library(finufft SHARED src/utils_precindep.cpp contrib/legendre_rule_fast.cpp)
-set_finufft_options(finufft)
-target_link_libraries(finufft PUBLIC finufft_f32 finufft_f64)
-# windows does not have a math library, so we need to exclude it
-if(NOT WIN32)
-    target_link_libraries(finufft PUBLIC m)
+    add_library(finufft SHARED src/utils_precindep.cpp contrib/legendre_rule_fast.cpp)
+    set_finufft_options(finufft)
+    target_link_libraries(finufft PUBLIC finufft_f32 finufft_f64)
+    # windows does not have a math library, so we need to exclude it
+    if(NOT WIN32)
+        target_link_libraries(finufft PUBLIC m)
+    endif()
+    target_include_directories(finufft PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+    add_library(finufft_static STATIC src/utils_precindep.cpp contrib/legendre_rule_fast.cpp)
+    set_finufft_options(finufft)
+    target_link_libraries(finufft_static PUBLIC finufft_f32 finufft_f64)
+    # windows does not have a math library, so we need to exclude it
+    if(NOT WIN32)
+        target_link_libraries(finufft_static PUBLIC m)
+    endif()
+    target_include_directories(finufft_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 endif()
-target_include_directories(finufft PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-
-add_library(finufft_static STATIC src/utils_precindep.cpp contrib/legendre_rule_fast.cpp)
-set_finufft_options(finufft)
-target_link_libraries(finufft_static PUBLIC finufft_f32 finufft_f64)
-# windows does not have a math library, so we need to exclude it
-if(NOT WIN32)
-    target_link_libraries(finufft_static PUBLIC m)
-endif()
-target_include_directories(finufft_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if(FINUFFT_USE_CUDA)
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)

--- a/cmake/setupCPM.cmake
+++ b/cmake/setupCPM.cmake
@@ -10,7 +10,7 @@ endif()
 if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
     message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
     file(DOWNLOAD
-        https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+        https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
         ${CPM_DOWNLOAD_LOCATION}
     )
 endif()

--- a/docs/install_gpu.rst
+++ b/docs/install_gpu.rst
@@ -27,6 +27,7 @@ To automate the installation process, we use ``cmake``. To use this, run
 
 The ``libcufinufft.so`` (along with ``libfinufft.so``) will now be present in your ``build`` directory. Note that for this to work, you must have the Nvidia CUDA toolchain installed (such as the ``nvcc`` compiler, among others). To speed up the compilation, you could replace the last command by ``cmake --build . -j`` to use all threads,
 or ``cmake --build . -j8`` to specify using 8 threads, for example.
+To avoid building the CPU library (``libfinufft.so``), you can set the ``FINUFFT_USE_CPU`` flag to ``OFF``.
 
 In order to configure cuFINUFFT for a specific compute capability, use the ``CMAKE_CUDA_ARCHITECTURES`` flag. For example, to compile for compute capability 8.0 (supported by NVidia A100), replace the 3rd command above by
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,7 +62,3 @@ endfunction()
 # use above function to actually add the tests, with certain requested and check tols
 add_tests_with_prec(float 1e-5 2e-4 f)
 add_tests_with_prec(double 1e-12 1e-11 "")
-
-if (FINUFFT_USE_CUDA)
-  add_subdirectory(cuda)
-endif()

--- a/tools/cufinufft/docker/cuda11.0/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.0/Dockerfile-x86_64
@@ -68,7 +68,7 @@ RUN yum install -y \
 COPY . /io
 RUN mkdir -p /io/build
 WORKDIR /io/build
-RUN scl enable devtoolset-9 -- cmake -D FINUFFT_USE_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES="35;50;60;70;75;80" -DBUILD_TESTING=ON -DFINUFFT_BUILD_TESTS=ON ..
+RUN scl enable devtoolset-9 -- cmake -D FINUFFT_USE_CUDA=ON -D FINUFFT_USE_CPU=OFF -D CMAKE_CUDA_ARCHITECTURES="35;50;60;70;75;80" -DBUILD_TESTING=ON -DFINUFFT_BUILD_TESTS=ON ..
 RUN scl enable devtoolset-9 -- make -j4
 
 # And we need to pack it in our LD path


### PR DESCRIPTION
Currently, all builds have to include Finufft, which is a bit inconvenient when working with the cuFinufft code for two reasons:

– build takes longer
– other dependencies are required (FFTW)

This PR adds the option `FINUFFT_USE_CPU` which defaults to `ON` but can be set to `OFF` in order to build only cuFinufft.