### PR TITLE
Solve issues with Python wheel building

### DIFF
--- a/.github/workflows/python_build_wheels.yml
+++ b/.github/workflows/python_build_wheels.yml
@@ -92,11 +92,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.2
         with:
           package-dir: 'python/finufft'
-        env:
-          # This is required to force cmake to avoid using MSVC (the default).
-          # By setting the generator to Ninja, cmake will pick gcc (mingw64)
-          # as the compiler.
-          CIBW_CONFIG_SETTINGS: "cmake.args='-G Ninja'"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/python/finufft/pyproject.toml
+++ b/python/finufft/pyproject.toml
@@ -60,7 +60,12 @@ build-verbosity = 1
 skip = "pp* *musllinux*"
 test-requires = ["pytest", "pytest-mock"]
 test-command = "pytest {project}/python/finufft/test"
-config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = ""}
+
+# Ensure that the wheels are compatible with x86-64. Without this, they crash
+# in x86_64 compatibility mode (Rosetta 2) on macOS.
+config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "-march=x86-64", "cmake.define.CMAKE_VERBOSE_MAKEFILE" = "ON"}
+
+# TODO: CIBW crashes when we try to make config-settings above into a table. Why?
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"
@@ -72,3 +77,14 @@ before-build = "pip install delvewheel"
 # CIBW doesn't do vendoring of DLLs on Windows by default, so we have to
 # install delvewheel and run it.
 repair-wheel-command = "delvewheel repair -v --analyze-existing -w {dest_dir} {wheel}"
+# Need to repeat this here as the platform-specific config-settings overwrite
+# the general ones.
+# The last setting is required to force cmake to avoid using MSVC (the
+# default). By setting the generator to Ninja, cmake will pick gcc (mingw64) as
+# the compiler.
+config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "-march=x86-64", "cmake.define.CMAKE_VERBOSE_MAKEFILE" = "ON", "cmake.args" = "-G Ninja"}
+
+[[tool.cibuildwheel.overrides]]
+select = "*arm64*"
+# Don't enforce x84_64 when building on arm64.
+config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "", "cmake.define.CMAKE_VERBOSE_MAKEFILE" = "ON"}

--- a/python/finufft/pyproject.toml
+++ b/python/finufft/pyproject.toml
@@ -87,4 +87,4 @@ config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "-march=x86-64", "cmake.d
 [[tool.cibuildwheel.overrides]]
 select = "*arm64*"
 # Don't enforce x84_64 when building on arm64.
-config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "", "cmake.define.CMAKE_VERBOSE_MAKEFILE" = "ON"}
+config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "-mcpu=apple-m3", "cmake.define.CMAKE_VERBOSE_MAKEFILE" = "ON"}


### PR DESCRIPTION
This PR does a few things:
* Make cmake output a verbose makefile that tells us what commands are actually run.
* Move some of the CIBW config settings for Windows into pyproject.toml.
* Force wheels to be built with `-march=x86_64` to enhance compatibility (this seems to be an issue in particular running wheels on macOS with x86_64 compatibility mode on ARM chips). This excludes the macOS arm64 wheels, of course.