### PR TITLE
Remove `dim` and `type` from `cufinufft_default_opts`.

### DIFF
--- a/docs/c_gpu.rst
+++ b/docs/c_gpu.rst
@@ -295,10 +295,8 @@ To create such a structure, use:
 .. code-block:: c
 
     cufinufft_opts opts;
-    ier = cufinufft_default_opts(type, dim, &opts);
+    cufinufft_default_opts(&opts);
 
-where ``type`` and ``dim`` are as above in ``cufinufft_makeplan``.
-As before, the returned value is zero if success, otherwise an error occurred.
 Then you may change fields of ``opts`` by hand, finally pass ``&opts`` in as the last argument to ``cufinufft_makeplan`` or ``cufinufftf_makeplan``.
 The options fields are currently only documented in the ``include/cufinufft_opts.h``.
 

--- a/include/cufinufft.h
+++ b/include/cufinufft.h
@@ -10,7 +10,7 @@ typedef struct cufinufft_fplan_s *cufinufftf_plan;
 #ifdef __cplusplus
 extern "C" {
 #endif
-int cufinufft_default_opts(int type, int dim, cufinufft_opts *opts);
+void cufinufft_default_opts(cufinufft_opts *opts);
 
 int cufinufft_makeplan(int type, int dim, int64_t *n_modes, int iflag, int ntr, double eps, cufinufft_plan *d_plan_ptr,
                        cufinufft_opts *opts);

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -107,11 +107,7 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
 
     /* If a user has not supplied their own options, assign defaults for them. */
     if (opts == NULL) { // use default opts
-        ier = cufinufft_default_opts(type, dim, &(d_plan->opts));
-        if (ier != 0) {
-            printf("error: cufinufft_default_opts returned error %d.\n", ier);
-            return ier;
-        }
+        cufinufft_default_opts(&(d_plan->opts));
     } else {                  // or read from what's passed in
         d_plan->opts = *opts; // keep a deep copy; changing *opts now has no effect
     }

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -113,11 +113,10 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
     }
 
     /* Automatically set GPU method. */
-    if(d_plan->opts.gpu_method == 0)
-    {
-        if(type == 1)
+    if (d_plan->opts.gpu_method == 0) {
+        if (type == 1)
             d_plan->opts.gpu_method = 2;
-        else if(type == 2)
+        else if (type == 2)
             d_plan->opts.gpu_method = 1;
     }
 

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -116,6 +116,15 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
         d_plan->opts = *opts; // keep a deep copy; changing *opts now has no effect
     }
 
+    /* Automatically set GPU method. */
+    if(d_plan->opts.gpu_method == 0)
+    {
+        if(type == 1)
+            d_plan->opts.gpu_method = 2;
+        else if(type == 2)
+            d_plan->opts.gpu_method = 1;
+    }
+
     /* Setup Spreader */
     using namespace cufinufft::common;
     ier = setup_spreader_for_nufft(d_plan->spopts, tol, d_plan->opts);

--- a/perftest/cuda/cuperftest.cu
+++ b/perftest/cuda/cuperftest.cu
@@ -173,7 +173,7 @@ void run_test(test_options_t &test_opts) {
     for (int i = 0; i < 3; ++i)
         dim = test_opts.N[i] > 1 ? i + 1 : dim;
 
-    cufinufft_default_opts(test_opts.type, dim, &opts);
+    cufinufft_default_opts(&opts);
     opts.gpu_method = test_opts.method;
     opts.gpu_sort = test_opts.sort;
     opts.gpu_kerevalmeth = test_opts.kerevalmethod;

--- a/python/cufinufft/cufinufft/_cufinufft.py
+++ b/python/cufinufft/cufinufft/_cufinufft.py
@@ -93,8 +93,8 @@ CufinufftPlanf_p = ctypes.POINTER(CufinufftPlanf)
 NufftOpts_p = ctypes.POINTER(NufftOpts)
 
 _default_opts = lib.cufinufft_default_opts
-_default_opts.argtypes = [c_int, c_int, NufftOpts_p]
-_default_opts.restype = c_int
+_default_opts.argtypes = [NufftOpts_p]
+_default_opts.restype = None
 
 _make_plan = lib.cufinufft_makeplan
 _make_plan.argtypes = [

--- a/python/cufinufft/cufinufft/_plan.py
+++ b/python/cufinufft/cufinufft/_plan.py
@@ -115,7 +115,7 @@ class Plan:
         self._maxbatch = 1    # TODO: optimize this one day
 
         # Get the default option values.
-        self._opts = self._default_opts(nufft_type, self.dim)
+        self._opts = self._default_opts()
 
         # Extract list of valid field names.
         field_names = [name for name, _ in self._opts._fields_]
@@ -135,7 +135,7 @@ class Plan:
         self._references = []
 
     @staticmethod
-    def _default_opts(nufft_type, dim):
+    def _default_opts():
         """
         Generates a cufinufft opt struct of the dtype coresponding to plan.
 
@@ -147,10 +147,7 @@ class Plan:
 
         nufft_opts = NufftOpts()
 
-        ier = _default_opts(nufft_type, dim, nufft_opts)
-
-        if ier != 0:
-            raise RuntimeError('Configuration not yet implemented.')
+        _default_opts(nufft_opts)
 
         return nufft_opts
 

--- a/src/cuda/cufinufft.cu
+++ b/src/cuda/cufinufft.cu
@@ -84,7 +84,6 @@ int cufinufft_default_opts(int type, int dim, cufinufft_opts *opts)
     Melody Shih 07/25/19; Barnett 2/5/21.
 */
 {
-    int ier;
     opts->upsampfac = 2.0;
 
     /* following options are for gpu */
@@ -104,50 +103,9 @@ int cufinufft_default_opts(int type, int dim, cufinufft_opts *opts)
 
     opts->gpu_maxbatchsize = 0; // Heuristically set
 
-    switch (dim) {
-    case 1: {
-        opts->gpu_kerevalmeth = 1; // using horner
-        if (type == 1) {
-            opts->gpu_method = 2;
-        }
-        if (type == 2) {
-            opts->gpu_method = 1;
-        }
-        if (type == 3) {
-            std::cerr << "Not Implemented yet" << std::endl;
-            ier = 1;
-            return ier;
-        }
-    } break;
-    case 2: {
-        opts->gpu_kerevalmeth = 1; // using horner
-        if (type == 1) {
-            opts->gpu_method = 2;
-        }
-        if (type == 2) {
-            opts->gpu_method = 1;
-        }
-        if (type == 3) {
-            std::cerr << "Not Implemented yet" << std::endl;
-            ier = 1;
-            return ier;
-        }
-    } break;
-    case 3: {
-        opts->gpu_kerevalmeth = 1; // using horner
-        if (type == 1) {
-            opts->gpu_method = 2;
-        }
-        if (type == 2) {
-            opts->gpu_method = 1;
-        }
-        if (type == 3) {
-            std::cerr << "Not Implemented yet" << std::endl;
-            ier = 1;
-            return ier;
-        }
-    } break;
-    }
+    opts->gpu_kerevalmeth = 1; // Horner
+
+    opts->gpu_method = 0; // Auto method (2 for type 1, 2 for type 2).
 
     // By default, only use device 0
     opts->gpu_device_id = 0;

--- a/src/cuda/cufinufft.cu
+++ b/src/cuda/cufinufft.cu
@@ -67,7 +67,7 @@ int cufinufft_destroy(cufinufft_plan d_plan) {
     return cufinufft_destroy_impl<double>((cufinufft_plan_t<double> *)d_plan);
 }
 
-int cufinufft_default_opts(int type, int dim, cufinufft_opts *opts)
+void cufinufft_default_opts(cufinufft_opts *opts)
 /*
     Sets the default options in cufinufft_opts. This must be called
     before the user changes any options from default values.
@@ -109,7 +109,5 @@ int cufinufft_default_opts(int type, int dim, cufinufft_opts *opts)
 
     // By default, only use device 0
     opts->gpu_device_id = 0;
-
-    return 0;
 }
 }

--- a/test/cuda/cufinufft1d_test.cu
+++ b/test/cuda/cufinufft1d_test.cu
@@ -82,11 +82,8 @@ int run_test(int method, int type, int N1, int M, T tol, T checktol, int iflag) 
 
     // Here we setup our own opts, for gpu_method.
     cufinufft_opts opts;
-    ier = cufinufft_default_opts(type, dim, &opts);
-    if (ier != 0) {
-        printf("err %d: cufinufft_default_opts\n", ier);
-        return ier;
-    }
+    cufinufft_default_opts(&opts);
+
     opts.gpu_method = method;
     opts.gpu_maxbatchsize = 1;
 

--- a/test/cuda/cufinufft2d1nupts_test.cu
+++ b/test/cuda/cufinufft2d1nupts_test.cu
@@ -93,11 +93,7 @@ int run_test(int method) {
 
     // Here we setup our own opts, for gpu_method.
     cufinufft_opts opts;
-    ier = cufinufft_default_opts(type, dim, &opts);
-    if (ier != 0) {
-        printf("err %d: cufinufft_default_opts\n", ier);
-        return ier;
-    }
+    cufinufft_default_opts(&opts);
 
     opts.gpu_method = method;
     opts.gpu_maxbatchsize = 1;

--- a/test/cuda/cufinufft2d_test.cu
+++ b/test/cuda/cufinufft2d_test.cu
@@ -82,11 +82,7 @@ int run_test(int method, int type, int N1, int N2, int M, T tol, T checktol, int
 
     // Here we setup our own opts, for gpu_method.
     cufinufft_opts opts;
-    int ier = cufinufft_default_opts(type, dim, &opts);
-    if (ier != 0) {
-        printf("err %d: cufinufft_default_opts\n", ier);
-        return ier;
-    }
+    cufinufft_default_opts(&opts);
 
     opts.gpu_method = method;
     opts.gpu_maxbatchsize = 1;
@@ -94,7 +90,7 @@ int run_test(int method, int type, int N1, int N2, int M, T tol, T checktol, int
     int nmodes[3] = {N1, N2, 1};
     int ntransf = 1;
     cudaEventRecord(start);
-    ier = cufinufft_makeplan_impl(type, dim, nmodes, iflag, ntransf, tol, &dplan, &opts);
+    int ier = cufinufft_makeplan_impl(type, dim, nmodes, iflag, ntransf, tol, &dplan, &opts);
     if (ier != 0) {
         printf("err: cufinufft2d_plan\n");
         return ier;

--- a/test/cuda/cufinufft2dmany_test.cu
+++ b/test/cuda/cufinufft2dmany_test.cu
@@ -86,11 +86,8 @@ int run_test(int method, int type, int N1, int N2, int ntransf, int maxbatchsize
 
     // Here we setup our own opts, for gpu_method.
     cufinufft_opts opts;
-    ier = cufinufft_default_opts(type, dim, &opts);
-    if (ier != 0) {
-        printf("err %d: cufinufft_default_opts\n", ier);
-        return ier;
-    }
+    cufinufft_default_opts(&opts);
+
     opts.gpu_method = method;
     opts.gpu_maxbatchsize = maxbatchsize;
 

--- a/test/cuda/cufinufft3d_test.cu
+++ b/test/cuda/cufinufft3d_test.cu
@@ -86,11 +86,8 @@ int run_test(int method, int type, int N1, int N2, int N3, int M, T tol, T check
 
     // Here we setup our own opts, for gpu_method and gpu_kerevalmeth.
     cufinufft_opts opts;
-    ier = cufinufft_default_opts(type, dim, &opts);
-    if (ier != 0) {
-        printf("err %d: cufinufft_default_opts\n", ier);
-        return ier;
-    }
+    cufinufft_default_opts(&opts);
+
     opts.gpu_method = method;
     opts.gpu_kerevalmeth = 1;
     opts.gpu_maxbatchsize = 1;

--- a/test/cuda/interp1d_test.cu
+++ b/test/cuda/interp1d_test.cu
@@ -41,7 +41,7 @@ int run_test(int method, int nupts_distribute, int nf1, int M, T tol, int kereva
     dplan = new cufinufft_plan_t<real_t>;
     // Zero out your struct, (sets all pointers to NULL, crucial)
     memset(dplan, 0, sizeof(*dplan));
-    ier = cufinufft_default_opts(2, dim, &(dplan->opts));
+    cufinufft_default_opts(&(dplan->opts));
     dplan->opts.gpu_method = method;
     dplan->opts.gpu_maxsubprobsize = 1024;
     dplan->opts.gpu_kerevalmeth = kerevalmeth;

--- a/test/cuda/interp1d_test.cu
+++ b/test/cuda/interp1d_test.cu
@@ -36,7 +36,6 @@ int run_test(int method, int nupts_distribute, int nf1, int M, T tol, int kereva
     checkCudaErrors(cudaMalloc(&d_c, M * sizeof(complex_t)));
     checkCudaErrors(cudaMalloc(&d_fw, nf1 * sizeof(complex_t)));
 
-    int dim = 1;
     cufinufft_plan_t<real_t> *dplan;
     dplan = new cufinufft_plan_t<real_t>;
     // Zero out your struct, (sets all pointers to NULL, crucial)


### PR DESCRIPTION
This brings the interface in line with Finufft per #255. The `dim` and `type` (well, actually only `type`) were used to set `gpu_method`. Now this is set to `0`, an “auto” setting which results in `make_plan` choosing the most appropriate method for the type. (We'll be able to incorporate precision later as well, see #321.)

Resolves #255.