### PR TITLE
Constrain jenkins to use v100 GPUs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
          dockerfile {
             filename 'tools/cufinufft/docker/cuda11.0/Dockerfile-x86_64'
             args '--gpus 2'
+            label 'v100'
          }
       }
       environment {


### PR DESCRIPTION
Running on the K40's causes the tests to fail since `nvidia-smi` does not support querying the `compute_cap` flag for older drivers. While this can be bypassed by fixing the architecture, a second issue is that modern versions of `torch` won't run on that architecture, which we need for #326.

Simplest solution is therefore to require running Jenkins on the V100.