### PR TITLE
Fix examples on Mac OSX with Apple Silicon

### DIFF
--- a/makefile
+++ b/makefile
@@ -208,7 +208,7 @@ endif
 	@echo "Done running: $(EXAMPLES)"
 # fun fact: gnu make patterns match those with shortest "stem", so this works:
 examples/%: examples/%.o $(DYNLIB)
-	$(CXX) $(CXXFLAGS) ${LDFLAGS} $< $(ABSDYNLIB) -o $@
+	$(CXX) $(CXXFLAGS) ${LDFLAGS} $< $(ABSDYNLIB) $(LIBSFFT) -o $@
 examples/%c: examples/%c.o $(DYNLIB)
 	$(CC) $(CFLAGS) ${LDFLAGS} $< $(ABSDYNLIB) $(LIBSFFT) $(CLINK) -o $@
 examples/%cf: examples/%cf.o $(DYNLIB)


### PR DESCRIPTION
This addition fixes an issue where the examples could not be built on a Macbook Pro M3 running Mac OS Sonoma 14.2.1 with Clang. The failing CI on my fork does not seem to be related to this PR.

Cheers
Jonas
