### PR TITLE
Enforce nthreads = 1 for single threaded lib

### DIFF
--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -594,6 +594,12 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
   int nthr = MY_OMP_GET_MAX_THREADS();      // use as many as OMP gives us
   if (p->opts.nthreads>0)
     nthr = p->opts.nthreads;                // user override (no limit or check)
+#ifndef _OPENMP
+  if(nthr != 1) {
+    nthr = 1
+    fprintf(stderr,"%s warning: Running finufft single threaded lib with nthreads != 1, enforcing nthreads = 1 ! \n",__func__);
+  }
+#endif
   p->opts.nthreads = nthr;                  // store actual # thr planned for
 
   // choose batchSize for types 1,2 or 3... (uses int ceil(b/a)=1+(b-1)/a trick)

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -591,17 +591,16 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
   p->fftSign = (iflag>=0) ? 1 : -1;         // clean up flag input
 
   // choose overall # threads...
-  int nthr = MY_OMP_GET_MAX_THREADS();      // use as many as OMP gives us
-  if (p->opts.nthreads>0)
-    nthr = p->opts.nthreads;                // user override (no limit or check)
-#ifndef _OPENMP
-  if(nthr != 1) {
-    nthr = 1;
-    fprintf(stderr,"%s warning: Running finufft single threaded lib with nthreads != 1, enforcing nthreads = 1 ! \n",__func__);
+  int maxnthr = MY_OMP_GET_MAX_THREADS();
+  int nthr = maxnthr;                       // use as many as OMP gives us
+  if (p->opts.nthreads>0) {
+    nthr = min(maxnthr,p->opts.nthreads);   // user override up to max avail
+    if (p->opts.nthreads > maxnthr)         // if no OMP, maxnthr=1
+      fprintf(stderr,"%s warning: user requested %d threads, but only %d threads available; enforcing nthreads=%d.\n",__func__,p->opts.nthreads,maxnthr,nthr);
   }
-#endif
   p->opts.nthreads = nthr;                  // store actual # thr planned for
-
+  // (this sets all downstream spread/interp, 1dkernel, and FFT thread counts)
+  
   // choose batchSize for types 1,2 or 3... (uses int ceil(b/a)=1+(b-1)/a trick)
   if (p->opts.maxbatchsize==0) {            // logic to auto-set best batchsize
     p->nbatch = 1+(ntrans-1)/nthr;          // min # batches poss

--- a/src/finufft.cpp
+++ b/src/finufft.cpp
@@ -596,7 +596,7 @@ int FINUFFT_MAKEPLAN(int type, int dim, BIGINT* n_modes, int iflag,
     nthr = p->opts.nthreads;                // user override (no limit or check)
 #ifndef _OPENMP
   if(nthr != 1) {
-    nthr = 1
+    nthr = 1;
     fprintf(stderr,"%s warning: Running finufft single threaded lib with nthreads != 1, enforcing nthreads = 1 ! \n",__func__);
   }
 #endif


### PR DESCRIPTION
Enforce nthreads = 1 for single threaded lib, to improve the case that single threaded finufft lib running with nthreads != 1 gives inf/nan error flatironinstitute/jax-finufft#73 and flatironinstitute/finufft#430. 