### PR TITLE
Fix: allow cufinufft doc to build without shared lib available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('../python/finufft'))
 sys.path.insert(0, os.path.abspath('../python/cufinufft'))
 
 # quash sphinx's inevitable failure of C++ lib extension to import...
-autodoc_mock_imports = ['finufft._finufft', 'numpy', 'pycuda']
+autodoc_mock_imports = ['finufft._finufft', 'numpy', 'pycuda', 'cufinufft._cufinufft']
 # The above is not enough for nested import -- forcibly mock them out ahead of time:
 #for name in autodoc_mock_imports:
 #    sys.modules[name] = sphinx.ext.autodoc._MockModule(name, None)

--- a/docs/python_gpu.rst
+++ b/docs/python_gpu.rst
@@ -66,3 +66,4 @@ Full documentation
 .. automodule:: cufinufft
     :members:
     :member-order: bysource
+    :undoc-members:


### PR DESCRIPTION
Closes #364 

This now builds the docs even when cuda is unavailable (confirmed locally), and lists the new `nufft*d*` functions for cufinufft