### PR TITLE
Do not compile Python wheels with -march=native

### DIFF
--- a/python/cufinufft/pyproject.toml
+++ b/python/cufinufft/pyproject.toml
@@ -41,7 +41,10 @@ build-dir = "build/{wheel_tag}"
 # Tell skbuild to look for the CMakeLists.txt file two directories up.
 cmake.source-dir = "../../"
 cmake.targets = ["cufinufft"]
-cmake.define = {"FINUFFT_BUILD_PYTHON" = "ON", "FINUFFT_USE_CUDA" = "ON", "FINUFFT_USE_CPU" = "OFF"}
+cmake.define.FINUFFT_BUILD_PYTHON = "ON"
+cmake.define.FINUFFT_USE_CUDA = "ON"
+cmake.define.FINUFFT_USE_CPU = "OFF"
+cmake.define.FINUFFT_ARCH_FLAGS = ""        # Disable -march=native (default)
 
 wheel.packages = ["cufinufft"]
 

--- a/python/finufft/pyproject.toml
+++ b/python/finufft/pyproject.toml
@@ -41,7 +41,8 @@ build-dir = "build/{wheel_tag}"
 # Tell skbuild to look for the CMakeLists.txt file two directories up.
 cmake.source-dir = "../../"
 cmake.targets = ["finufft"]
-cmake.define = {"FINUFFT_BUILD_PYTHON" = "ON"}
+cmake.define.FINUFFT_BUILD_PYTHON = "ON"
+cmake.define.FINUFFT_ARCH_FLAGS = ""        # Disable -march=native (default)
 
 wheel.packages = ["finufft"]
 


### PR DESCRIPTION
This will give a slight performance hit, but ensure that our wheels are able to run on older CPUs. If a user needs the increased performance that comes with `-march=native`, we ask them to compile the package from source.