### PR TITLE
Include fftw3 as a dep for fortran examples

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -1,14 +1,16 @@
-add_library(directft OBJECT
-    directft/dirft1d.f directft/dirft1df.f
-    directft/dirft2d.f directft/dirft2df.f
-    directft/dirft3d.f directft/dirft3df.f)
+add_library(
+  directft OBJECT directft/dirft1d.f directft/dirft1df.f directft/dirft2d.f
+                  directft/dirft2df.f directft/dirft3d.f directft/dirft3df.f)
 
-set(FORTRAN_EXAMPLES guru1d1 nufft1d_demo nufft2d_demo nufft2dmany_demo nufft3d_demo simple1d1)
+set(FORTRAN_EXAMPLES guru1d1 nufft1d_demo nufft2d_demo nufft2dmany_demo
+                     nufft3d_demo simple1d1)
 
 foreach(EXAMPLE ${FORTRAN_EXAMPLES})
-    add_executable(fort_${EXAMPLE} examples/${EXAMPLE}.f)
-    add_executable(fort_${EXAMPLE}f examples/${EXAMPLE}f.f)
+  add_executable(fort_${EXAMPLE} examples/${EXAMPLE}.f)
+  add_executable(fort_${EXAMPLE}f examples/${EXAMPLE}f.f)
 
-    target_link_libraries(fort_${EXAMPLE} PRIVATE directft finufft)
-    target_link_libraries(fort_${EXAMPLE}f PRIVATE directft finufft)
+  target_link_libraries(fort_${EXAMPLE} PRIVATE directft finufft
+                                                ${FINUFFT_FFTLIBS})
+  target_link_libraries(fort_${EXAMPLE}f PRIVATE directft finufft
+                                                 ${FINUFFT_FFTLIBS})
 endforeach()


### PR DESCRIPTION
Currently, we get the following error when trying to build with `FINUFFT_BUILD_FORTRAN=ON`:
```
[ 48%] Building Fortran object fortran/CMakeFiles/fort_guru1d1.dir/examples/guru1d1.f.o
cd /home/janden/projects/finufft/build/fortran && /usr/bin/gfortran  -I/home/janden/projects/finufft/include -O3 -c /home/janden/projects/finufft/fortran/examples/guru1d1.f -o CMakeFiles/fort_guru1d1.dir/examples/guru1d1.f.o
/home/janden/projects/finufft/fortran/examples/guru1d1.f:19: Error: Can't open included file 'fftw3.f'
```

This PR fixes this by explicitly including `FINUFFT_FFTLIBS` as a linked library for the examples.

Note: There is a lot of noise here due to the cmake-format hook which forces reformatting. Perhaps it would be good to do this across all CMakeLists.txt in a single commit?