### PR TITLE
bugfix/enhance: change all FFTW critical to mutex. nix FFTW_PLAN_SAFE

### DIFF
--- a/docs/cex.rst
+++ b/docs/cex.rst
@@ -273,9 +273,7 @@ Thread safety and global state
 ------------------------------
 
 It is possible to call FINUFFT from within multithreaded code, e.g. in an
-OpenMP parallel block. In this case ``opts.nthreads=1`` should be set,
-and FINUFFT must have been compiled with the ``-DFFTW_PLAN_SAFE`` flag,
-making it thread-safe.
+OpenMP parallel block. In this case ``opts.nthreads=1`` should be set.
 For demos of this, see
 
 * ``examples/threadsafe1d1`` which runs a 1D type-1 separately on each thread, checking the math, and
@@ -290,20 +288,3 @@ its state, and does not have a global state (other than one ``static``
 flag used as a lock on FFTW initialization in the FINUFFT plan
 stage). This means different FINUFFT calls should not affect each other,
 although they may affect other codes that use FFTW via FFTW's global state.
-
-Alternatively  it is possible to achieve thread safety without compiling with ``-DFFTW_PLAN_SAFE``. This can lead to higher performance.
-This way to achieve thread safety is to use the guru interface and split initialization and transformation into two steps. The initialization step is not thread safe, but the transformation step is. The initialization step can be parallelized over threads, but the transformation step cannot. See ``examples/threadsafe1d1`` for an example of this.
-In particular:
-
-.. code-block:: C++
-
-  finufft_makeplan(...args...) // not thread safe
-
-All the other functions are thread safe. With OpenMP is possible to use:
-  
-.. code-block:: C++
-                
-  #pragma omp critical
-  finufft_makeplan(...args...) // not thread safe
-
-to achieve thread safety.

--- a/docs/devnotes.rst
+++ b/docs/devnotes.rst
@@ -23,7 +23,7 @@ Developer notes
 
 * For testing and performance measuring routines see ``test/README`` and ``perftest/README``. We need more of the latter, eg, something making performance graphs that enable rapid eyeball comparison of various settings/machines.
 
-* Continuous Integration (CI). See files for this in ``.github/workflows/``. It currently tests the default ``makefile`` settings in linux, and three other ``make.inc.*`` files covering OSX and Windows (MinGW). CI does not test build variants OMP=OFF nor FFTW_PLAN_SAFE options. The dev should test these locally. Likewise, the Julia wrapper is separate and thus not tested in CI. We have added ``JenkinsFile`` for the GPU CI via python wrappers.
+* Continuous Integration (CI). See files for this in ``.github/workflows/``. It currently tests the default ``makefile`` settings in linux, and three other ``make.inc.*`` files covering OSX and Windows (MinGW). CI does not test build the variant OMP=OFF. The dev should test these locally. Likewise, the Julia wrapper is separate and thus not tested in CI. We have added ``JenkinsFile`` for the GPU CI via python wrappers.
 
 * **Installing MWrap**. This is needed only for experts to rebuild the matlab/octave interfaces.
   `MWrap <https://github.com/zgimbutas/mwrap>`_

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -264,8 +264,6 @@ This is for experts.
 Here are all the flags that the FINUFFT source responds to.
 Activate them by adding a line of the form ``CXXFLAGS+=-DMYFLAG`` in your ``make.inc``:
 
-* ``-DFFTW_PLAN_SAFE``: This makes FINUFFT call ``fftw_make_planner_thread_safe()`` as part of its FFTW3 planner stage; see http://www.fftw.org/fftw3_doc/Thread-safety.html. This makes FINUFFT thread-safe. See ``examples/threadsafe1d1.cpp`` and ``examples/threadsafe2d2f.cpp``. This is only available in FFTW version >=3.3.6; for this reason it is not yet the default. If you get segfault on these examples, try ``FFTWOMPSUFFIX = threads`` as explained below.
-
 * ``-DSINGLE``: This is internally used by our build process to switch
   (via preprocessor macros) the source from double to single precision.
   You should not need to use this flag yourself.

--- a/docs/trouble.rst
+++ b/docs/trouble.rst
@@ -70,7 +70,7 @@ Crash (segfault) issues and advice
 
 - Maybe you have switched off nonuniform point bounds checking (``opts.chkbnds=0``) for a little extra speed? Try switching it on again to catch illegal coordinates.
 
-- Thread-safety: are you calling FINUFFT from inside a multithreaded block of code, without compiling with ``-DFFTW_PLAN_SAFE`` or setting ``opts.nthreads=1``? If ``gdb`` indicates crashes during FFTW calls, this is another sign.
+- Thread-safety: are you calling FINUFFT from inside a multithreaded block of code without setting ``opts.nthreads=1``? If ``gdb`` indicates crashes during FFTW calls, this is another sign.
   
 - To isolate where a crash is occurring, set ``opts.debug`` to 1 or 2, and check the text output of the various stages. With a debug setting of 2 or above, when ``ntrans>1`` a large amount of text can be generated.
     

--- a/examples/threadsafe1d1.cpp
+++ b/examples/threadsafe1d1.cpp
@@ -15,8 +15,7 @@ int main(int argc, char* argv[])
    Adapted from simple1d1.cpp: C++, STL double complex vectors, with math test.
    Barnett 4/19/21, eg for Goran Zauhar, issue #183.
 
-   Notes: libfinufft *must* have been built with -DFFTW_PLAN_SAFE, which needs
-   FFTW >= 3.3.6. You also may not have libfftw3_omp, so I have switched to
+   Notes: You may not have libfftw3_omp, so I have switched to
    libfftw3_threads in this suggested compile command:
 
    g++ -fopenmp threadsafe1d1.cpp -I../include ../lib/libfinufft.so -o threadsafe1d1 -lfftw3 -lfftw3_threads -lm

--- a/examples/threadsafe2d2f.cpp
+++ b/examples/threadsafe2d2f.cpp
@@ -3,10 +3,7 @@
    submitted github Issue #72. Unlike threadsafe1d1, it does not test the math;
    it is the shell of an application from MRI reconstruction.
 
-   FINUFFT lib must be built with (non-default) flag -DFFTW_PLAN_SAFE, and
-   FFTW version >= 3.3.6. See http://www.fftw.org/fftw3_doc/Thread-safety.html
-
-   Then to compile (note uses threads rather than omp version of FFTW3):
+   To compile (note uses threads rather than omp version of FFTW3):
 
    g++ -fopenmp threadsafe2d2f.cpp -I../include ../lib/libfinufft.so -o threadsafe2d2f -lfftw3 -lfftw3_threads -lm -g -Wall
 

--- a/include/finufft/fftw_defs.h
+++ b/include/finufft/fftw_defs.h
@@ -45,10 +45,4 @@
   #define FFTW_CLEANUP_THREADS()
 #endif
 
-#ifdef FFTW_PLAN_SAFE
-  #define FFTW_PLAN_SF() FFTWIFY(make_planner_thread_safe())
-#else
-  #define FFTW_PLAN_SF()
-#endif
-
 #endif  // FFTW_DEFS_H

--- a/makefile
+++ b/makefile
@@ -29,8 +29,6 @@ PYTHON = python3
 CFLAGS := -O3 -funroll-loops -march=native -fcx-limited-range $(CFLAGS)
 FFLAGS := $(CFLAGS) $(FFLAGS)
 CXXFLAGS := $(CFLAGS) $(CXXFLAGS)
-# put this in your make.inc if you have FFTW>=3.3.5 and want thread-safe use...
-#CXXFLAGS += -DFFTW_PLAN_SAFE
 # FFTW base name, and math linking...
 FFTWNAME = fftw3
 # linux default is fftw3_omp, since 10% faster than fftw3_threads...
@@ -192,10 +190,6 @@ endif
 # examples (C++/C) -----------------------------------------------------------
 # build all examples (single-prec codes separate, and not all have one)...
 EXAMPLES = $(basename $(wildcard examples/*.c examples/*.cpp))
-# ...except only build threadsafe ones if user switch on (thus FFTW>=3.3.6):
-ifeq (,$(findstring FFTW_PLAN_SAFE,$(CXXFLAGS)))
-  EXAMPLES := $(filter-out %/threadsafe1d1 %/threadsafe2d2f, $(EXAMPLES))
-endif
 examples: $(EXAMPLES)
 ifneq ($(MINGW),ON)
   # Windows-MSYS does not find the dynamic libraries, so we make a temporary copy

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <iomanip>
 #include <math.h>
+#include <mutex>
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
@@ -91,6 +92,10 @@ Design notes for guru interface implementation:
 
 namespace finufft {
   namespace common {
+
+  // Technically global state...
+  // Needs to be static to avoid name collision with SINGLE/DOUBLE
+  static std::mutex fftw_lock;
 
   // We macro because it has no FLT args but gets compiled for both prec's...
 #ifdef SINGLE
@@ -544,7 +549,6 @@ void FINUFFT_DEFAULT_OPTS(finufft_opts *o)
   // sphinx tag (don't remove): @defopts_end
 }
 
-
 // PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
 int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
                      int ntrans, FLT tol, FINUFFT_PLAN *pp, finufft_opts* opts)
@@ -645,17 +649,16 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
     int nthr_fft = nthr;    // give FFTW all threads (or use o.spread_thread?)
                             // Note: batchSize not used since might be only 1.
     // Now place FFTW initialization in a lock, courtesy of OMP. Makes FINUFFT
-    // thread-safe (can be called inside OMP) if -DFFTW_PLAN_SAFE used...
-#pragma omp critical
+    // thread-safe (can be called inside OMP)
     {
-      static bool did_fftw_init = 0;    // the only global state of FINUFFT
+      static bool did_fftw_init = false;    // the only global state of FINUFFT
+      std::lock_guard<std::mutex> lock(fftw_lock);
       if (!did_fftw_init) {
 	FFTW_INIT();            // setup FFTW global state; should only do once
 	FFTW_PLAN_TH(nthr_fft); // ditto
-	FFTW_PLAN_SF();         // if -DFFTW_PLAN_SAFE, make FFTW thread-safe
-	did_fftw_init = 1;      // insure other FINUFFT threads don't clash
+	did_fftw_init = true;   // ensure other FINUFFT threads don't clash
       }
-    } 
+    }
 
     p->spopts.spread_direction = type;
 
@@ -707,8 +710,11 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
       fprintf(stderr, "[%s] fwBatch would be bigger than MAX_NF, not attempting malloc!\n",__func__);
       return ERR_MAXNALLOC;
     }
-#pragma omp critical
-    p->fwBatch = FFTW_ALLOC_CPX(p->nf * p->batchSize);    // the big workspace
+
+    {
+      std::lock_guard<std::mutex> lock(fftw_lock);
+      p->fwBatch = FFTW_ALLOC_CPX(p->nf * p->batchSize); // the big workspace
+    }
     if (p->opts.debug) printf("[%s] fwBatch %.2fGB alloc:   \t%.3g s\n", __func__,(double)1E-09*sizeof(CPX)*p->nf*p->batchSize, timer.elapsedsec());
     if(!p->fwBatch) {      // we don't catch all such mallocs, just this big one
       fprintf(stderr, "[%s] FFTW malloc failed for fwBatch (working fine grids)!\n",__func__);
@@ -719,9 +725,11 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
     timer.restart();            // plan the FFTW
     int *ns = GRIDSIZE_FOR_FFTW(p);
     // fftw_plan_many_dft args: rank, gridsize/dim, howmany, in, inembed, istride, idist, ot, onembed, ostride, odist, sign, flags 
-#pragma omp critical
-    p->fftwPlan = FFTW_PLAN_MANY_DFT(dim, ns, p->batchSize, p->fwBatch,
-         NULL, 1, p->nf, p->fwBatch, NULL, 1, p->nf, p->fftSign, p->opts.fftw);
+    {
+      std::lock_guard<std::mutex> lock(fftw_lock);
+      p->fftwPlan = FFTW_PLAN_MANY_DFT(dim, ns, p->batchSize, p->fwBatch, NULL, 1, p->nf, p->fwBatch, NULL, 1, p->nf,
+                                       p->fftSign, p->opts.fftw);
+    }
     if (p->opts.debug) printf("[%s] FFTW plan (mode %d, nthr=%d):\t%.3g s\n", __func__,p->opts.fftw, nthr_fft, timer.elapsedsec());
     delete []ns;
     
@@ -821,8 +829,8 @@ int FINUFFT_SETPTS(FINUFFT_PLAN p, BIGINT nj, FLT* xj, FLT* yj, FLT* zj,
       fprintf(stderr, "[%s t3] fwBatch would be bigger than MAX_NF, not attempting malloc!\n",__func__);
       return ERR_MAXNALLOC;
     }
-#pragma omp critical
     {
+      std::lock_guard<std::mutex> lk(fftw_lock);
       if (p->fwBatch)
         FFTW_FR(p->fwBatch);
       p->fwBatch = FFTW_ALLOC_CPX(p->nf * p->batchSize); // maybe big workspace
@@ -1126,12 +1134,17 @@ int FINUFFT_DESTROY(FINUFFT_PLAN p)
 {
   if (!p)                // NULL ptr, so not a ptr to a plan, report error
     return 1;
-#pragma omp critical
-  FFTW_FR(p->fwBatch);   // free the big FFTW (or t3 spread) working array
+
+  {
+    std::lock_guard<std::mutex> lock(fftw_lock);
+    FFTW_FR(p->fwBatch); // free the big FFTW (or t3 spread) working array
+  }
   free(p->sortIndices);
   if (p->type==1 || p->type==2) {
-#pragma omp critical
-    FFTW_DE(p->fftwPlan);
+    {
+      std::lock_guard<std::mutex> lock(fftw_lock);
+      FFTW_DE(p->fftwPlan);
+    }
     free(p->phiHat1);
     free(p->phiHat2);
     free(p->phiHat3);


### PR DESCRIPTION
This addresses almost all points made at #353 and should _actually_ fix the underlying issue of `fftw` thread safety.
* Remove `FFTW_PLAN_SAFE` and any mention, other than in changelog
* convert any `#pragma omp critical` around `FFTW` calls to using `std::lock_guard` -- fixes two issues
  * Now works when `-DFINUFFT_USE_OPENMP=off`
  * Should actually fix the bug. Critical only guaranteed that the section of interest was executed one thread at a time, but two different sections could still execute in tandem. I didn't see this cause a problem in multiple tests, but it would probably eventually happen.
