### PR TITLE
Remove compute capabilities 3.5 and 7.5 from cufinufft wheels

### DIFF
--- a/tools/cufinufft/build-library.sh
+++ b/tools/cufinufft/build-library.sh
@@ -8,7 +8,7 @@ cd /io/build
 cmake -D FINUFFT_USE_CUDA=ON \
       -D FINUFFT_USE_CPU=OFF \
       -D FINUFFT_BUILD_TESTS=ON \
-      -D CMAKE_CUDA_ARCHITECTURES="35;50;60;70;75;80" \
+      -D CMAKE_CUDA_ARCHITECTURES="50;60;70;75;80" \
       -D CMAKE_CUDA_FLAGS="-Wno-deprecated-gpu-targets" \
       -D BUILD_TESTING=ON \
       ..

--- a/tools/cufinufft/build-library.sh
+++ b/tools/cufinufft/build-library.sh
@@ -8,7 +8,7 @@ cd /io/build
 cmake -D FINUFFT_USE_CUDA=ON \
       -D FINUFFT_USE_CPU=OFF \
       -D FINUFFT_BUILD_TESTS=ON \
-      -D CMAKE_CUDA_ARCHITECTURES="50;60;70;75;80" \
+      -D CMAKE_CUDA_ARCHITECTURES="50;60;70;80" \
       -D CMAKE_CUDA_FLAGS="-Wno-deprecated-gpu-targets" \
       -D BUILD_TESTING=ON \
       ..


### PR DESCRIPTION
Goal here is to bring binary wheels down to less than 150 MB, which is the file size limit for PyPI. Here this is done by excluding compute capabilities 3.5 and 7.5, which brings us to 148 MB.