### PR TITLE
Make cufinufft compiles with CUDA 12 on Windows

### DIFF
--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -58,6 +58,7 @@ set_target_properties(
              CUDA_SEPARABLE_COMPILATION ON
              CUDA_STANDARD 17
              CUDA_STANDARD_REQUIRED ON
+             WINDOWS_EXPORT_ALL_SYMBOLS ON
              ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 target_compile_features(cufinufft PRIVATE cxx_std_17)
 target_compile_options(cufinufft PRIVATE ${FINUFFT_CUDA_FLAGS})

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -22,8 +22,7 @@ set(CUFINUFFT_INCLUDE_DIRS
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/contrib
     $<TARGET_PROPERTY:CUDA::cudart,INTERFACE_INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:CUDA::cufft,INTERFACE_INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:CUDA::nvToolsExt,INTERFACE_INCLUDE_DIRECTORIES>)
+    $<TARGET_PROPERTY:CUDA::cufft,INTERFACE_INCLUDE_DIRECTORIES>)
 
 set(CUFINUFFT_INCLUDE_DIRS
     ${CUFINUFFT_INCLUDE_DIRS}
@@ -43,41 +42,15 @@ set(FINUFFT_CUDA_FLAGS
     >
     >)
 
-add_library(cufinufft_common_objects OBJECT ${PRECISION_INDEPENDENT_SRC})
-target_include_directories(cufinufft_common_objects
-                           PUBLIC ${CUFINUFFT_INCLUDE_DIRS})
-set_target_properties(
-  cufinufft_common_objects
-  PROPERTIES POSITION_INDEPENDENT_CODE ${FINUFFT_POSITION_INDEPENDENT_CODE}
-             CUDA_ARCHITECTURES "${FINUFFT_CUDA_ARCHITECTURES}"
-             CUDA_SEPARABLE_COMPILATION ON
-             CUDA_STANDARD 17
-             CUDA_STANDARD_REQUIRED ON)
-target_compile_features(cufinufft_common_objects PRIVATE cxx_std_17)
-target_compile_options(cufinufft_common_objects PRIVATE ${FINUFFT_CUDA_FLAGS})
-
-add_library(cufinufft_objects OBJECT ${PRECISION_DEPENDENT_SRC})
-target_include_directories(cufinufft_objects PUBLIC ${CUFINUFFT_INCLUDE_DIRS})
-set_target_properties(
-  cufinufft_objects
-  PROPERTIES POSITION_INDEPENDENT_CODE ${FINUFFT_POSITION_INDEPENDENT_CODE}
-             CUDA_ARCHITECTURES "${FINUFFT_CUDA_ARCHITECTURES}"
-             CUDA_SEPARABLE_COMPILATION ON
-             CUDA_STANDARD 17
-             CUDA_STANDARD_REQUIRED ON)
-target_compile_features(cufinufft_objects PRIVATE cxx_std_17)
-target_compile_options(cufinufft_objects PRIVATE ${FINUFFT_CUDA_FLAGS})
-
 if(FINUFFT_SHARED_LINKING)
-  add_library(cufinufft SHARED $<TARGET_OBJECTS:cufinufft_common_objects>
-                               $<TARGET_OBJECTS:cufinufft_objects>)
+  add_library(cufinufft SHARED ${PRECISION_INDEPENDENT_SRC} ${PRECISION_DEPENDENT_SRC})
 else()
-  add_library(cufinufft STATIC $<TARGET_OBJECTS:cufinufft_common_objects>
-                               $<TARGET_OBJECTS:cufinufft_objects>)
+  add_library(cufinufft STATIC ${PRECISION_INDEPENDENT_SRC} ${PRECISION_DEPENDENT_SRC})
   set_target_properties(
     cufinufft PROPERTIES POSITION_INDEPENDENT_CODE
                          ${FINUFFT_POSITION_INDEPENDENT_CODE})
 endif()
+target_include_directories(cufinufft PUBLIC ${CUFINUFFT_INCLUDE_DIRS})
 
 set_target_properties(
   cufinufft
@@ -89,11 +62,9 @@ set_target_properties(
 target_compile_features(cufinufft PRIVATE cxx_std_17)
 target_compile_options(cufinufft PRIVATE ${FINUFFT_CUDA_FLAGS})
 if(WIN32)
-  target_link_libraries(cufinufft PUBLIC CUDA::cudart CUDA::cufft
-                                         CUDA::nvToolsExt)
+  target_link_libraries(cufinufft PUBLIC CUDA::cudart CUDA::cufft)
 else()
-  target_link_libraries(cufinufft PUBLIC CUDA::cudart_static CUDA::cufft_static
-                                         CUDA::nvToolsExt)
+  target_link_libraries(cufinufft PUBLIC CUDA::cudart_static CUDA::cufft_static)
 endif()
 
 file(GLOB CUFINUFFT_PUBLIC_HEADERS "${CMAKE_SOURCE_DIR}/include/cufinufft*.h")

--- a/src/cuda/utils.cpp
+++ b/src/cuda/utils.cpp
@@ -25,7 +25,14 @@ CUFINUFFT_BIGINT next235beven(CUFINUFFT_BIGINT n, CUFINUFFT_BIGINT b)
 
 // ----------------------- helpers for timing (always stay double prec)...
 
-void CNTime::start() { gettimeofday(&initial, 0); }
+void CNTime::start() {
+#ifdef _WIN32
+  QueryPerformanceFrequency(&frequency);
+  QueryPerformanceCounter(&initial);
+#else
+  gettimeofday(&initial, 0);
+#endif
+}
 
 double CNTime::restart()
 // Barnett changed to returning in sec
@@ -38,11 +45,17 @@ double CNTime::restart()
 double CNTime::elapsedsec()
 // returns answers as double, in seconds, to microsec accuracy. Barnett 5/22/18
 {
+#ifdef _WIN32
+  LARGE_INTEGER now;
+  QueryPerformanceCounter(&now);
+  return static_cast<double>(now.QuadPart - initial.QuadPart) / frequency.QuadPart;
+#else
   struct timeval now;
   gettimeofday(&now, 0);
   double nowsec     = (double)now.tv_sec + 1e-6 * now.tv_usec;
   double initialsec = (double)initial.tv_sec + 1e-6 * initial.tv_usec;
   return nowsec - initialsec;
+#endif
 }
 
 } // namespace utils


### PR DESCRIPTION
I make the following changes to make cufinufft compilable with CUDA 12 on Windows

1. Use `windows.h` to replace `sys/time.h` on Windows.
2. Use `_USE_MATH_DEFINES` to ensure `M_PI` is defined.
3. Delete `CUDA::nvToolsExt` in CMake file because it does not exist in CUDA 12, see [link1](https://discuss.pytorch.org/t/failed-to-find-nvtoolsext/179635) and [link2](https://github.com/pytorch/pytorch/issues/116242).
4. Simplify the logic for `cufinufft` in CMake, because original `cufinufft` just merges two object libraries to a static or shared library. It will lead to linking error for MSVC if a library with no `.cu` file links multiple libraries with CUDA. It is a bug reported [here](https://forums.developer.nvidia.com/t/linking-multiple-static-cuda-libs/148964) and [there](https://gitlab.kitware.com/cmake/cmake/-/issues/17520).