### PR TITLE
Fix logging bug caused by np.distutils

### DIFF
--- a/python/cufinufft/cufinufft/_cufinufft.py
+++ b/python/cufinufft/cufinufft/_cufinufft.py
@@ -13,6 +13,8 @@ import pathlib
 import numpy as np
 from ctypes.util import find_library
 
+from packaging.version import Version
+
 from ctypes import c_double
 from ctypes import c_int
 from ctypes import c_int64
@@ -22,6 +24,16 @@ from ctypes import c_void_p
 c_int64_p = ctypes.POINTER(c_int64)
 c_float_p = ctypes.POINTER(c_float)
 c_double_p = ctypes.POINTER(c_double)
+
+
+# numpy.distutils has a bug that changes the logging level from under us. As a
+# workaround, we save it and reset it later. This only happens on older
+# versions of NumPy, so let's check the version before doing this.
+reset_log_level = Version(np.__version__) < Version("1.25")
+
+if reset_log_level:
+    import logging
+    log_level = logging.root.level
 
 lib = None
 # Try to load the library as installed in the Python package.
@@ -34,6 +46,9 @@ for lib_name in library_names:
     except OSError:
         # Paranoid, in case lib is set to something and then an exception is thrown
         lib = None
+
+if reset_log_level:
+    logging.root.setLevel(log_level)
 
 if lib is None:
     # If that fails, try to load the library from the system path.

--- a/python/finufft/finufft/_finufft.py
+++ b/python/finufft/finufft/_finufft.py
@@ -19,10 +19,21 @@ import os
 import platform
 from numpy.ctypeslib import ndpointer
 
+from packaging.version import Version
+
 c_int_p = ctypes.POINTER(c_int)
 c_float_p = ctypes.POINTER(c_float)
 c_double_p = ctypes.POINTER(c_double)
 c_longlong_p = ctypes.POINTER(c_longlong)
+
+# numpy.distutils has a bug that changes the logging level from under us. As a
+# workaround, we save it and reset it later. This only happens on older
+# versions of NumPy, so let's check the version before doing this.
+reset_log_level = Version(np.__version__) < Version("1.25")
+
+if reset_log_level:
+    import logging
+    log_level = logging.root.level
 
 # TODO: See if there is a way to improve this so it is less hacky.
 lib = None
@@ -39,6 +50,9 @@ for lib_name in library_names:
     except OSError:
         # Paranoid, in case lib is set to something and then an exception is thrown
         lib = None
+
+if reset_log_level:
+    logging.root.setLevel(log_level)
 
 if lib is None:
     # If that fails, try to load the library from the system path.


### PR DESCRIPTION
For older (<1.25) versions of NumPy, calling `np.ctypeslib.load_library` results in the logging level being reset. This workaround checks for that bug and preserves the logging level.

Incorporates fix suggested by @lu1and10 in https://github.com/ComputationalCryoEM/ASPIRE-Python/pull/1168#issuecomment-2322349795