### PR TITLE
Bump Python versions to 2.2.0 proper

### DIFF
--- a/python/cufinufft/cufinufft/__init__.py
+++ b/python/cufinufft/cufinufft/__init__.py
@@ -8,4 +8,4 @@ __all__ = ["nufft1d1", "nufft1d2",
            "nufft3d1", "nufft3d2",
            "Plan"]
 
-__version__ = '2.2.0b0'
+__version__ = '2.2.0'

--- a/python/cufinufft/setup.py
+++ b/python/cufinufft/setup.py
@@ -39,7 +39,7 @@ print('cufinufft CUDA shared libraries found, continuing...')
 # Python Package Setup
 setup(
     name='cufinufft',
-    version='2.2.0b0',
+    version='2.2.0',
     author='Yu-shuan Melody Shih, Garrett Wright, Joakim Anden, Johannes Blaschke, Alex Barnett',
     author_email='janden-vscholar@flatironinstitute.org',
     url='https://github.com/flatironinstitute/finufft',

--- a/python/finufft/finufft/__init__.py
+++ b/python/finufft/finufft/__init__.py
@@ -17,4 +17,4 @@ from finufft._interfaces import nufft1d1,nufft1d2,nufft1d3
 from finufft._interfaces import nufft2d1,nufft2d2,nufft2d3
 from finufft._interfaces import nufft3d1,nufft3d2,nufft3d3
 
-__version__ = '2.2.0b0'
+__version__ = '2.2.0'

--- a/python/finufft/setup.py
+++ b/python/finufft/setup.py
@@ -5,7 +5,7 @@
 # attempt ../make.inc reading (failed) and default finufftdir. 2/25/20
 # Barnett trying to get sphinx.ext.autodoc to work w/ this, 10/5/20
 
-__version__ = '2.2.0b0'
+__version__ = '2.2.0'
 
 from setuptools import setup, Extension
 import os


### PR DESCRIPTION
Should have all the details ironed out now for the full 2.2.0 release.