### PR TITLE
Automatically set method for GPU type 3

### DIFF
--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -74,7 +74,7 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
   using namespace cufinufft::common;
   int ier;
   if (type < 1 || type > 3) {
-    fprintf(stderr, "[%s] Invalid type (%d): should be 1 or 2.\n", __func__, type);
+    fprintf(stderr, "[%s] Invalid type (%d): should be 1, 2, or 3.\n", __func__, type);
     return FINUFFT_ERR_TYPE_NOTVALID;
   }
   if (ntransf < 1) {

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -198,8 +198,9 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
   }
 
   // Default to method 1 for type 3.
-  if (type == 3 && d_plan->opts.gpu_method == 0)
+  if (type == 3 && d_plan->opts.gpu_method == 0) {
       d_plan->opts.gpu_method = 1;
+  }
 
   if (type == 1 || type == 2) {
     CUFINUFFT_BIGINT nf1 = 1, nf2 = 1, nf3 = 1;

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -228,7 +228,8 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
     }
   }
 
-  if ((ier = cudaGetLastError())) {
+  if (cudaGetLastError() != cudaSuccess) {
+    ier = FINUFFT_ERR_CUDA_FAILURE;
     goto finalize;
   }
 

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -178,7 +178,8 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
   }
 
   cufinufft_setup_binsize<T>(type, d_plan->spopts.nspread, dim, &d_plan->opts);
-  if (ier = cudaGetLastError(), ier != cudaSuccess) {
+  if (cudaGetLastError() != cudaSuccess) {
+    ier = FINUFFT_ERR_CUDA_FAILURE;
     goto finalize;
   }
   if (d_plan->opts.debug) {

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -196,6 +196,10 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
     printf("[cufinufft] shared memory required for the spreader: %ld\n", mem_required);
   }
 
+  // Default to method 1 for type 3.
+  if (type == 3 && d_plan->opts.gpu_method == 0)
+      d_plan->opts.gpu_method = 1;
+
   if (type == 1 || type == 2) {
     CUFINUFFT_BIGINT nf1 = 1, nf2 = 1, nf3 = 1;
     set_nf_type12(d_plan->ms, d_plan->opts, d_plan->spopts, &nf1,

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -801,7 +801,7 @@ int cufinufft_setpts_impl(int M, T *d_kx, T *d_ky, T *d_kz, int N, T *d_s, T *d_
     int t2modes[]               = {d_plan->nf1, d_plan->nf2, d_plan->nf3};
     cufinufft_opts t2opts       = d_plan->opts;
     t2opts.gpu_spreadinterponly = 0;
-    t2opts.gpu_method           = 1;
+    t2opts.gpu_method           = 0;
     // Safe to ignore the return value here?
     if (d_plan->t2_plan) cufinufft_destroy_impl(d_plan->t2_plan);
     // check that maxbatchsize is correct

--- a/test/cuda/CMakeLists.txt
+++ b/test/cuda/CMakeLists.txt
@@ -21,6 +21,10 @@ foreach(srcfile ${test_src})
 endforeach()
 
 function(add_tests PREC REQ_TOL CHECK_TOL UPSAMP)
+  add_test(NAME cufinufft1d1_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft1d_test 0 1 1e2 2e2 ${REQ_TOL} ${CHECK_TOL} ${PREC}
+                   ${UPSAMP})
+
   add_test(NAME cufinufft1d1_test_GM_${PREC}_${UPSAMP}
            COMMAND cufinufft1d_test 1 1 1e2 2e2 ${REQ_TOL} ${CHECK_TOL} ${PREC}
                    ${UPSAMP})
@@ -29,12 +33,25 @@ function(add_tests PREC REQ_TOL CHECK_TOL UPSAMP)
            COMMAND cufinufft1d_test 2 1 1e2 2e2 ${REQ_TOL} ${CHECK_TOL} ${PREC}
                    ${UPSAMP})
 
+  add_test(NAME cufinufft1d2_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft1d_test 0 2 1e2 2e2 ${REQ_TOL} ${CHECK_TOL} ${PREC}
+                   ${UPSAMP})
+
   add_test(NAME cufinufft1d2_test_GM_${PREC}_${UPSAMP}
            COMMAND cufinufft1d_test 1 2 1e2 2e2 ${REQ_TOL} ${CHECK_TOL} ${PREC}
                    ${UPSAMP})
+
+  add_test(NAME cufinufft1d3_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft1d_test 0 3 1e2 2e2 ${REQ_TOL} ${CHECK_TOL} ${PREC}
+                   ${UPSAMP})
+
   add_test(NAME cufinufft1d3_test_GM_${PREC}_${UPSAMP}
            COMMAND cufinufft1d_test 1 3 1e2 2e2 ${REQ_TOL} ${CHECK_TOL} ${PREC}
                    ${UPSAMP})
+
+  add_test(NAME cufinufft2d1_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft2d_test 0 1 1e2 2e2 2e4 ${REQ_TOL} ${CHECK_TOL}
+                   ${PREC} ${UPSAMP})
 
   add_test(NAME cufinufft2d1_test_GM_${PREC}_${UPSAMP}
            COMMAND cufinufft2d_test 1 1 1e2 2e2 2e4 ${REQ_TOL} ${CHECK_TOL}
@@ -44,8 +61,16 @@ function(add_tests PREC REQ_TOL CHECK_TOL UPSAMP)
            COMMAND cufinufft2d_test 2 1 1e2 2e2 2e4 ${REQ_TOL} ${CHECK_TOL}
                    ${PREC} ${UPSAMP})
 
+  add_test(NAME cufinufft2d2_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft2d_test 0 2 1e2 2e2 2e4 ${REQ_TOL} ${CHECK_TOL}
+                   ${PREC} ${UPSAMP})
+
   add_test(NAME cufinufft2d2_test_SM_${PREC}_${UPSAMP}
            COMMAND cufinufft2d_test 2 2 1e2 2e2 2e4 ${REQ_TOL} ${CHECK_TOL}
+                   ${PREC} ${UPSAMP})
+
+  add_test(NAME cufinufft2d3_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft2d_test 0 3 1e2 2e2 2e4 ${REQ_TOL} ${CHECK_TOL}
                    ${PREC} ${UPSAMP})
 
   add_test(NAME cufinufft2d3_test_SM_${PREC}_${UPSAMP}
@@ -76,6 +101,10 @@ function(add_tests PREC REQ_TOL CHECK_TOL UPSAMP)
            COMMAND cufinufft2dmany_test 2 3 1e2 2e2 5 0 2e4 ${REQ_TOL}
                    ${CHECK_TOL} ${PREC} ${UPSAMP})
 
+  add_test(NAME cufinufft3d1_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft3d_test 0 1 2 5 10 20 ${REQ_TOL} ${CHECK_TOL}
+                   ${PREC} ${UPSAMP})
+
   add_test(NAME cufinufft3d1_test_GM_${PREC}_${UPSAMP}
            COMMAND cufinufft3d_test 1 1 2 5 10 20 ${REQ_TOL} ${CHECK_TOL}
                    ${PREC} ${UPSAMP})
@@ -98,8 +127,16 @@ function(add_tests PREC REQ_TOL CHECK_TOL UPSAMP)
                      ${PREC} ${UPSAMP})
   endif()
 
+  add_test(NAME cufinufft3d2_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft3d_test 0 2 2 5 10 20 ${REQ_TOL} ${CHECK_TOL}
+                   ${PREC} ${UPSAMP})
+
   add_test(NAME cufinufft3d2_test_GM_${PREC}_${UPSAMP}
            COMMAND cufinufft3d_test 1 2 2 5 10 20 ${REQ_TOL} ${CHECK_TOL}
+                   ${PREC} ${UPSAMP})
+
+  add_test(NAME cufinufft3d3_test_auto_${PREC}_${UPSAMP}
+           COMMAND cufinufft3d_test 0 3 2 5 10 30 ${REQ_TOL} ${CHECK_TOL}
                    ${PREC} ${UPSAMP})
 
   add_test(NAME cufinufft3d3_test_GM_${PREC}_${UPSAMP}


### PR DESCRIPTION
Currently, type 3 crashes when invoked with default GPU method (`opts.gpu_method = 0`). This detects the default setting and sets it to 1.