### PR TITLE
[BugFix] Robustize cuFINUFFT Python guru interface.

### DIFF
--- a/python/cufinufft/cufinufft/_plan.py
+++ b/python/cufinufft/cufinufft/_plan.py
@@ -5,6 +5,8 @@ the cufinufft CUDA libraries.
 """
 
 import atexit
+import collections.abc
+import numbers
 import sys
 import warnings
 
@@ -108,8 +110,12 @@ class Plan:
         else:
             raise TypeError("Expected complex64 or complex128.")
 
-        if isinstance(n_modes, int):
+        if isinstance(n_modes, numbers.Integral):
             n_modes = (n_modes,)
+        elif isinstance(n_modes, collections.abc.Iterable):
+            n_modes = tuple(n_modes)
+        else:
+            raise ValueError(f"Invalid n_modes '{n_modes}'")
 
         self.dim = len(n_modes)
         self.type = nufft_type


### PR DESCRIPTION
As per the docs:
* `finufft.Plan(n_modes_or_dim)` accepts `(int, tuple[int])`
* `cufinufft.Plan(n_modes)` accepts `(int, tuple[int])`

In practice `n_modes_or_dim` is transformed internally to a NumPy array, hence providing any iterable to `finufft.Plan()` works.
However `n_modes` in `cufinufft.Plan()` is more restrictive: it works with `tuple[int]`, fails planning if `list[int]`, and wrongfully passes planning if `ndarray[int]`, but then seg-faults at `execute()`.

The examples below showcase the problem:
```
### mve_finufft.py
import finufft
import numpy as np

xp, fi = np, finufft

M, D = 1_000, 2
N = (20, 21, 22)[:D]
cdtype = np.cdouble

plan = fi.Plan(
    nufft_type=1,
    n_modes_or_dim=tuple(N),  # ok
    # n_modes_or_dim=list(N),  # ok
    # n_modes_or_dim=np.array(N),  # ok
    dtype=cdtype,
    isign=1,
)

rng = xp.random.default_rng(0)
x = rng.uniform(-np.pi, np.pi, size=(D, M))
plan.setpts(**dict(zip("xyz"[:D], x[:D])))

w = rng.standard_normal(2 * M).view(cdtype)
out = plan.execute(w)
```
```
### mve_cufinufft.py
import cufinufft
import cupy as cp
import numpy as np

xp, fi = cp, cufinufft

M, D = 1_000, 2
N = (20, 21, 22)[:D]
cdtype = np.cdouble

plan = fi.Plan(
    nufft_type=1,
    n_modes=tuple(N),  # ok
    # n_modes=list(N),  # planning error
    # n_modes=np.array(N),  # execute error + seg-fault (sometimes)
    dtype=cdtype,
    isign=1,
)

rng = xp.random.default_rng(0)
x = rng.uniform(-np.pi, np.pi, size=(D, M))
plan.setpts(**dict(zip("xyz"[:D], x[:D])))

w = rng.standard_normal(2 * M).view(cdtype)
out = plan.execute(w)
```

This PR increases the robustness of `cufinufft.Plan()` to match the flexibility of the CPU interface.