### PR TITLE
Make cufinufft version dynamic

### DIFF
--- a/python/cufinufft/pyproject.toml
+++ b/python/cufinufft/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "cufinufft"
 description = "Non-uniform fast Fourier transforms on the GPU"
-version = "2.2.0"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = ["numpy"]
@@ -31,6 +30,7 @@ classifiers = [
     "Environment :: GPU",
     "Topic :: Scientific/Engineering :: Mathematics"
     ]
+dynamic = ["version"]
 
 [tool.scikit-build]
 # Protect the configuration against future changes in scikit-build-core
@@ -47,3 +47,8 @@ wheel.packages = ["cufinufft"]
 
 # Indicate that we don't depend on the CPython API
 wheel.py-api = "py3"
+
+[tool.scikit-build.metadata.version]
+# Instead of hardcoding the version here, extract it from the source files.
+provider = "scikit_build_core.metadata.regex"
+input = "cufinufft/__init__.py"


### PR DESCRIPTION
Instead of hardcoding it in pyproject.toml, have it read (using regex) from cufinufft/__init__.py. This way we have a single source of truth for the cuFinufft Python version.