### PR TITLE
ci: tag all manylinux docker images

### DIFF
--- a/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.2/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64:2024-09-09-f386546
 LABEL maintainer "Joakim Andén"
 
 ENV CUDA_MAJOR 11

--- a/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda11.8/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64:2024-09-09-f386546
 LABEL maintainer "Joakim Andén"
 
 ENV CUDA_MAJOR 11

--- a/tools/cufinufft/docker/cuda12.0/Dockerfile-x86_64
+++ b/tools/cufinufft/docker/cuda12.0/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64:2024-09-09-f386546
 LABEL maintainer "Joakim Andén"
 
 ENV CUDA_MAJOR 12

--- a/tools/finufft/docker/Dockerfile-x86_64
+++ b/tools/finufft/docker/Dockerfile-x86_64
@@ -7,7 +7,7 @@
 # instead of building from source.
 
 
-FROM quay.io/pypa/manylinux2010_x86_64
+FROM quay.io/pypa/manylinux2010_x86_64:2024-09-09-f386546
 LABEL maintainer "Libin Lu"
 
 RUN set -e -x


### PR DESCRIPTION
in jenkins, `image:latest` won't know to automatically update itself, so can run an old cached version. This is likely causing issues with invalid `python3` commands.

https://github.com/flatironinstitute/finufft/pull/549#issuecomment-2338504811
