### PR TITLE
l2 err overrides one-output err in errmax for math test exit codes

### DIFF
--- a/test/basicpassfail.cpp
+++ b/test/basicpassfail.cpp
@@ -14,7 +14,7 @@ int main() {
   std::vector<CPX> F(N);              // alloc output mode coeffs
 
   // Make the input data....................................
-  srand(42);                                               // seed
+  srand(42);                                               // seed (fixed)
   std::vector<FLT> x(M);                                   // NU pts locs
   std::vector<CPX> c(M);                                   // strengths
   for (BIGINT j = 0; j < M; ++j) {

--- a/test/finufft1d_test.cpp
+++ b/test/finufft1d_test.cpp
@@ -82,7 +82,6 @@ int main(int argc, char *argv[]) {
   }
   err = abs(Ftr + IMA * Fti - F[N / 2 + nt]) / infnorm(N, F);
   printf("\tone mode: rel err in F[%lld] is %.3g\n", (long long)nt, err);
-  errmax = max(err, errmax);
   if (((int64_t)M) * N <= TEST_BIGPROB) { // also full direct eval
     CPX *Ft = (CPX *)malloc(sizeof(CPX) * N);
     dirft1d1(M, x, c, isign, N, Ft);
@@ -90,7 +89,8 @@ int main(int argc, char *argv[]) {
     errmax = max(err, errmax);
     printf("\tdirft1d: rel l2-err of result F is %.3g\n", err);
     free(Ft);
-  }
+  } else
+    errmax = max(err, errmax);
 
   printf("test 1d type 2:\n"); // -------------- type 2
 #pragma omp parallel
@@ -116,8 +116,7 @@ int main(int argc, char *argv[]) {
   // #pragma omp parallel for schedule(static,TEST_RANDCHUNK) reduction(cmplxadd:ct)
   for (BIGINT m1 = -k0; m1 <= (N - 1) / 2; ++m1)
     ct += F[m++] * exp(IMA * ((FLT)(isign * m1)) * x[jt]); // crude direct
-  err    = abs(ct - c[jt]) / infnorm(M, c);
-  errmax = max(err, errmax);
+  err = abs(ct - c[jt]) / infnorm(M, c);
   printf("\tone targ: rel err in c[%lld] is %.3g\n", (long long)jt, err);
   if (((int64_t)M) * N <= TEST_BIGPROB) { // also full direct eval
     CPX *ct = (CPX *)malloc(sizeof(CPX) * M);
@@ -127,7 +126,8 @@ int main(int argc, char *argv[]) {
     printf("\tdirft1d: rel l2-err of result c is %.3g\n", err);
     // cout<<"c/ct:\n"; for (int j=0;j<M;++j) cout<<c[j]/ct[j]<<endl;
     free(ct);
-  }
+  } else
+    errmax = max(err, errmax);
 
   printf("test 1d type 3:\n"); // -------------- type 3
                                // reuse the strengths c, interpret N as number of targs:
@@ -165,8 +165,7 @@ int main(int argc, char *argv[]) {
     Ftr += real(c[j]) * co - imag(c[j]) * si; // cpx arith by hand
     Fti += imag(c[j]) * co + real(c[j]) * si;
   }
-  err    = abs(Ftr + IMA * Fti - F[kt]) / infnorm(N, F);
-  errmax = max(err, errmax);
+  err = abs(Ftr + IMA * Fti - F[kt]) / infnorm(N, F);
   printf("\tone targ: rel err in F[%lld] is %.3g\n", (long long)kt, err);
   if (((int64_t)M) * N <= TEST_BIGPROB) { // also full direct eval
     CPX *Ft = (CPX *)malloc(sizeof(CPX) * N);
@@ -177,7 +176,8 @@ int main(int argc, char *argv[]) {
     // cout<<"s, F, Ft:\n"; for (int k=0;k<N;++k) cout<<s[k]<<"
     // "<<F[k]<<"\t"<<Ft[k]<<"\t"<<F[k]/Ft[k]<<endl;
     free(Ft);
-  }
+  } else
+    errmax = max(err, errmax);
 
   free(x);
   free(c);

--- a/test/finufft2d_test.cpp
+++ b/test/finufft2d_test.cpp
@@ -82,7 +82,6 @@ int main(int argc, char *argv[]) {
   }
   BIGINT it = N1 / 2 + nt1 + N1 * (N2 / 2 + nt2); // index in complex F as 1d array
   err       = abs(Ftr + IMA * Fti - F[it]) / infnorm(N, F);
-  errmax    = max(err, errmax);
   printf("\tone mode: rel err in F[%lld,%lld] is %.3g\n", (long long)nt1, (long long)nt2,
          err);
   if ((int64_t)M * N <= TEST_BIGPROB) { // also check vs full direct eval
@@ -92,7 +91,8 @@ int main(int argc, char *argv[]) {
     errmax = max(err, errmax);
     printf("\tdirft2d: rel l2-err of result F is %.3g\n", err);
     free(Ft);
-  }
+  } else
+    errmax = max(err, errmax);
 
   printf("test 2d type 2:\n"); // -------------- type 2
 #pragma omp parallel
@@ -118,8 +118,7 @@ int main(int argc, char *argv[]) {
     for (BIGINT m1 = -(N1 / 2); m1 <= (N1 - 1) / 2; ++m1)
       ct += F[m++] * exp(IMA * (FLT)isign * (m1 * x[jt] + m2 * y[jt])); // crude
                                                                         // direct
-  err    = abs(ct - c[jt]) / infnorm(M, c);
-  errmax = max(err, errmax);
+  err = abs(ct - c[jt]) / infnorm(M, c);
   printf("\tone targ: rel err in c[%lld] is %.3g\n", (long long)jt, err);
   if ((int64_t)M * N <= TEST_BIGPROB) { // also full direct eval
     CPX *ct = (CPX *)malloc(sizeof(CPX) * M);
@@ -129,7 +128,8 @@ int main(int argc, char *argv[]) {
     printf("\tdirft2d: rel l2-err of result c is %.3g\n", err);
     // cout<<"c,ct:\n"; for (int j=0;j<M;++j) cout<<c[j]<<"\t"<<ct[j]<<endl;
     free(ct);
-  }
+  } else
+    errmax = max(err, errmax);
 
   printf("test 2d type 3:\n"); // -------------- type 3
                                // reuse the strengths c, interpret N as number of targs:
@@ -174,8 +174,7 @@ int main(int argc, char *argv[]) {
     Ftr += real(c[j]) * co - imag(c[j]) * si; // cpx arith by hand
     Fti += imag(c[j]) * co + real(c[j]) * si;
   }
-  err    = abs(Ftr + IMA * Fti - F[kt]) / infnorm(N, F);
-  errmax = max(err, errmax);
+  err = abs(Ftr + IMA * Fti - F[kt]) / infnorm(N, F);
   printf("\tone targ: rel err in F[%lld] is %.3g\n", (long long)kt, err);
   if (((int64_t)M) * N <= TEST_BIGPROB) {     // also full direct eval
     CPX *Ft = (CPX *)malloc(sizeof(CPX) * N);
@@ -186,7 +185,8 @@ int main(int argc, char *argv[]) {
     // cout<<"s t, F, Ft, F/Ft:\n"; for (int k=0;k<N;++k) cout<<s[k]<<" "<<t[k]<<",
     // "<<F[k]<<",\t"<<Ft[k]<<",\t"<<F[k]/Ft[k]<<endl;
     free(Ft);
-  }
+  } else
+    errmax = max(err, errmax);
 
   free(x);
   free(y);

--- a/test/finufft3d_test.cpp
+++ b/test/finufft3d_test.cpp
@@ -89,7 +89,6 @@ int main(int argc, char *argv[]) {
   // index in complex F as 1d array...
   BIGINT it = N1 / 2 + nt1 + N1 * (N2 / 2 + nt2) + N1 * N2 * (N3 / 2 + nt3);
   err       = abs(Ftr + IMA * Fti - F[it]) / infnorm(N, F);
-  errmax    = max(err, errmax);
   printf("\tone mode: rel err in F[%lld,%lld,%lld] is %.3g\n", (long long)nt1,
          (long long)nt2, (long long)nt3, err);
   if ((int64_t)M * N <= TEST_BIGPROB) { // also check vs full direct eval
@@ -99,7 +98,8 @@ int main(int argc, char *argv[]) {
     errmax = max(err, errmax);
     printf("\tdirft3d: rel l2-err of result F is %.3g\n", err);
     free(Ft);
-  }
+  } else
+    errmax = max(err, errmax);
 
   printf("test 3d type 2:\n"); // -------------- type 2
 #pragma omp parallel
@@ -125,8 +125,7 @@ int main(int argc, char *argv[]) {
     for (BIGINT m2 = -(N2 / 2); m2 <= (N2 - 1) / 2; ++m2)
       for (BIGINT m1 = -(N1 / 2); m1 <= (N1 - 1) / 2; ++m1)
         ct += F[m++] * exp(IMA * (FLT)isign * (m1 * x[jt] + m2 * y[jt] + m3 * z[jt]));
-  err    = abs(ct - c[jt]) / infnorm(M, c);
-  errmax = max(err, errmax);
+  err = abs(ct - c[jt]) / infnorm(M, c);
   printf("\tone targ: rel err in c[%lld] is %.3g\n", (long long)jt, err);
   if ((int64_t)M * N <= TEST_BIGPROB) { // also full direct eval
     CPX *ct = (CPX *)malloc(sizeof(CPX) * M);
@@ -135,7 +134,8 @@ int main(int argc, char *argv[]) {
     errmax = max(err, errmax);
     printf("\tdirft3d: rel l2-err of result c is %.3g\n", err);
     free(ct);
-  }
+  } else
+    errmax = max(err, errmax);
 
   printf("test 3d type 3:\n"); // -------------- type 3
                                // reuse the strengths c, interpret N as number of targs:
@@ -185,8 +185,7 @@ int main(int argc, char *argv[]) {
     Ftr += real(c[j]) * co - imag(c[j]) * si; // cpx arith by hand
     Fti += imag(c[j]) * co + real(c[j]) * si;
   }
-  err    = abs(Ftr + IMA * Fti - F[kt]) / infnorm(N, F);
-  errmax = max(err, errmax);
+  err = abs(Ftr + IMA * Fti - F[kt]) / infnorm(N, F);
   printf("\tone targ: rel err in F[%lld] is %.3g\n", (long long)kt, err);
   if (((int64_t)M) * N <= TEST_BIGPROB) {           // also full direct eval
     CPX *Ft = (CPX *)malloc(sizeof(CPX) * N);
@@ -197,7 +196,8 @@ int main(int argc, char *argv[]) {
     // cout<<"s t u, F, Ft, F/Ft:\n"; for (int k=0;k<N;++k) cout<<s[k]<<" "<<t[k]<<"
     // "<<u[k]<<", "<<F[k]<<",\t"<<Ft[k]<<",\t"<<F[k]/Ft[k]<<endl;
     free(Ft);
-  }
+  } else
+    errmax = max(err, errmax);
 
   free(x);
   free(y);


### PR DESCRIPTION
This should fix indeterminacy with DUCC / fastmath/ OSX, etc, and in general less random failures.

There is no way to apply this to the "many" tests, since they don't have the l2 err metric (we could create a different threshold for them?) They also can't be applied to basicpassfail, unless we implement the direct transform there too, but that has a fixed seed and deterministic rand generation, so should be less susceptible.
