### PR TITLE
cuda-python-bugfix: allow passage of cuda stream objects or pointers

### DIFF
--- a/python/cufinufft/cufinufft/_compat.py
+++ b/python/cufinufft/cufinufft/_compat.py
@@ -1,7 +1,7 @@
 import inspect
 
 import numpy as np
-
+import warnings
 
 def get_array_ptr(data):
     try:
@@ -30,6 +30,10 @@ def get_array_module(obj):
 def get_stream_ptr(obj):
     framework = get_array_module(obj)
     if isinstance(obj, int):
+        warnings.warn("Raw stream pointers are deprecated and will be removed in version 2.4. "
+                      "Please use your python GPU framework's stream object type directly.",
+                      DeprecationWarning)
+
         return obj
     if framework == 'numba':
         return obj.handle.value

--- a/python/cufinufft/cufinufft/_compat.py
+++ b/python/cufinufft/cufinufft/_compat.py
@@ -27,6 +27,22 @@ def get_array_module(obj):
         return "generic"
 
 
+def get_stream_ptr(obj):
+    framework = get_array_module(obj)
+    if isinstance(obj, int):
+        return obj
+    if framework == 'numba':
+        return obj.handle.value
+    if framework == 'pycuda':
+        return obj.handle
+    if framework == 'torch':
+        return obj.cuda_stream
+    # Unknown / generic / cupy
+    if hasattr(obj, 'ptr'):
+        return obj.ptr
+    raise TypeError("Unknown cuda stream pointer type")
+
+
 def get_array_size(obj):
     array_module = get_array_module(obj)
 

--- a/python/cufinufft/examples/example3d2many_async_cupy.py
+++ b/python/cufinufft/examples/example3d2many_async_cupy.py
@@ -44,7 +44,7 @@ def test():
 
     # Initialize the plan and set the points.
     plan_stream = cupy.cuda.Stream(null=True)
-    plan = cufinufft.Plan(2, N, n_transf, eps=eps, dtype=complex_dtype, gpu_kerevalmeth=1, gpu_stream=plan_stream.ptr)
+    plan = cufinufft.Plan(2, N, n_transf, eps=eps, dtype=complex_dtype, gpu_kerevalmeth=1, gpu_stream=plan_stream)
     plan.setpts(cupy.array(x), cupy.array(y), cupy.array(z))
 
     # Using a simple front/back buffer approach. backbuffer is for DtoH transfers, and front for
@@ -54,9 +54,9 @@ def test():
     back_fk_gpu = cupy.empty(fk_all[0].shape, fk_all[0].dtype)
     front_c_gpu = cupy.empty(c_all_async[0].shape, c_all_async[0].dtype)
     back_c_gpu = cupy.empty(c_all_async[0].shape, c_all_async[0].dtype)
-    front_plan = cufinufft.Plan(2, N, n_transf, eps=eps, dtype=complex_dtype, gpu_kerevalmeth=1, gpu_stream=front_stream.ptr)
+    front_plan = cufinufft.Plan(2, N, n_transf, eps=eps, dtype=complex_dtype, gpu_kerevalmeth=1, gpu_stream=front_stream)
     front_plan.setpts(cupy.array(x), cupy.array(y), cupy.array(z))
-    back_plan = cufinufft.Plan(2, N, n_transf, eps=eps, dtype=complex_dtype, gpu_kerevalmeth=1, gpu_stream=back_stream.ptr)
+    back_plan = cufinufft.Plan(2, N, n_transf, eps=eps, dtype=complex_dtype, gpu_kerevalmeth=1, gpu_stream=back_stream)
     back_plan.setpts(cupy.array(x), cupy.array(y), cupy.array(z))
 
     # Run with async
@@ -100,11 +100,5 @@ def test():
     print(f"speedup (sync / async): {round(sync_time / async_time, 2)}")
     print(f"speedup (naive / sync): {round(naive_time / sync_time, 2)}")
     print(f"speedup (naive / async): {round(naive_time / async_time, 2)}")
-
-    # Since plans carry raw stream pointers which aren't reference counted, we need to make
-    # sure they're deleted before the stream objects that hold them. Otherwise, the stream
-    # might be deleted before cufinufft can use it in the deletion routines. Manually clear
-    # them out here.
-    del plan, front_plan, back_plan
 
 test()


### PR DESCRIPTION
Pointers are dangerous because they aren't reference counted and so can be deleted before cufinufft cleans up (#417). This patch allows the user to pass either a stream object OR a pointer in the `gpu_stream` argument of Plan

Might warrant discussion of if we should just scrap the raw pointer altogether