### PR TITLE
revisit logic for choosing number of threads in various FINUFFT tasks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 List of features / changes made / release notes, in reverse chronological order.
 If not stated, FINUFFT is assumed (cuFINUFFT <=1.3 is listed separately).
 
-* CPU plan stage prevents now caps # threads at omp_get_max_threads (being 1
-  for single-thread build); warns if this cap was activated (PR 431)
+* CPU plan stage allows any # threads, warns if > omp_get_max_threads(); or
+  if single-threaded fixes nthr=1 and warns opts.nthreads>1 attempt.
+  Sort now respects spread_opts.sort_threads not nthreads. Supercedes PR 431.
 * new docs troubleshooting accuracy limitations due to condition number of the
   NUFFT problem.
 * new sanity check on nj and nk (<0 or too big); new err code, tester, doc.

--- a/docs/opts.rst
+++ b/docs/opts.rst
@@ -128,7 +128,9 @@ Diagnostic options
 Algorithm performance options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**nthreads**: Number of threads to use. This is capped at the number of available threads (eg, to prevent misuse of a single-threaded code). It then sets the number of threads FINUFFT will use in FFTW, bin-sorting, and spreading/interpolation steps. This number of threads also controls the batch size for vectorized transforms (ie ``ntr>1`` :ref:`here <c>`). Setting ``nthreads=0`` uses all threads available, usually recommended. However, for repeated small problems it can be advantageous to use a small number, even as small as 1.
+**nthreads**: (Ignored in single-threaded library builds.) If positive, sets the number of threads to use throughout (multi-threaded build of) library, or if ``0`` uses the maximum number of threads available according to OpenMP. In the positive case, no cap is placed on this number. This number of threads is passed to bin-sorting (which may choose to use less threads), but is adhered to in FFTW and spreading/interpolation steps. This number of threads (or 1 for single-threaded builds) also controls the batch size for vectorized transforms (ie ``ntr>1`` :ref:`here <c>`).
+For medium-to-large transforms, ``0`` is usually recommended.
+However, for (repeated) small transforms it can be advantageous to use a small number, even as small as ``1``.
 
 **fftw**: FFTW planner flags. This number is simply passed to FFTW's planner;
 the flags are documented `here <http://www.fftw.org/fftw3_doc/Planner-Flags.html#Planner-Flags>`_.


### PR DESCRIPTION
material changes are
* remove capping at omp_get_max_nthreads(), based on Marco & team discussion 5/7/24
* warning user if they do the above; and if they try nthr>1 in OMP=OFF build
* bin-sort max thread number now properly overridden by spopts.nthreads, and (with higher priority) by spopts.sort_threads (which also overrides the drop-to-single-thread heuristic)
* no thread caps in spreadinterp; except if OMP=OFF now enforce nthr=1.

Here's detailed logic notes (also in gdoc):

OMP=OFF: (single-threaded). Always enforce nthr=1; warning raised (makeplan stage only) if user sets opts.nthreads>1.

OMP on: user can set any nonzero nthr; warning given if showwarn=1 & exceeds omp_max_threads().

At the makeplan stage, opts.nthreads is rewritten with actual # threads used (by fft, etc), thus it is never zero in downstream calls (setpts, exec). Spread_opts.nthreads is copied from opts.nthreads at this stage, so it is never 0.

FFT : uses opts.nthreads.

Spreadsorted and interpsorted: use spopts.nthreads (default 0 giving max_omp, but in FINUFFT context it is never zero; this would only occur in stand-alone testers for spreadinterp); unless OMP=OFF then use 1.


Bin sort (in spreadinterp.cpp): logic is bit trickier than spreadsorted or interpsorted. spopts.sort_threads (default 0 set in setup_spreader): if >0 acts as a high-priority override of sorting # threads (but overridden by OMP=OFF, in which case single-thread always used).

Otherwise, maxnthr is set by spopts.nthreads (or if 0, which never occurs in FINUFFT context, by querying omp_max…()), and then a heuristic is used to do single-thread or use maxnthr.

(Warnings are absent in spreadinterp.cpp since we don’t have a spread_opts.showwarn to switch them off, and the FINUFFT user will have been warned already). 




