### PR TITLE
Fix cufinufft wheel building

### DIFF
--- a/python/cufinufft/setup.py
+++ b/python/cufinufft/setup.py
@@ -2,6 +2,7 @@
 
 import os
 import ctypes
+from pathlib import Path
 
 from setuptools import setup, Extension
 
@@ -14,6 +15,13 @@ with open('README.md', encoding='utf8') as fh:
 # Parse the requirements
 with open('requirements.txt', 'r') as fh:
     requirements = [item.strip() for item in fh.readlines()]
+
+cufinufft_dir = os.environ.get('CUFINUFFT_DIR')
+
+if cufinufft_dir == None or cufinufft_dir == '':
+    cufinufft_dir = Path(__file__).resolve().parents[2]
+
+library_dir = os.path.join(cufinufft_dir, "build")
 
 # Sanity check that we can find the CUDA cufinufft libraries before we get too far.
 try:
@@ -63,6 +71,6 @@ setup(
         Extension(name='cufinufftc',
                   sources=[],
                   libraries=['cufinufft'],
-                  library_dirs=['lib'])
+                  library_dirs=[library_dir])
         ]
 )

--- a/tools/cufinufft/build-wheels.sh
+++ b/tools/cufinufft/build-wheels.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e -u -x
 
+function get_python_binary {
+    version="$1"
+    echo "/opt/python/$version/bin"
+}
+
 function repair_wheel {
     wheel="$1"
     if ! "${PYBIN}/auditwheel" show "$wheel"; then
@@ -10,13 +15,22 @@ function repair_wheel {
     fi
 }
 
+# Explicitly list Python versions to build for
+PYVERSIONS=(cp36-cp36m \
+            cp37-cp37m \
+            cp38-cp38 \
+            cp39-cp39 \
+            cp310-cp310 \
+            cp311-cp311)
 
 # Compile wheels
-for PYBIN in /opt/python/cp3*/bin; do
+for PYVERSION in ${PYVERSIONS[@]}; do
+    PYBIN=$(get_python_binary ${PYVERSION})
+
     "${PYBIN}/pip" install --upgrade pip
     "${PYBIN}/pip" install -r /io/python/cufinufft/requirements.txt
     "${PYBIN}/pip" install auditwheel pytest
-    "${PYBIN}/pip" wheel /io/ --no-deps -w wheelhouse/
+    "${PYBIN}/pip" wheel /io/python/cufinufft --no-deps -w wheelhouse/
 done
 
 
@@ -25,9 +39,10 @@ for whl in wheelhouse/*.whl; do
     repair_wheel "$whl"
 done
 
-
 # Install packages and test
-for PYBIN in /opt/python/cp3*/bin/; do
+for PYVERSION in ${PYVERSIONS[@]}; do
+    PYBIN=$(get_python_binary ${PYVERSION})
+
     "${PYBIN}/pip" install cufinufft -f /io/wheelhouse
     "${PYBIN}/python" -m pytest /io/python/cufinufft/tests
 done

--- a/tools/cufinufft/build-wheels.sh
+++ b/tools/cufinufft/build-wheels.sh
@@ -10,21 +10,21 @@ function repair_wheel {
     py_version="$1"
     wheel="$2"
 
-    PYBIN=$(get_python_binary "${py_version}")
+    py_binary=$(get_python_binary "${py_version}")
 
-    if ! "${PYBIN}/pip" show auditwheel > /dev/null 2>&1; then
-        "${PYBIN}/pip" install auditwheel
+    if ! "${py_binary}/pip" show auditwheel > /dev/null 2>&1; then
+        "${py_binary}/pip" install auditwheel
     fi
 
-    if ! "${PYBIN}/auditwheel" show "$wheel"; then
+    if ! "${py_binary}/auditwheel" show "$wheel"; then
         echo "Skipping non-platform wheel $wheel"
     else
-        "${PYBIN}/auditwheel" repair "$wheel" --plat "$PLAT" -w /io/wheelhouse/
+        "${py_binary}/auditwheel" repair "$wheel" --plat "$PLAT" -w /io/wheelhouse/
     fi
 }
 
 # Explicitly list Python versions to build for
-PYVERSIONS=(cp36-cp36m \
+py_versions=(cp36-cp36m \
             cp37-cp37m \
             cp38-cp38 \
             cp39-cp39 \
@@ -32,11 +32,11 @@ PYVERSIONS=(cp36-cp36m \
             cp311-cp311)
 
 # Compile wheels
-for PYVERSION in ${PYVERSIONS[@]}; do
-    PYBIN=$(get_python_binary ${PYVERSION})
+for py_version in ${py_versions[@]}; do
+    py_binary=$(get_python_binary ${py_version})
 
-    "${PYBIN}/pip" install --upgrade pip
-    "${PYBIN}/pip" wheel /io/python/cufinufft --no-deps -w wheelhouse/
+    "${py_binary}/pip" install --upgrade pip
+    "${py_binary}/pip" wheel /io/python/cufinufft --no-deps -w wheelhouse/
 done
 
 
@@ -47,10 +47,10 @@ for whl in wheelhouse/*.whl; do
 done
 
 # Install packages and test
-for PYVERSION in ${PYVERSIONS[@]}; do
-    PYBIN=$(get_python_binary ${PYVERSION})
+for py_version in ${py_versions[@]}; do
+    py_binary=$(get_python_binary ${py_version})
 
-    "${PYBIN}/pip" install cufinufft -f /io/wheelhouse
-    "${PYBIN}/pip" install pytest
-    "${PYBIN}/python" -m pytest /io/python/cufinufft/tests
+    "${py_binary}/pip" install cufinufft -f /io/wheelhouse
+    "${py_binary}/pip" install pytest
+    "${py_binary}/python" -m pytest /io/python/cufinufft/tests
 done

--- a/tools/cufinufft/build-wheels.sh
+++ b/tools/cufinufft/build-wheels.sh
@@ -7,7 +7,15 @@ function get_python_binary {
 }
 
 function repair_wheel {
-    wheel="$1"
+    py_version="$1"
+    wheel="$2"
+
+    PYBIN=$(get_python_binary "${py_version}")
+
+    if ! "${PYBIN}/pip" show auditwheel > /dev/null 2>&1; then
+        "${PYBIN}/pip" install auditwheel
+    fi
+
     if ! "${PYBIN}/auditwheel" show "$wheel"; then
         echo "Skipping non-platform wheel $wheel"
     else
@@ -29,14 +37,15 @@ for PYVERSION in ${PYVERSIONS[@]}; do
 
     "${PYBIN}/pip" install --upgrade pip
     "${PYBIN}/pip" install -r /io/python/cufinufft/requirements.txt
-    "${PYBIN}/pip" install auditwheel pytest
+    "${PYBIN}/pip" install pytest
     "${PYBIN}/pip" wheel /io/python/cufinufft --no-deps -w wheelhouse/
 done
 
 
 # Bundle external shared libraries into the wheels
+audit_py_version="cp310-cp310"
 for whl in wheelhouse/*.whl; do
-    repair_wheel "$whl"
+    repair_wheel "$audit_py_version" "$whl"
 done
 
 # Install packages and test

--- a/tools/cufinufft/build-wheels.sh
+++ b/tools/cufinufft/build-wheels.sh
@@ -36,8 +36,6 @@ for PYVERSION in ${PYVERSIONS[@]}; do
     PYBIN=$(get_python_binary ${PYVERSION})
 
     "${PYBIN}/pip" install --upgrade pip
-    "${PYBIN}/pip" install -r /io/python/cufinufft/requirements.txt
-    "${PYBIN}/pip" install pytest
     "${PYBIN}/pip" wheel /io/python/cufinufft --no-deps -w wheelhouse/
 done
 
@@ -53,5 +51,6 @@ for PYVERSION in ${PYVERSIONS[@]}; do
     PYBIN=$(get_python_binary ${PYVERSION})
 
     "${PYBIN}/pip" install cufinufft -f /io/wheelhouse
+    "${PYBIN}/pip" install pytest
     "${PYBIN}/python" -m pytest /io/python/cufinufft/tests
 done

--- a/tools/cufinufft/build-wheels.sh
+++ b/tools/cufinufft/build-wheels.sh
@@ -52,5 +52,5 @@ for py_version in ${py_versions[@]}; do
 
     "${py_binary}/pip" install cufinufft -f /io/wheelhouse
     "${py_binary}/pip" install pytest
-    "${py_binary}/python" -m pytest /io/python/cufinufft/tests
+    "${py_binary}/pytest" /io/python/cufinufft/tests
 done

--- a/tools/cufinufft/distribution_helper.sh
+++ b/tools/cufinufft/distribution_helper.sh
@@ -5,15 +5,24 @@
 cufinufft_version=1.3
 manylinux_version=manylinux2014
 cuda_version=11.0
-dockerhub=garrettwrong
+dockerhub=janden
 
 
 echo "# build the wheel"
-docker build -f ci/docker/cuda${cuda_version}/Dockerfile-x86_64 -t ${dockerhub}/cufinufft-${cufinufft_version}-${manylinux_version} .
+docker build \
+    --file ci/docker/cuda${cuda_version}/Dockerfile-x86_64 \
+    --tag ${dockerhub}/cufinufft-${cufinufft_version}-${manylinux_version} .
 
 
 echo "# Run the container, invoking the build-wheels script to generate the wheels"
-docker run --gpus all -it -v `pwd`/wheelhouse:/io/wheelhouse -e PLAT=${manylinux_version}_x86_64  ${dockerhub}/cufinufft-${cufinufft_version}-${manylinux_version} /io/ci/build-wheels.sh
+docker run \
+    --gpus all \
+    --interactive \
+    --tty \
+    --volume $(pwd)/wheelhouse:/io/wheelhouse \
+    --env PLAT=${manylinux_version}_x86_64 \
+    ${dockerhub}/cufinufft-${cufinufft_version}-${manylinux_version} \
+    /io/ci/build-wheels.sh
 
 echo "# Copy the wheels we care about to the dist folder"
 mkdir -p dist

--- a/tools/cufinufft/docker/cuda11.0/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.0/Dockerfile-x86_64
@@ -71,6 +71,8 @@ WORKDIR /io/build
 RUN scl enable devtoolset-9 -- cmake -D FINUFFT_USE_CUDA=ON -D CMAKE_CUDA_ARCHITECTURES="35;50;60;70;75;80" -DBUILD_TESTING=ON -DFINUFFT_BUILD_TESTS=ON ..
 RUN scl enable devtoolset-9 -- make -j4
 
+WORKDIR /io
+
 # And we need to pack it in our LD path
 ENV LD_LIBRARY_PATH /io/build:${LD_LIBRARY_PATH}
 


### PR DESCRIPTION
After merging the cufinufft code and reorganizing the directories, the standard wheel-building scripts (and setup.py) for cufinufft were broken. This PR fixes those scripts and cleans them up a little bit.