### PR TITLE
bugfix: set rpath in cufinufft's setup.py

### DIFF
--- a/python/cufinufft/setup.py
+++ b/python/cufinufft/setup.py
@@ -71,6 +71,8 @@ setup(
         Extension(name='cufinufftc',
                   sources=[],
                   libraries=['cufinufft'],
-                  library_dirs=[library_dir])
+                  library_dirs=[library_dir],
+                  runtime_library_dirs=[library_dir],
+                  )
         ]
 )


### PR DESCRIPTION
In short, after the python install, there are instances when `cufinufft` can't find `libcufinufft`. 

Right now, the `cufinufft` `setup.py` looks for `libcufinufft` and uses the `setuptools.Extension` to build a package initializer object that is _supposed_ to store the path to `libcufinufft` in it, except it doesn't. The fix is to add the relevant path to `runtime_library_dirs`. This automatically breaks windows builds, which we don't support anyway afaik.