### PR TITLE
Fix finufft setup.py

### DIFF
--- a/python/finufft/setup.py
+++ b/python/finufft/setup.py
@@ -10,6 +10,7 @@ __version__ = '2.1.0'
 from setuptools import setup, Extension
 import os
 import platform
+from pathlib import Path
 
 from tempfile import mkstemp
 
@@ -18,8 +19,7 @@ finufft_dir = os.environ.get('FINUFFT_DIR')
 # Note: This will not work if run through pip install since setup.py is copied
 # to a different location.
 if finufft_dir == None or finufft_dir == '':
-    current_path = os.path.abspath(__file__)
-    finufft_dir = os.path.dirname(os.path.dirname(current_path))
+    finufft_dir = Path(__file__).resolve().parents[2]
 
 # Set include and library paths relative to FINUFFT root directory.
 inc_dir = os.path.join(finufft_dir, 'include')


### PR DESCRIPTION
After the directory reorg, `setup.py` fails to find the README needed to fill in the package description. This corrects the path.