### PR TITLE
Simplify building of Python source distributions

### DIFF
--- a/python/cufinufft/pyproject.toml
+++ b/python/cufinufft/pyproject.toml
@@ -38,7 +38,7 @@ minimum-version = "0.4"
 # Setuptools-style build caching in a local directory
 build-dir = "build/{wheel_tag}"
 
-# Tell skbuild to look for the CMakeLists.txt file two directories up.
+# Tell skbuild to where to find CMakeLists.txt.
 cmake.source-dir = "../../"
 cmake.targets = ["cufinufft"]
 cmake.define = {"FINUFFT_BUILD_PYTHON" = "ON", "FINUFFT_USE_CUDA" = "ON", "FINUFFT_USE_CPU" = "OFF"}
@@ -47,6 +47,27 @@ wheel.packages = ["cufinufft"]
 
 # Indicate that we don't depend on the CPython API
 wheel.py-api = "py3"
+
+sdist.exclude = [".*",
+                 "CMakePresets.json",
+                 "contributing.md",
+                 "CHANGELOG",
+                 "devel",
+                 "docs",
+                 "examples",
+                 "fortran",
+                 "Jenkinsfile",
+                 "lib*",
+                 "make*",
+                 "matlab",
+                 "perftest",
+                 "test",
+                 "tools",
+                 "tutorial",
+                 "python/finufft",
+                 "python/cufinufft/tests",
+                 "src"]
+sdist.include = ["src/cuda"]
 
 [tool.scikit-build.metadata.version]
 # Instead of hardcoding the version here, extract it from the source files.

--- a/python/finufft/pyproject.toml
+++ b/python/finufft/pyproject.toml
@@ -38,7 +38,7 @@ minimum-version = "0.4"
 # Setuptools-style build caching in a local directory
 build-dir = "build/{wheel_tag}"
 
-# Tell skbuild to look for the CMakeLists.txt file two directories up.
+# Tell skbuild to where to find CMakeLists.txt.
 cmake.source-dir = "../../"
 cmake.targets = ["finufft"]
 cmake.define = {"FINUFFT_BUILD_PYTHON" = "ON"}
@@ -47,6 +47,26 @@ wheel.packages = ["finufft"]
 
 # Indicate that we don't depend on the CPython API
 wheel.py-api = "py3"
+
+sdist.exclude = [".*",
+                 "CMakePresets.json",
+                 "contributing.md",
+                 "CHANGELOG",
+                 "devel",
+                 "docs",
+                 "examples",
+                 "fortran",
+                 "Jenkinsfile",
+                 "lib*",
+                 "make*",
+                 "matlab",
+                 "perftest",
+                 "test",
+                 "tools",
+                 "tutorial",
+                 "include/cufinufft*",
+                 "python/cufinufft",
+                 "src/cuda"]
 
 [tool.scikit-build.metadata.version]
 # Instead of hardcoding the version here, extract it from the source files.

--- a/tools/common/docker/Dockerfile-x86_64
+++ b/tools/common/docker/Dockerfile-x86_64
@@ -1,0 +1,13 @@
+FROM quay.io/pypa/manylinux2014_x86_64:2024-09-09-f386546
+LABEL maintainer "Joakim Andén"
+
+ENV PATH /opt/python/cp312-cp312/bin:${PATH}
+
+RUN pip install --root-user-action ignore --no-cache-dir --upgrade pip
+RUN pip install --root-user-action ignore --no-cache-dir --upgrade build toml-cli
+
+COPY . /io/finufft
+
+WORKDIR /io
+
+CMD ["/bin/bash"]

--- a/tools/common/sdist-helper.sh
+++ b/tools/common/sdist-helper.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+dockerhub=janden
+image=finufft-sdist
+
+docker build --file tools/common/docker/Dockerfile-x86_64 \
+             --tag ${dockerhub}/${image} \
+             .
+
+docker run --volume $(pwd)/wheelhouse:/io/wheelhouse \
+           ${dockerhub}/${image} \
+           /io/finufft/tools/finufft/build-sdist.sh
+
+docker run --volume $(pwd)/wheelhouse:/io/wheelhouse \
+           ${dockerhub}/${image} \
+           /io/finufft/tools/cufinufft/build-sdist.sh

--- a/tools/cufinufft/build-sdist.sh
+++ b/tools/cufinufft/build-sdist.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+# Move pyproject.toml to root (otherwise no way to include C++ sources in sdist).
+mv finufft/python/cufinufft/pyproject.toml finufft/
+
+# Fix paths in pyproject.toml to reflect the new directory structure.
+toml set --toml-path finufft/pyproject.toml \
+         tool.scikit-build.cmake.source-dir "."
+toml set --toml-path finufft/pyproject.toml \
+         tool.scikit-build.wheel.packages --to-array "[\"python/cufinufft/cufinufft\"]"
+toml set --toml-path finufft/pyproject.toml \
+         tool.scikit-build.metadata.version.input "python/cufinufft/cufinufft/__init__.py"
+
+# Package the sdist.
+python3 -m build --verbose --sdist --outdir wheelhouse finufft

--- a/tools/finufft/build-sdist.sh
+++ b/tools/finufft/build-sdist.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+# Move pyproject.toml to root (otherwise no way to include C++ sources in sdist).
+mv finufft/python/finufft/pyproject.toml finufft/
+
+# Fix paths in pyproject.toml to reflect the new directory structure.
+toml set --toml-path finufft/pyproject.toml \
+         tool.scikit-build.cmake.source-dir "."
+toml set --toml-path finufft/pyproject.toml \
+         tool.scikit-build.wheel.packages --to-array "[\"python/finufft/finufft\"]"
+toml set --toml-path finufft/pyproject.toml \
+         tool.scikit-build.metadata.version.input "python/finufft/finufft/__init__.py"
+
+# Package the sdist.
+python3 -m build --verbose --sdist --outdir wheelhouse finufft


### PR DESCRIPTION
This standardizes the creation of Python source distributions (sdists) using Docker and a few scripts.

Note that we cannot do this “the easy way” because to build an sdist, `pyproject.toml` has to be in the root (for us, it's in `python/finufft` or `python/cufinufft` depending on the package). So we have to move one of them to the root directory and call `build`. This also means that some of the relative paths have to be updated.

At any rate, these scripts should simplify the process. We may want to automate this completely at some later point by including it in the CI.