### PR TITLE
Remove CMAKE_CUDA_ARCHS and fix builds for multiple CUDA architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,9 +280,9 @@ if(FINUFFT_USE_CPU)
 endif()
 
 if(FINUFFT_USE_CUDA)
-  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  if(NOT DEFINED FINUFFT_CUDA_ARCHITECTURES)
     message(
-      "FINUFFT WARNING: No CUDA architecture supplied via '-DCMAKE_CUDA_ARCHITECTURES=...', defaulting to 'native'"
+      "FINUFFT WARNING: No CUDA architecture supplied via '-DFINUFFT_CUDA_ARCHITECTURES=...', defaulting to 'native'"
     )
     message(
       "See: https://developer.nvidia.com/cuda-gpus for more details on what architecture to supply."

--- a/perftest/cuda/CMakeLists.txt
+++ b/perftest/cuda/CMakeLists.txt
@@ -5,6 +5,6 @@ target_compile_features(cuperftest PRIVATE cxx_std_17)
 set_target_properties(
   cuperftest
   PROPERTIES LINKER_LANGUAGE CUDA
-             CUDA_ARCHITECTURES ${FINUFFT_CUDA_ARCHITECTURES}
+             CUDA_ARCHITECTURES "${FINUFFT_CUDA_ARCHITECTURES}"
              CUDA_STANDARD 17
              CUDA_STANDARD_REQUIRED ON)

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(cufinufft_common_objects
 set_target_properties(
   cufinufft_common_objects
   PROPERTIES POSITION_INDEPENDENT_CODE ${FINUFFT_SHARED_LINKING}
-             CUDA_ARCHITECTURES ${FINUFFT_CUDA_ARCHITECTURES}
+             CUDA_ARCHITECTURES "${FINUFFT_CUDA_ARCHITECTURES}"
              CUDA_SEPARABLE_COMPILATION ON
              CUDA_STANDARD 17
              CUDA_STANDARD_REQUIRED ON)
@@ -60,7 +60,7 @@ target_include_directories(cufinufft_objects PUBLIC ${CUFINUFFT_INCLUDE_DIRS})
 set_target_properties(
   cufinufft_objects
   PROPERTIES POSITION_INDEPENDENT_CODE ${FINUFFT_SHARED_LINKING}
-             CUDA_ARCHITECTURES ${FINUFFT_CUDA_ARCHITECTURES}
+             CUDA_ARCHITECTURES "${FINUFFT_CUDA_ARCHITECTURES}"
              CUDA_SEPARABLE_COMPILATION ON
              CUDA_STANDARD 17
              CUDA_STANDARD_REQUIRED ON)

--- a/test/cuda/CMakeLists.txt
+++ b/test/cuda/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(srcfile ${test_src})
   target_compile_features(${executable} PUBLIC cxx_std_17)
   set_target_properties(
     ${executable} PROPERTIES LINKER_LANGUAGE CUDA CUDA_ARCHITECTURES
-                                                  ${FINUFFT_CUDA_ARCHITECTURES})
+                                                  "${FINUFFT_CUDA_ARCHITECTURES}")
   message(STATUS "Adding test ${executable}"
                  " with CUDA_ARCHITECTURES=${FINUFFT_CUDA_ARCHITECTURES}"
                  " and INCLUDE=${CUFINUFFT_INCLUDE_DIRS}")


### PR DESCRIPTION
This pull request removes the warning `"FINUFFT WARNING: No CUDA architecture supplied via '-DCMAKE_CUDA_ARCHITECTURES=...', defaulting to 'native'"` occuring if we use `FINUFFT_CUDA_ARCHITECTURES` to specify the target CUDA architectures. Further, passing multiple architectures as in building cufinufft for julia [JuliaPackaging/Yggdrasil/C/cufinufft/build_tarballs.j](https://github.com/JuliaPackaging/Yggdrasil/blob/master/C/cufinufft/build_tarballs.jl) should now work again.

Cheers
Jonas