### PR TITLE
cuda: use sync malloc/free when async not supported #445

### DIFF
--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -129,6 +129,13 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
   // for support
   cudaDeviceGetAttribute(&d_plan->supports_pools, cudaDevAttrMemoryPoolsSupported,
                          device_id);
+  static bool warned = false;
+  if (!warned && !d_plan->supports_pools && d_plan->opts.gpu_stream != nullptr) {
+    fprintf(stderr,
+            "[cufinufft] Warning: cudaMallocAsync not supported on this device. Use of "
+            "CUDA streams may not perform optimally.\n");
+    warned = true;
+  }
 
   auto &stream = d_plan->stream = (cudaStream_t)d_plan->opts.gpu_stream;
 

--- a/include/cufinufft/types.h
+++ b/include/cufinufft/types.h
@@ -39,6 +39,7 @@ template<typename T> struct cufinufft_plan_t {
   int ntransf;
   int maxbatchsize;
   int iflag;
+  int supports_pools;
 
   int totalnumsubprob;
   T *fwkerhalf1;

--- a/src/cuda/1d/spread1d_wrapper.cu
+++ b/src/cuda/1d/spread1d_wrapper.cu
@@ -203,7 +203,8 @@ int cuspread1d_subprob_prop(int nf1, int M, cufinufft_plan_t<T> *d_plan)
     return ier;
   cudaStreamSynchronize(stream);
   if ((ier = checkCudaErrors(
-           cudaMallocAsync(&d_subprob_to_bin, totalnumsubprob * sizeof(int), stream))))
+           cudaMallocWrapper(&d_subprob_to_bin, totalnumsubprob * sizeof(int), stream,
+                             d_plan->supports_pools))))
     return ier;
   map_b_into_subprob_1d<<<(numbins + 1024 - 1) / 1024, 1024, 0, stream>>>(
       d_subprob_to_bin, d_subprobstartpts, d_numsubprob, numbins);
@@ -215,7 +216,7 @@ int cuspread1d_subprob_prop(int nf1, int M, cufinufft_plan_t<T> *d_plan)
   }
 
   assert(d_subprob_to_bin != NULL);
-  cudaFreeAsync(d_plan->subprob_to_bin, stream);
+  cudaFreeWrapper(d_plan->subprob_to_bin, stream, d_plan->supports_pools);
   d_plan->subprob_to_bin  = d_subprob_to_bin;
   d_plan->totalnumsubprob = totalnumsubprob;
 

--- a/src/cuda/2d/spread2d_wrapper.cu
+++ b/src/cuda/2d/spread2d_wrapper.cu
@@ -220,7 +220,8 @@ int cuspread2d_subprob_prop(int nf1, int nf2, int M, cufinufft_plan_t<T> *d_plan
     return ier;
   cudaStreamSynchronize(stream);
   if ((ier = checkCudaErrors(
-           cudaMallocAsync(&d_subprob_to_bin, totalnumsubprob * sizeof(int), stream))))
+           cudaMallocWrapper(&d_subprob_to_bin, totalnumsubprob * sizeof(int), stream,
+                             d_plan->supports_pools))))
     return ier;
   map_b_into_subprob_2d<<<(numbins[0] * numbins[1] + 1024 - 1) / 1024, 1024, 0, stream>>>(
       d_subprob_to_bin, d_subprobstartpts, d_numsubprob, numbins[0] * numbins[1]);
@@ -232,7 +233,7 @@ int cuspread2d_subprob_prop(int nf1, int nf2, int M, cufinufft_plan_t<T> *d_plan
   }
 
   assert(d_subprob_to_bin != NULL);
-  cudaFreeAsync(d_plan->subprob_to_bin, stream);
+  cudaFreeWrapper(d_plan->subprob_to_bin, stream, d_plan->supports_pools);
   d_plan->subprob_to_bin  = d_subprob_to_bin;
   d_plan->totalnumsubprob = totalnumsubprob;
 

--- a/src/cuda/3d/spread3d_wrapper.cu
+++ b/src/cuda/3d/spread3d_wrapper.cu
@@ -260,8 +260,8 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
                                              cudaMemcpyDeviceToHost, stream))))
     return ier;
   cudaStreamSynchronize(stream);
-  if ((ier = checkCudaErrors(
-           cudaMallocAsync(&d_idxnupts, totalNUpts * sizeof(int), stream))))
+  if ((ier = checkCudaErrors(cudaMallocWrapper(&d_idxnupts, totalNUpts * sizeof(int),
+                                               stream, d_plan->supports_pools))))
     return ier;
 
   calc_inverse_of_global_sort_index_ghost<<<(M + 1024 - 1) / 1024, 1024, 0, stream>>>(
@@ -320,7 +320,8 @@ int cuspread3d_blockgather_prop(int nf1, int nf2, int nf3, int M,
     return ier;
   cudaStreamSynchronize(stream);
   if ((ier = checkCudaErrors(
-           cudaMallocAsync(&d_subprob_to_bin, totalnumsubprob * sizeof(int), stream))))
+           cudaMallocWrapper(&d_subprob_to_bin, totalnumsubprob * sizeof(int), stream,
+                             d_plan->supports_pools))))
     return ier;
   map_b_into_subprob_3d_v1<<<(n + 1024 - 1) / 1024, 1024, 0, stream>>>(
       d_subprob_to_bin, d_subprobstartpts, d_numsubprob, n);
@@ -474,8 +475,8 @@ int cuspread3d_subprob_prop(int nf1, int nf2, int nf3, int M,
                                       sizeof(int), cudaMemcpyDeviceToHost, stream)))
     return FINUFFT_ERR_CUDA_FAILURE;
   cudaStreamSynchronize(stream);
-  if (checkCudaErrors(
-          cudaMallocAsync(&d_subprob_to_bin, totalnumsubprob * sizeof(int), stream)))
+  if (checkCudaErrors(cudaMallocWrapper(&d_subprob_to_bin, totalnumsubprob * sizeof(int),
+                                        stream, d_plan->supports_pools)))
     return FINUFFT_ERR_CUDA_FAILURE;
 
   map_b_into_subprob_3d_v2<<<(numbins[0] * numbins[1] + 1024 - 1) / 1024, 1024, 0,


### PR DESCRIPTION
This PR attempts to resolve the issue that `cudaMallocAsync/cudaMallocFree` is not supported based purely on compute capability, but is device dependent as well. To resolve this I probe for async memory pool capabilities as suggested at https://github.com/kokkos/kokkos/issues/7044 and then store that info on the plan struct. `free` and `malloc` calls are then all wrapped, passing this result so that the appropriate call is made.

We should probably print a warning, but unlike the cpu version, there is no verbosity option supplied to the library, so I wasn't sure the best way to provide a message without spamming the user if they don't care. A short-term solution would be to just make it print the result only on the first failure, and then mark the failure visited via a `static bool`. 