### PR TITLE
cuda: fix argument names in cufinufft C api

### DIFF
--- a/include/cufinufft.h
+++ b/include/cufinufft.h
@@ -19,13 +19,13 @@ int cufinufft_makeplan(int type, int dim, const int64_t *n_modes, int iflag, int
 int cufinufftf_makeplan(int type, int dim, const int64_t *n_modes, int iflag, int ntr, float eps,
                         cufinufftf_plan *d_plan_ptr, cufinufft_opts *opts);
 
-int cufinufft_setpts(cufinufft_plan d_plan, int M, double *h_kx, double *h_ky, double *h_kz, int N, double *h_s,
-                     double *h_t, double *h_u);
-int cufinufftf_setpts(cufinufftf_plan d_plan, int M, float *h_kx, float *h_ky, float *h_kz, int N, float *h_s,
-                      float *h_t, float *h_u);
+int cufinufft_setpts(cufinufft_plan d_plan, int M, double *d_x, double *d_y, double *d_z, int N, double *d_s,
+                     double *d_t, double *d_u);
+int cufinufftf_setpts(cufinufftf_plan d_plan, int M, float *d_x, float *d_y, float *d_z, int N, float *d_s,
+                      float *d_t, float *d_u);
 
-int cufinufft_execute(cufinufft_plan d_plan, cuDoubleComplex *h_c, cuDoubleComplex *h_fk);
-int cufinufftf_execute(cufinufftf_plan d_plan, cuFloatComplex *h_c, cuFloatComplex *h_fk);
+int cufinufft_execute(cufinufft_plan d_plan, cuDoubleComplex *d_c, cuDoubleComplex *d_fk);
+int cufinufftf_execute(cufinufftf_plan d_plan, cuFloatComplex *d_c, cuFloatComplex *d_fk);
 
 int cufinufft_destroy(cufinufft_plan d_plan);
 int cufinufftf_destroy(cufinufftf_plan d_plan);

--- a/src/cuda/cufinufft.cu
+++ b/src/cuda/cufinufft.cu
@@ -53,14 +53,14 @@ int cufinufft_makeplan(int type, int dim, const int64_t *nmodes, int iflag, int 
                                    opts);
 }
 
-int cufinufftf_setpts(cufinufftf_plan d_plan, int M, float *d_kx, float *d_ky, float *d_kz, int N, float *d_s,
+int cufinufftf_setpts(cufinufftf_plan d_plan, int M, float *d_x, float *d_y, float *d_z, int N, float *d_s,
                       float *d_t, float *d_u) {
-    return cufinufft_setpts_impl(M, d_kx, d_ky, d_kz, N, d_s, d_t, d_u, (cufinufft_plan_t<float> *)d_plan);
+    return cufinufft_setpts_impl(M, d_x, d_y, d_z, N, d_s, d_t, d_u, (cufinufft_plan_t<float> *)d_plan);
 }
 
-int cufinufft_setpts(cufinufft_plan d_plan, int M, double *d_kx, double *d_ky, double *d_kz, int N, double *d_s,
+int cufinufft_setpts(cufinufft_plan d_plan, int M, double *d_x, double *d_y, double *d_z, int N, double *d_s,
                      double *d_t, double *d_u) {
-    return cufinufft_setpts_impl(M, d_kx, d_ky, d_kz, N, d_s, d_t, d_u, (cufinufft_plan_t<double> *)d_plan);
+    return cufinufft_setpts_impl(M, d_x, d_y, d_z, N, d_s, d_t, d_u, (cufinufft_plan_t<double> *)d_plan);
 }
 
 int cufinufftf_execute(cufinufftf_plan d_plan, cuFloatComplex *d_c, cuFloatComplex *d_fk) {


### PR DESCRIPTION
The prefix `h_` indicates that these are host pointers when in fact they are device pointers so switching to `d_` here. Also replacing `kx`, etc. with `x` for simplicity.