### PR TITLE
potential way of implementing discussion #587

### DIFF
--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -164,7 +164,7 @@ template<typename TF> struct FINUFFT_PLAN_T { // the main plan class, fully C++
 
   std::array<UBIGINT, 3> nf123{1, 1, 1}; // size of internal fine grid in x/y/z
                                          // direction
-  UBIGINT nf = 1; // total # fine grid points (product of the above three)
+  inline UBIGINT nf() const { return nf123[0]*nf123[1]*nf123[2]; } // total # fine grid points (product of the above three)
 
   int fftSign;    // sign in exponential for NUFFT defn, guaranteed to be +-1
 

--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -160,7 +160,7 @@ template<typename TF> struct FINUFFT_PLAN_T { // the main plan class, fully C++
 
   std::array<UBIGINT, 3> mstu; // number of modes in x/y/z dir (historical CMCL name) =
                                // N1/N2/N3
-  inline UBIGINT N() { return mstu[0]*mstu[1]*mstu[2]; } // total # modes (prod of above three)
+  inline UBIGINT N() const { return mstu[0]*mstu[1]*mstu[2]; } // total # modes (prod of above three)
 
   std::array<UBIGINT, 3> nf123{1, 1, 1}; // size of internal fine grid in x/y/z
                                          // direction

--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -160,10 +160,10 @@ template<typename TF> struct FINUFFT_PLAN_T { // the main plan class, fully C++
 
   std::array<UBIGINT, 3> mstu; // number of modes in x/y/z dir (historical CMCL name) =
                                // N1/N2/N3
-  UBIGINT N;                   // total # modes (prod of above three)
+  inline UBIGINT N() { return mstu[0]*mstu[1]*mstu[2]; } // total # modes (prod of above three)
 
-  std::array<UBIGINT, 3> nf123 = {1, 1, 1}; // size of internal fine grid in x/y/z
-                                            // direction
+  std::array<UBIGINT, 3> nf123{1, 1, 1}; // size of internal fine grid in x/y/z
+                                         // direction
   UBIGINT nf = 1; // total # fine grid points (product of the above three)
 
   int fftSign;    // sign in exponential for NUFFT defn, guaranteed to be +-1

--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -132,9 +132,7 @@ static inline void MY_OMP_SET_NUM_THREADS [[maybe_unused]] (int) {}
 
 // group together a bunch of type 3 rescaling/centering/phasing parameters:
 template<typename T> struct type3params {
-  T X1, C1, D1, h1, gam1; // x dim: X=halfwid C=center D=freqcen h,gam=rescale
-  T X2, C2, D2, h2, gam2; // y
-  T X3, C3, D3, h3, gam3; // z
+  std::array<T, 3> X, C, D, h, gam; // x dim: X=halfwid C=center D=freqcen h,gam=rescale
 };
 
 template<typename TF> struct FINUFFT_PLAN_T { // the main plan class, fully C++
@@ -151,30 +149,26 @@ template<typename TF> struct FINUFFT_PLAN_T { // the main plan class, fully C++
   FINUFFT_PLAN_T &operator=(const FINUFFT_PLAN_T &) = delete;
   ~FINUFFT_PLAN_T();
 
-  int type;                // transform type (Rokhlin naming): 1,2 or 3
-  int dim;                 // overall dimension: 1,2 or 3
-  int ntrans;              // how many transforms to do at once (vector or "many" mode)
-  BIGINT nj;               // num of NU pts in type 1,2 (for type 3, num input x pts)
-  BIGINT nk;               // number of NU freq pts (type 3 only)
-  TF tol;                  // relative user tolerance
-  int batchSize;           // # strength vectors to group together for FFTW, etc
-  int nbatch;              // how many batches done to cover all ntrans vectors
+  int type;      // transform type (Rokhlin naming): 1,2 or 3
+  int dim;       // overall dimension: 1,2 or 3
+  int ntrans;    // how many transforms to do at once (vector or "many" mode)
+  BIGINT nj;     // num of NU pts in type 1,2 (for type 3, num input x pts)
+  BIGINT nk;     // number of NU freq pts (type 3 only)
+  TF tol;        // relative user tolerance
+  int batchSize; // # strength vectors to group together for FFTW, etc
+  int nbatch;    // how many batches done to cover all ntrans vectors
 
-  BIGINT ms;               // number of modes in x (1) dir (historical CMCL name) = N1
-  BIGINT mt;               // number of modes in y (2) direction = N2
-  BIGINT mu;               // number of modes in z (3) direction = N3
-  BIGINT N;                // total # modes (prod of above three)
+  std::array<UBIGINT, 3> mstu; // number of modes in x/y/z dir (historical CMCL name) =
+                               // N1/N2/N3
+  UBIGINT N;                   // total # modes (prod of above three)
 
-  BIGINT nf1 = 1;          // size of internal fine grid in x (1) direction
-  BIGINT nf2 = 1;          // " y (2)
-  BIGINT nf3 = 1;          // " z (3)
-  BIGINT nf  = 1;          // total # fine grid points (product of the above three)
+  std::array<UBIGINT, 3> nf123 = {1, 1, 1}; // size of internal fine grid in x/y/z
+                                            // direction
+  UBIGINT nf = 1; // total # fine grid points (product of the above three)
 
-  int fftSign;             // sign in exponential for NUFFT defn, guaranteed to be +-1
+  int fftSign;    // sign in exponential for NUFFT defn, guaranteed to be +-1
 
-  std::vector<TF> phiHat1; // FT of kernel in t1,2, on x-axis mode grid
-  std::vector<TF> phiHat2; // " y-axis.
-  std::vector<TF> phiHat3; // " z-axis.
+  std::array<std::vector<TF>, 3> phiHat; // FT of kernel in t1,2, on x/y/z-axis mode grid
 
   // fwBatch: (batches of) fine working grid(s) for the FFT to plan & act on.
   // Usually the largest internal array. Its allocator is 64-byte (cache-line) aligned:
@@ -185,17 +179,17 @@ template<typename TF> struct FINUFFT_PLAN_T { // the main plan class, fully C++
 
   // for t1,2: ptr to user-supplied NU pts (no new allocs).
   // for t3: will become ptr to internally allocated "primed" (scaled) Xp, Yp, Zp vecs.
-  TF *X = nullptr, *Y = nullptr, *Z = nullptr;
+  std::array<TF *, 3> XYZ = {nullptr, nullptr, nullptr};
 
   // type 3 specific
-  TF *S = nullptr, *T = nullptr, *U = nullptr; // ptrs to user's target NU-point arrays
-                                               // (no new allocs)
-  std::vector<TC> prephase;                    // pre-phase, for all input NU pts
-  std::vector<TC> deconv;     // reciprocal of kernel FT, phase, all output NU pts
-  std::vector<TC> CpBatch;    // working array of prephased strengths
-  std::vector<TF> Xp, Yp, Zp; // internal primed NU points (x'_j, etc)
-  std::vector<TF> Sp, Tp, Up; // internal primed targs (s'_k, etc)
-  type3params<TF> t3P;        // groups together type 3 shift, scale, phase, parameters
+  std::array<TF *, 3> STU = {nullptr, nullptr, nullptr}; // ptrs to user's target NU-point
+                                                         // arrays (no new allocs)
+  std::vector<TC> prephase; // pre-phase, for all input NU pts
+  std::vector<TC> deconv;   // reciprocal of kernel FT, phase, all output NU pts
+  std::vector<TC> CpBatch;  // working array of prephased strengths
+  std::array<std::vector<TF>, 3> XYZp; // internal primed NU points (x'_j, etc)
+  std::array<std::vector<TF>, 3> STUp; // internal primed targs (s'_k, etc)
+  type3params<TF> t3P; // groups together type 3 shift, scale, phase, parameters
   std::unique_ptr<FINUFFT_PLAN_T<TF>> innerT2plan; // ptr used for type 2 in step 2 of
                                                    // type 3
 

--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -160,11 +160,11 @@ template<typename TF> struct FINUFFT_PLAN_T { // the main plan class, fully C++
 
   std::array<UBIGINT, 3> mstu; // number of modes in x/y/z dir (historical CMCL name) =
                                // N1/N2/N3
-  inline UBIGINT N() const { return mstu[0]*mstu[1]*mstu[2]; } // total # modes (prod of above three)
+  UBIGINT N() const { return mstu[0]*mstu[1]*mstu[2]; } // total # modes (prod of above three)
 
   std::array<UBIGINT, 3> nf123{1, 1, 1}; // size of internal fine grid in x/y/z
                                          // direction
-  inline UBIGINT nf() const { return nf123[0]*nf123[1]*nf123[2]; } // total # fine grid points (product of the above three)
+  UBIGINT nf() const { return nf123[0]*nf123[1]*nf123[2]; } // total # fine grid points (product of the above three)
 
   int fftSign;    // sign in exponential for NUFFT defn, guaranteed to be +-1
 

--- a/perftest/guru_timing_test.cpp
+++ b/perftest/guru_timing_test.cpp
@@ -271,8 +271,8 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
 
     case 1:
       timer.restart();
-      ier = FINUFFT1D1(plan->nj, x, cStart, plan->fftSign, plan->tol, plan->ms, fStart,
-                       popts);
+      ier = FINUFFT1D1(plan->nj, x, cStart, plan->fftSign, plan->tol, plan->mstu[0],
+                       fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -281,8 +281,8 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
 
     case 2:
       timer.restart();
-      ier = FINUFFT1D2(plan->nj, x, cStart, plan->fftSign, plan->tol, plan->ms, fStart,
-                       popts);
+      ier = FINUFFT1D2(plan->nj, x, cStart, plan->fftSign, plan->tol, plan->mstu[0],
+                       fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -291,8 +291,8 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
 
     case 3:
       timer.restart();
-      ier = FINUFFT1D3(plan->nj, x, cStart, plan->fftSign, plan->tol, plan->nk, plan->S,
-                       fStart, popts);
+      ier = FINUFFT1D3(plan->nj, x, cStart, plan->fftSign, plan->tol, plan->nk,
+                       plan->STU[0], fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -308,8 +308,8 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
 
     case 1:
       timer.restart();
-      ier = FINUFFT2D1(plan->nj, x, y, cStart, plan->fftSign, plan->tol, plan->ms,
-                       plan->mt, fStart, popts);
+      ier = FINUFFT2D1(plan->nj, x, y, cStart, plan->fftSign, plan->tol, plan->mstu[0],
+                       plan->mstu[1], fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -318,8 +318,8 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
 
     case 2:
       timer.restart();
-      ier = FINUFFT2D2(plan->nj, x, y, cStart, plan->fftSign, plan->tol, plan->ms,
-                       plan->mt, fStart, popts);
+      ier = FINUFFT2D2(plan->nj, x, y, cStart, plan->fftSign, plan->tol, plan->mstu[0],
+                       plan->mstu[1], fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -329,7 +329,7 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
     case 3:
       timer.restart();
       ier = FINUFFT2D3(plan->nj, x, y, cStart, plan->fftSign, plan->tol, plan->nk,
-                       plan->S, plan->T, fStart, popts);
+                       plan->STU[0], plan->STU[1], fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -345,8 +345,8 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
 
     case 1:
       timer.restart();
-      ier = FINUFFT3D1(plan->nj, x, y, z, cStart, plan->fftSign, plan->tol, plan->ms,
-                       plan->mt, plan->mu, fStart, popts);
+      ier = FINUFFT3D1(plan->nj, x, y, z, cStart, plan->fftSign, plan->tol, plan->mstu[0],
+                       plan->mstu[1], plan->mstu[2], fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -355,8 +355,8 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
 
     case 2:
       timer.restart();
-      ier = FINUFFT3D2(plan->nj, x, y, z, cStart, plan->fftSign, plan->tol, plan->ms,
-                       plan->mt, plan->mu, fStart, popts);
+      ier = FINUFFT3D2(plan->nj, x, y, z, cStart, plan->fftSign, plan->tol, plan->mstu[0],
+                       plan->mstu[1], plan->mstu[2], fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -366,7 +366,7 @@ double finufftFunnel(CPX *cStart, CPX *fStart, FLT *x, FLT *y, FLT *z, FINUFFT_P
     case 3:
       timer.restart();
       ier = FINUFFT3D3(plan->nj, x, y, z, cStart, plan->fftSign, plan->tol, plan->nk,
-                       plan->S, plan->T, plan->U, fStart, popts);
+                       plan->STU[0], plan->STU[1], plan->STU[2], fStart, popts);
       t   = timer.elapsedsec();
       if (ier)
         return fail;
@@ -399,7 +399,7 @@ double many_simple_calls(CPX *c, CPX *F, FLT *x, FLT *y, FLT *z, FINUFFT_PLAN pl
 
   for (int k = 0; k < plan->ntrans; k++) {
     cStart = c + plan->nj * k;
-    fStart = F + plan->ms * plan->mt * plan->mu * k;
+    fStart = F + plan->mstu[0] * plan->mstu[1] * plan->mstu[2] * k;
 
     // printf("k=%d, debug=%d.................\n",k, plan->opts.debug);
     if (k != 0) { // prevent massive debug output

--- a/src/finufft_core.cpp
+++ b/src/finufft_core.cpp
@@ -476,7 +476,7 @@ static int deconvolveBatch(int batchSize, FINUFFT_PLAN_T<T> *p, std::complex<T> 
   for (int i = 0; i < batchSize; i++) {
     std::complex<T> *fwi = p->fwBatch.data() + i * p->nf; // start of i'th fw array in
                                                           // wkspace
-    std::complex<T> *fki = fkBatch + i * p->N; // start of i'th fk array in fkBatch
+    std::complex<T> *fki = fkBatch + i * p->N(); // start of i'th fk array in fkBatch
 
     // Call routine from common.cpp for the dim; prefactors hardcoded to 1.0...
     if (p->dim == 1)
@@ -625,10 +625,8 @@ FINUFFT_PLAN_T<TF>::FINUFFT_PLAN_T(int type_, int dim_, const BIGINT *n_modes, i
   }
 
   if (type != 3) { // read in user Fourier mode array sizes...
-    N = 1;
     for (int idim = 0; idim < 3; ++idim) {
       mstu[idim] = (idim < dim) ? n_modes[idim] : 1;
-      N *= mstu[idim];
     }
   }
 
@@ -638,8 +636,8 @@ FINUFFT_PLAN_T<TF>::FINUFFT_PLAN_T(int type_, int dim_, const BIGINT *n_modes, i
     if (tol >= (TF)1E-9) {                // the tol sigma=5/4 can reach
       if (type == 3)                      // could move to setpts, more known?
         opts.upsampfac = 1.25;            // faster b/c smaller RAM & FFT
-      else if ((dim == 1 && N > 10000000) || (dim == 2 && N > 300000) ||
-               (dim == 3 && N > 3000000)) // type 1,2 heuristic cutoffs, double,
+      else if ((dim == 1 && N() > 10000000) || (dim == 2 && N() > 300000) ||
+               (dim == 3 && N() > 3000000)) // type 1,2 heuristic cutoffs, double,
                                           // typ tol, 12-core xeon
         opts.upsampfac = 1.25;
     }
@@ -993,7 +991,7 @@ int FINUFFT_PLAN_T<TF>::execute(std::complex<TF> *cj, std::complex<TF> *fk) {
       int thisBatchSize     = std::min(ntrans - b * batchSize, batchSize);
       int bB                = b * batchSize; // index of vector, since batchsizes same
       std::complex<TF> *cjb = cj + bB * nj;  // point to batch of weights
-      std::complex<TF> *fkb = fk + bB * N;   // point to batch of mode coeffs
+      std::complex<TF> *fkb = fk + bB * N();   // point to batch of mode coeffs
       if (opts.debug > 1)
         printf("[%s] start batch %d (size %d):\n", __func__, b, thisBatchSize);
 


### PR DESCRIPTION
This demonstrates how variables depending on problem dimensionality could be merged into `std::array`s, and how it potentially simplifies the code.

This is not yet complete:
- I'm not happy with the variable names yet. For example, I renamed `nf1, nf2, nf3` to `nf123`, since the obvious candidate `nf` was already used for storing the product `nf1*nf2*nf3`, and I didn't want to do big refactorings for this demonstrations.
- there are more good candidates in the interface of  `spreadinterp`, which I haven't looked at much, mostly because there is a clash between `finufft_core.h`, where integer quantities are usually `BIGINT`,and `spreadinterp.h`, where they tend to be `UBIGINT`. While it is possible to convert individual integers on the fly when crossing the interface, the same does not work for `std::array`s, so I tought I'd ask for opinions before taking this any further.