### PR TITLE
users.rst: add nifty-ls

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -42,6 +42,8 @@ and also add them to GitHub's Used By feature):
 
 #. `FTK <https://github.com/flatironinstitute/ftk>`_: Factorization of the translation kernel for fast 2D rigid image alignment, by Rangan, Spivak, Andén, and Barnett.
 
+#. `nifty-ls <https://github.com/flatironinstitute/nifty-ls>`_: Fast evaluation of the Lomb-Scargle periodogram for time series analysis, backed by finufft or cufinufft
+
    
 Other wrappers to (cu)FINUFFT
 ------------------------------


### PR DESCRIPTION
I've released the first version of [nifty-ls](https://github.com/flatironinstitute/nifty-ls/), which uses finufft or cufinufft to accelerate Lomb-Scargle for astronomers. It's many times faster than the usual Astropy method, and orders of magnitude more accurate! Thanks @ahbarnett and @dfm for your help.

One challenge in using finufft was setting an appropriate default number of threads (for 1D type-1, both batched and unbatched). I implemented some heuristics based on the problem size, but it's probably not optimal/portable. I realize it's a hard problem to solve, but it would be great if finufft could implement some of this upstream!