### PR TITLE
Update cufinufft wheel building scripts

### DIFF
--- a/tools/cufinufft/distribution_helper.sh
+++ b/tools/cufinufft/distribution_helper.sh
@@ -2,17 +2,17 @@
 
 # Helper Script For Building Wheels
 
-cufinufft_version=2.2
 manylinux_version=manylinux2014
-cuda_version=11.0
+cuda_version=11.2
 dockerhub=janden
 
+image_name=cufinufft-cuda${cuda_version}
 
 echo "# Build the docker image"
 docker build \
     --file tools/cufinufft/docker/cuda${cuda_version}/Dockerfile-x86_64 \
-    --tag ${dockerhub}/cufinufft-${cufinufft_version}-${manylinux_version} .
-
+    --tag ${dockerhub}/cufinufft-cuda${cuda_version} \
+    .
 
 echo "# Create the container and start it"
 docker create \
@@ -20,50 +20,41 @@ docker create \
     --interactive \
     --tty \
     --volume $(pwd)/wheelhouse:/io/wheelhouse \
-    --env PLAT=${manylinux_version}_x86_64 \
-    --env LIBRARY_PATH="/io/build" \
-    --env LD_LIBRARY_PATH="/io/build" \
-    --name cufinufft \
-    ${dockerhub}/cufinufft-${cufinufft_version}-${manylinux_version}
+    --name ${image_name} \
+    ${dockerhub}/${image_name}
 
-docker start cufinufft
+docker start ${image_name}
 
-echo "# Copy the code and build the library"
-docker cp . cufinufft:/io
-docker exec cufinufft /io/tools/cufinufft/build-library.sh
+echo "# Copy the code"
+docker cp . ${image_name}:/io
 
 echo "# Build the wheels"
-docker exec cufinufft /io/tools/cufinufft/build-wheels.sh
+docker exec ${image_name} \
+    python3 -m pip wheel \
+    --verbose \
+    /io/python/cufinufft \
+    --config-settings=cmake.define.FINUFFT_CUDA_ARCHITECTURES="50;60;70;80" \
+    --config-settings=cmake.define.CMAKE_CUDA_FLAGS="-Wno-deprecated-gpu-targets" \
+    --config-settings=cmake.define.FINUFFT_ARCH_FLAGS="" \
+    --config-settings=cmake.define.CMAKE_VERBOSE_MAKEFILE=ON \
+    --no-deps \
+    --wheel-dir /io/wheelhouse
+
+wheel_name=$(docker exec ${image_name} bash -c 'ls /io/wheelhouse/cufinufft-*-linux_x86_64.whl')
+
+echo "# Repair the wheels"
+docker exec ${image_name} \
+    python3 -m auditwheel repair \
+    ${wheel_name} \
+    --plat manylinux2014_x86_64 \
+    --wheel-dir /io/wheelhouse/
 
 echo "# Shut down the container and remove it"
-docker stop cufinufft
-docker rm cufinufft
+docker stop ${image_name}
+docker rm ${image_name}
 
 echo "# Copy the wheels we care about to the dist folder"
 mkdir -p dist
-cp -v wheelhouse/cufinufft-${cufinufft_version}-cp3*${manylinux_version}* dist
+cp -v wheelhouse/cufinufft-*${manylinux_version}* dist
 
-echo "The following steps should be performed manually for now.\n"
-
-echo "# Push to Test PyPI for review/testing"
-echo "#twine upload -r testpypi dist/*"
-echo
-
-
-echo "# Tag release."
-## Can do in a repo and push or on manually on GH gui.
-echo
-
-
-echo "# Review wheels from test index"
-echo "#pip install -i https://test.pypi.org/simple/ --no-deps cufinufft"
-echo
-
-
-echo "# Push to live index"
-echo "## twine upload dist/*"
-echo
-
-
-echo "# optionally push it (might take a long time)."
-echo "#docker push ${dockerhub}/cufinufft-${cufinufft_version}-${manylinux_version}"
+# TODO: Test installing the wheels and running pytest.

--- a/tools/cufinufft/docker/README
+++ b/tools/cufinufft/docker/README
@@ -1,0 +1,5 @@
+These configurations are based off of manylinux2014, which is itself based off
+of centos8.
+
+These images extend manylinux with a compatible CUDA toolkit and runtime
+environment suitable for both building and running code inside docker.

--- a/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
@@ -64,4 +64,11 @@ RUN yum install -y \
         cmake && \
     rm -rf /var/cache/yum/*
 
+# pick py312 as default
+RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
+
+# upgrade pip, install auditwheel
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade auditwheel
+
 CMD ["/bin/bash"]

--- a/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
@@ -63,3 +63,5 @@ ENV PATH /opt/rh/devtoolset-9/root/usr/bin:${PATH}
 RUN yum install -y \
         cmake && \
     rm -rf /var/cache/yum/*
+
+CMD ["/bin/bash"]

--- a/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
@@ -68,7 +68,7 @@ RUN yum install -y \
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
 
 # upgrade pip, install auditwheel
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --upgrade auditwheel
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    python3 -m pip install --no-cache-dir --upgrade auditwheel
 
 CMD ["/bin/bash"]

--- a/tools/cufinufft/docker/cuda11.2/README
+++ b/tools/cufinufft/docker/cuda11.2/README
@@ -1,6 +1,0 @@
-This configuration is based off of manylinux2014,
-which is iteself based off of centos8.
-
-I have extended manylinux with a compatible CUDA
-toolkit and runtime environment suitable for
-both building and running code inside docker.

--- a/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
@@ -64,4 +64,11 @@ RUN yum install -y \
         cmake && \
     rm -rf /var/cache/yum/*
 
+# pick py312 as default
+RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
+
+# upgrade pip, install auditwheel
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade auditwheel
+
 CMD ["/bin/bash"]

--- a/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
@@ -1,16 +1,8 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 LABEL maintainer "Joakim Andén"
 
-ENV CUDA_MAJOR 12
-ENV CUDA_MINOR 0
-
-ENV CUDART_VERSION 12.0.146
-ENV CUFFT_VERSION 11.0.1.95
-ENV CURAND_VERSION 10.3.1.124
-ENV PROFILER_VERSION 12.0.140
-ENV NVTX_VERSION 12.0.140
-ENV NVCC_VERSION 12.0.140
-
+ENV CUDA_MAJOR 11
+ENV CUDA_MINOR 8
 ENV CUDA_DASH_VERSION ${CUDA_MAJOR}-${CUDA_MINOR}
 ENV CUDA_DOT_VERSION ${CUDA_MAJOR}.${CUDA_MINOR}
 
@@ -24,7 +16,7 @@ COPY tools/cufinufft/docker/cuda${CUDA_DOT_VERSION}/cuda.repo /etc/yum.repos.d/c
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum install -y \
-        cuda-cudart-${CUDA_DASH_VERSION}-${CUDART_VERSION}-1 \
+        cuda-cudart-${CUDA_DASH_VERSION} \
         cuda-compat-${CUDA_DASH_VERSION} && \
     ln -s cuda-${CUDA_DOT_VERSION} /usr/local/cuda && \
     rm -rf /var/cache/yum/*
@@ -43,23 +35,29 @@ ENV NVIDIA_REQUIRE_CUDA "cuda>=${CUDA_DOT_VERSION} brand=tesla,driver>=418,drive
 
 # runtime
 RUN yum install -y \
-        libcufft-${CUDA_DASH_VERSION}-${CUFFT_VERSION}-1 \
-        libcurand-${CUDA_DASH_VERSION}-${CURAND_VERSION}-1 \
-        cuda-nvtx-${CUDA_DASH_VERSION}-${NVTX_VERSION}-1 && \
+        cuda-libraries-${CUDA_DASH_VERSION} \
+        cuda-nvtx-${CUDA_DASH_VERSION} && \
     rm -rf /var/cache/yum/*
 
 # devel
 RUN yum install -y \
-        cuda-cudart-devel-${CUDA_DASH_VERSION}-${CUDART_VERSION}-1 \
-        libcufft-devel-${CUDA_DASH_VERSION}-${CUFFT_VERSION}-1 \
-        libcurand-devel-${CUDA_DASH_VERSION}-${CURAND_VERSION}-1 \
-        cuda-profiler-api-${CUDA_DASH_VERSION}-${PROFILER_VERSION}-1 \
-        cuda-nvcc-${CUDA_DASH_VERSION}-${NVCC_VERSION}-1 && \
+        cuda-cudart-devel-${CUDA_DASH_VERSION} \
+        cuda-libraries-devel-${CUDA_DASH_VERSION} \
+        cuda-nvprof-${CUDA_DASH_VERSION} \
+        cuda-nvcc-${CUDA_DASH_VERSION} && \
     rm -rf /var/cache/yum/*
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
 # /CUDA #
+
+# CUDA 11 doesn't work on gcc/g++ newer than v9
+RUN yum install -y \
+        devtoolset-9-gcc \
+        devtoolset-9-gcc-c++ && \
+    rm -rf /var/cache/yum/*
+
+ENV PATH /opt/rh/devtoolset-9/root/usr/bin:${PATH}
 
 # finufft reqs
 RUN yum install -y \

--- a/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
@@ -68,7 +68,7 @@ RUN yum install -y \
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
 
 # upgrade pip, install auditwheel
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --upgrade auditwheel
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    python3 -m pip install --no-cache-dir --upgrade auditwheel
 
 CMD ["/bin/bash"]

--- a/tools/cufinufft/docker/cuda11.8/cuda.repo
+++ b/tools/cufinufft/docker/cuda11.8/cuda.repo
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/tools/cufinufft/docker/cuda12.0/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda12.0/Dockerfile-x86_64
@@ -66,4 +66,11 @@ RUN yum install -y \
         cmake && \
     rm -rf /var/cache/yum/*
 
+# pick py312 as default
+RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
+
+# upgrade pip, install auditwheel
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade auditwheel
+
 CMD ["/bin/bash"]

--- a/tools/cufinufft/docker/cuda12.0/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda12.0/Dockerfile-x86_64
@@ -70,7 +70,7 @@ RUN yum install -y \
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
 
 # upgrade pip, install auditwheel
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --upgrade auditwheel
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    python3 -m pip install --no-cache-dir --upgrade auditwheel
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
This brings the cufinufft wheel building up to date with the new skbuild-based approach. To build the wheels, make sure docker is installed and run `tools/cufinufft/distribution_helper.sh`. The wheels should then end up in `dist`.