### PR TITLE
Default to method 1 for 3D double-precision type 1 at low epsilon

### DIFF
--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -114,8 +114,11 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
 
     /* Automatically set GPU method. */
     if (d_plan->opts.gpu_method == 0) {
-        if (type == 1)
+        if (type == 1 && (sizeof(T) == 4 || dim < 3 || tol >= 1e-3))
             d_plan->opts.gpu_method = 2;
+        else if (type == 1 && tol < 1e-3)
+            /* For 3D double precision at small epsilon, default to method 1. */
+            d_plan->opts.gpu_method = 1;
         else if (type == 2)
             d_plan->opts.gpu_method = 1;
     }

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -114,10 +114,16 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
 
     /* Automatically set GPU method. */
     if (d_plan->opts.gpu_method == 0) {
+        /* For type 1, we default to method 2 (SM) since this is generally faster.
+         * However, in the special case of _double precision_ in _three dimensions_
+         * with more than _three digits of precision_, there is note enough shared
+         * memory for this to work. As a result, we will default to method 1 (GM) in
+         * this special case.
+         *
+         * For type 2, we always default to method 1 (GM). */
         if (type == 1 && (sizeof(T) == 4 || dim < 3 || tol >= 1e-3))
             d_plan->opts.gpu_method = 2;
         else if (type == 1 && tol < 1e-3)
-            /* For 3D double precision at small epsilon, default to method 1. */
             d_plan->opts.gpu_method = 1;
         else if (type == 2)
             d_plan->opts.gpu_method = 1;

--- a/python/cufinufft/tests/test_basic.py
+++ b/python/cufinufft/tests/test_basic.py
@@ -11,7 +11,7 @@ import utils
 DTYPES = [np.float32, np.float64]
 SHAPES = [(16,), (16, 16), (16, 16, 16)]
 MS = [256, 1024, 4096]
-TOLS = [1e-2, 1e-3]
+TOLS = [1e-3, 1e-6]
 OUTPUT_ARGS = [False, True]
 CONTIGUOUS = [False, True]
 

--- a/python/cufinufft/tests/test_simple.py
+++ b/python/cufinufft/tests/test_simple.py
@@ -11,7 +11,7 @@ DTYPES = [np.float32, np.float64]
 SHAPES = [(16,), (16, 16), (16, 16, 16)]
 N_TRANS = [(), (1,), (2,)]
 MS = [256, 1024, 4096]
-TOLS = [1e-2, 1e-3]
+TOLS = [1e-3, 1e-6]
 OUTPUT_ARGS = [False, True]
 
 @pytest.mark.parametrize("dtype", DTYPES)


### PR DESCRIPTION
Here method 2 fails since it requires too much shared memory. If the user doesn't specify a method (i.e., `gpu_method` is set to `0`, the “auto” value), we switch to method 1 in `makeplan` in this case to avoid crash during `execute`.

Closes #321.