### PR TITLE
Update docs config for cufinufft

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,8 @@ import sphinx.ext.autodoc
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../python'))
+sys.path.insert(0, os.path.abspath('../python/finufft'))
+sys.path.insert(0, os.path.abspath('../python/cufinufft'))
 
 # quash sphinx's inevitable failure of C++ lib extension to import...
 autodoc_mock_imports = ['finufft._finufft', 'numpy']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('../python/finufft'))
 sys.path.insert(0, os.path.abspath('../python/cufinufft'))
 
 # quash sphinx's inevitable failure of C++ lib extension to import...
-autodoc_mock_imports = ['finufft._finufft', 'numpy']
+autodoc_mock_imports = ['finufft._finufft', 'numpy', 'pycuda']
 # The above is not enough for nested import -- forcibly mock them out ahead of time:
 #for name in autodoc_mock_imports:
 #    sys.modules[name] = sphinx.ext.autodoc._MockModule(name, None)

--- a/python/cufinufft/cufinufft/__init__.py
+++ b/python/cufinufft/cufinufft/__init__.py
@@ -3,5 +3,9 @@ from cufinufft._plan import Plan
 from cufinufft._simple import (nufft1d1, nufft1d2, nufft2d1, nufft2d2,
                                nufft3d1, nufft3d2)
 
-__all__ = ['cufinufft']
+__all__ = ["nufft1d1", "nufft1d2",
+           "nufft2d1", "nufft2d2",
+           "nufft3d1", "nufft3d2",
+           "Plan"]
+
 __version__ = '2.2.0dev0'


### PR DESCRIPTION
Need to specify the proper paths for Python and make sure the modules are being exported properly for cufinufft.

Closes #328.