### PR TITLE
added pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v18.1.6'
+    hooks:
+      - id: clang-format


### PR DESCRIPTION
I have added a pre-commit-hook to format the code automatically at every commit. It uses the .clang-format provided by @blackwer in the git root. 