### PR TITLE
bugfix: set number of fftw threads for each makeplan call

### DIFF
--- a/include/finufft/fftw_defs.h
+++ b/include/finufft/fftw_defs.h
@@ -37,13 +37,11 @@
 #ifdef _OPENMP
   #define FFTW_INIT FFTWIFY(init_threads)
   #define FFTW_PLAN_TH FFTWIFY(plan_with_nthreads)
-  #define FFTW_GET_THR_NUM FFTWIFY(planner_nthreads)
   #define FFTW_CLEANUP_THREADS FFTWIFY(cleanup_threads)
 #else
   // no OMP (no fftw{f}_threads or _omp), need dummy fftw threads calls...
   #define FFTW_INIT()
   #define FFTW_PLAN_TH(x)
-  #define FFTW_GET_THR_NUM(x) 1
   #define FFTW_CLEANUP_THREADS()
 #endif
 

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -724,13 +724,14 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
     {
       std::lock_guard<std::mutex> lock(fftw_lock);
 
-      // FFTW_PLAN_TH sets all future fftw plans to use nthr_fft threads. Since this might override what the user wants,
-      // we set it just for our one plan alloc and then revert to the current set value
-      const int nthr_fft_before = FFTW_GET_THR_NUM();
+      // FFTW_PLAN_TH sets all future fftw_plan calls to use nthr_fft threads.
+      // FIXME: Since this might override what the user wants for fftw, we'd like to set it
+      // just for our one plan and then revert to the user value. Unfortunately
+      // fftw_planner_nthreads wasn't introduced until fftw 3.3.9, and there isn't a convenient
+      // mechanism to probe the version
       FFTW_PLAN_TH(nthr_fft);
       p->fftwPlan = FFTW_PLAN_MANY_DFT(dim, ns, p->batchSize, p->fwBatch, NULL, 1, p->nf, p->fwBatch, NULL, 1, p->nf,
                                        p->fftSign, p->opts.fftw);
-      FFTW_PLAN_TH(nthr_fft_before);
     }
     if (p->opts.debug) printf("[%s] FFTW plan (mode %d, nthr=%d):\t%.3g s\n", __func__,p->opts.fftw, nthr_fft, timer.elapsedsec());
     delete []ns;


### PR DESCRIPTION
This fixes the issue where only the first call to our makeplan routines would set the number of fftw threads. If a user wanted to change the number of fftw threads for different calls, it was impossible. 

Iniitially this commit also reverted the number of threads for future fftw_plan calls, but there is way to probe the current number of fftw threads when fftw < 3.3.9, and no trivial way to get a macro for the fftw version. This commit removes the "thread reversion" step of c923f89b (which was committed to master, failed CI because of an unsupported fftw version, and then reverted).