### PR TITLE
Compile binary Python wheels for Python 3.12

### DIFF
--- a/.github/workflows/python_build_win.ps1
+++ b/.github/workflows/python_build_win.ps1
@@ -12,18 +12,20 @@ Add-Content -Path make.inc -Value "FFLAGS+= -fallow-argument-mismatch -march=x86
 Add-Content -Path make.inc -Value "CFLAGS+= -march=x86-64"
 Add-Content -Path make.inc -Value "CXXFLAGS+= -march=x86-64"
 
-# mingw gcc compiler pacth to work with python
-Set-Variable cygwinccompiler_py -Value ([IO.Path]::Combine((Split-Path -Path $PYTHON), "Lib", 'distutils', 'cygwinccompiler.py'))
-Remove-Item -Path $cygwinccompiler_py -Force
-Copy-Item -Path .\.github\workflows\cygwinccompiler.py -Destination $cygwinccompiler_py
 Set-Variable libvcruntime140_a -Value ([IO.Path]::Combine((Split-Path -Path $PYTHON), "libs", 'libvcruntime140.a'))
 Copy-Item -Path .\.github\workflows\libvcruntime140.a -Destination $libvcruntime140_a
 
-# Setup the distutils.cfg file
-Set-Variable distutils_cfg -Value ([IO.Path]::Combine((Split-Path -Path $PYTHON), "Lib", 'distutils', 'distutils.cfg'))
-Set-Content -Path $distutils_cfg -Value "[build]`r`ncompiler=mingw32`r`n[build_ext]`r`ncompiler=mingw32"
 python -m pip install --upgrade setuptools wheel numpy pip
 if (-not $?) {throw "Failed pip install"}
+
+# mingw gcc compiler pacth to work with python
+Set-Variable cygwinccompiler_py -Value ([IO.Path]::Combine((Split-Path -Path $PYTHON), "lib", "site-packages", "setuptools", "_distutils", "cygwinccompiler.py"))
+Remove-Item -Path $cygwinccompiler_py -Force
+Copy-Item -Path .\.github\workflows\cygwinccompiler.py -Destination $cygwinccompiler_py
+
+# Setup the distutils.cfg file
+Set-Variable distutils_cfg -Value ([IO.Path]::Combine((Split-Path -Path $PYTHON), "lib", "site-packages", "setuptools", "_distutils", "distutils.cfg"))
+Set-Content -Path $distutils_cfg -Value "[build]`r`ncompiler=mingw32`r`n[build_ext]`r`ncompiler=mingw32"
 
 # call make
 Set-Variable repo_root -Value ([IO.Path]::Combine($PSScriptRoot, '..', '..'))

--- a/.github/workflows/python_wheel.yml
+++ b/.github/workflows/python_wheel.yml
@@ -108,74 +108,73 @@ jobs:
         export FINUFFT_DIR=`pwd`
         export CC=gcc-11
         export CXX=g++-11
-        cd python/finufft
         /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pip install -U wheel --user
-        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pip wheel . -w wheelhouse
+        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pip wheel python/finufft -w wheelhouse
         /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pip install -U wheel --user
-        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pip wheel . -w wheelhouse
+        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pip wheel python/finufft -w wheelhouse
         /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pip install -U wheel --user
-        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pip wheel . -w wheelhouse
+        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pip wheel python/finufft -w wheelhouse
         /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pip install -U wheel --user
-        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pip wheel . -w wheelhouse
+        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pip wheel python/finufft -w wheelhouse
         /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pip install -U wheel --user
-        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pip wheel . -w wheelhouse
+        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pip wheel python/finufft -w wheelhouse
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip install -U wheel --user
-        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip wheel . -w wheelhouse
+        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip wheel python/finufft -w wheelhouse
         /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install -U wheel --user
-        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip wheel . -w wheelhouse
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip wheel python/finufft -w wheelhouse
 
         PYTHON_BIN=/Library/Frameworks/Python.framework/Versions/3.12/bin/
         $PYTHON_BIN/python3 -m pip install delocate
         ls wheelhouse/finufft*.whl | xargs -n1 $PYTHON_BIN/delocate-wheel -w fixed_wheel/
         /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pip install --pre finufft -f fixed_wheel/
-        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 test/run_accuracy_tests.py
-        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 python/finufft/test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 python/finufft/examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pip install pytest
-        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pytest python/finufft/test
         /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pip install --pre finufft -f fixed_wheel/
-        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 test/run_accuracy_tests.py
-        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 python/finufft/test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 python/finufft/examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pip install pytest
-        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.7/bin/python3 -m pytest python/finufft/test
         /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pip install --pre finufft -f fixed_wheel/
-        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 test/run_accuracy_tests.py
-        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 python/finufft/test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 python/finufft/examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pip install pytest
-        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.8/bin/python3 -m pytest python/finufft/test
         /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pip install --pre finufft -f fixed_wheel/
-        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 test/run_accuracy_tests.py
-        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 python/finufft/test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 python/finufft/examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pip install pytest
-        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pytest python/finufft/test
         /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pip install --pre finufft -f fixed_wheel/
-        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 test/run_accuracy_tests.py
-        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 python/finufft/test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 python/finufft/examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pip install pytest
-        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.10/bin/python3 -m pytest python/finufft/test
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip install --pre finufft -f fixed_wheel/
-        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 test/run_accuracy_tests.py
-        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 python/finufft/test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 python/finufft/examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip install pytest
-        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pytest python/finufft/test
         /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install --pre finufft -f fixed_wheel/
-        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 test/run_accuracy_tests.py
-        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 python/finufft/test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 python/finufft/examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install pytest
-        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pytest python/finufft/test
 
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
         name: macos-wheels
-        path: python/finufft/fixed_wheel/*.whl
+        path: fixed_wheel/*.whl
 
   Windows:
     runs-on: windows-latest

--- a/.github/workflows/python_wheel.yml
+++ b/.github/workflows/python_wheel.yml
@@ -222,6 +222,15 @@ jobs:
         .\.github\workflows\python_build_win.ps1
         .\.github\workflows\python_test_win.ps1
 
+    - name: Build and Test Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        architecture: 'x64'
+    - run: |
+        .\.github\workflows\python_build_win.ps1
+        .\.github\workflows\python_test_win.ps1
+
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python_wheel.yml
+++ b/.github/workflows/python_wheel.yml
@@ -97,6 +97,11 @@ jobs:
           --output python_installer.pkg
         sudo installer -pkg python_installer.pkg -target /
 
+        curl \
+          https://www.python.org/ftp/python/3.12.1/python-3.12.1-macos11.pkg \
+          --output python_installer.pkg
+        sudo installer -pkg python_installer.pkg -target /
+
     - name: Compile python bindings
       run: |
         make lib
@@ -122,7 +127,11 @@ jobs:
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip install -U wheel --user
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip wheel . -w wheelhouse
-        PYTHON_BIN=/Library/Frameworks/Python.framework/Versions/3.11/bin/
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install --upgrade setuptools wheel numpy pip
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install -U wheel --user
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip wheel . -w wheelhouse
+
+        PYTHON_BIN=/Library/Frameworks/Python.framework/Versions/3.12/bin/
         $PYTHON_BIN/python3 -m pip install delocate
         ls wheelhouse/finufft*.whl | xargs -n1 $PYTHON_BIN/delocate-wheel -w fixed_wheel/
         /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 -m pip install --pre finufft -f fixed_wheel/
@@ -155,6 +164,12 @@ jobs:
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 examples/simple1d1.py
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pip install pytest
         /Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -m pytest test
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install --pre finufft -f fixed_wheel/
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 test/run_accuracy_tests.py
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 examples/simple1d1.py
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pip install pytest
+        /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 -m pytest test
+
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/python_wheel.yml
+++ b/.github/workflows/python_wheel.yml
@@ -78,22 +78,22 @@ jobs:
         sudo installer -pkg python_installer.pkg -target /
 
         curl \
-          https://www.python.org/ftp/python/3.8.3/python-3.8.3-macosx10.9.pkg \
+          https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg \
           --output python_installer.pkg
         sudo installer -pkg python_installer.pkg -target /
 
         curl \
-          https://www.python.org/ftp/python/3.9.7/python-3.9.7-macos11.pkg \
+          https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg \
           --output python_installer.pkg
         sudo installer -pkg python_installer.pkg -target /
 
         curl \
-          https://www.python.org/ftp/python/3.10.1/python-3.10.1-macos11.pkg \
+          https://www.python.org/ftp/python/3.10.11/python-3.10.11-macos11.pkg \
           --output python_installer.pkg
         sudo installer -pkg python_installer.pkg -target /
 
         curl \
-          https://www.python.org/ftp/python/3.11.0/python-3.11.0-macos11.pkg \
+          https://www.python.org/ftp/python/3.11.7/python-3.11.7-macos11.pkg \
           --output python_installer.pkg
         sudo installer -pkg python_installer.pkg -target /
 

--- a/python/cufinufft/cufinufft/_cufinufft.py
+++ b/python/cufinufft/cufinufft/_cufinufft.py
@@ -8,14 +8,7 @@ differentiated by 'f' suffix.
 import ctypes
 import os
 import warnings
-
-# While imp is deprecated, it is currently the inspection solution
-#   that works for all versions of Python 2 and 3.
-# One day if that changes, can be replaced
-#   with importlib.find_spec.
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    import imp
+import importlib.util
 
 from ctypes import c_double
 from ctypes import c_int
@@ -42,10 +35,9 @@ except OSError:
 try:
     if lib is None:
         # Find the library.
-        fh = imp.find_module('cufinufft/cufinufftc')[0]
+        lib_path = importlib.util.find_spec('cufinufft.cufinufftc').origin
         # Get the full path for the ctypes loader.
-        full_lib_path = os.path.realpath(fh.name)
-        fh.close()    # Be nice and close the open file handle.
+        full_lib_path = os.path.realpath(lib_path)
 
         # Load the library,
         #    which rpaths the libraries we care about.

--- a/python/finufft/finufft/_finufft.py
+++ b/python/finufft/finufft/_finufft.py
@@ -10,14 +10,7 @@ import ctypes
 import os
 import warnings
 import platform
-
-# While imp is deprecated, it is currently the inspection solution
-#   that works for all versions of Python 2 and 3.
-# One day if that changes, can be replaced
-#   with importlib.find_spec.
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    import imp
+import importlib
 
 import numpy as np
 
@@ -48,14 +41,13 @@ except OSError:
 try:
     if lib is None:
         # Find the library.
-        fh = imp.find_module('finufft/finufftc')[0]
+        lib_path = importlib.util.find_spec('finufft.finufftc').origin
         # Get the full path for the ctypes loader.
         if platform.system() == 'Windows':
-            os.environ["PATH"] += os.pathsep + os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(fh.name))),'finufft')
-            full_lib_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(fh.name))),'finufft','libfinufft.dll')
+            os.environ["PATH"] += os.pathsep + os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(lib_path))),'finufft')
+            full_lib_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(lib_path))),'finufft','libfinufft.dll')
         else:
-            full_lib_path = os.path.realpath(fh.name)
-        fh.close()    # Be nice and close the open file handle.
+            full_lib_path = os.path.realpath(lib_path)
 
         # Load the library,
         #    which rpaths the libraries we care about.

--- a/python/finufft/finufft/_finufft.py
+++ b/python/finufft/finufft/_finufft.py
@@ -10,7 +10,7 @@ import ctypes
 import os
 import warnings
 import platform
-import importlib
+import importlib.util
 
 import numpy as np
 

--- a/tools/cufinufft/build-wheels.sh
+++ b/tools/cufinufft/build-wheels.sh
@@ -29,7 +29,8 @@ py_versions=(cp36-cp36m \
             cp38-cp38 \
             cp39-cp39 \
             cp310-cp310 \
-            cp311-cp311)
+            cp311-cp311 \
+            cp312-cp312)
 
 # NOTE: For CUDA 12, cp36-cp36m and cp37-cp37m are broken since these force an
 # older version of pycuda (2022.1), which does not build under CUDA 12.

--- a/tools/finufft/build-wheels-linux.sh
+++ b/tools/finufft/build-wheels-linux.sh
@@ -24,6 +24,7 @@ versions=("cp36-cp36m"
           "cp39-cp39"
           "cp310-cp310"
           "cp311-cp311"
+          "cp312-cp312"
           "pp38-pypy38_pp73"
           "pp39-pypy39_pp73")
 


### PR DESCRIPTION
Updates the code to use `importlib` instead of `imp` to make the library compatible with Python 3.12. Also updates the wheel building scripts to build wheels for Python 3.12 and test them.