### PR TITLE
Tweak type 3 setpts

### DIFF
--- a/src/finufft_core.cpp
+++ b/src/finufft_core.cpp
@@ -259,7 +259,7 @@ public:
   }
 
   /*
-    Evaluates the Fourier transform of te kernel at a single point.
+    Evaluates the Fourier transform of the kernel at a single point.
 
     Inputs:
     k - frequency, dual to the kernel's natural argument, ie exp(i.k.z)

--- a/src/finufft_core.cpp
+++ b/src/finufft_core.cpp
@@ -267,7 +267,7 @@ public:
     Outputs:
     phihat - real Fourier transform evaluated at freq k
    */
-  T operator()(T k) {
+  FINUFFT_ALWAYS_INLINE T operator()(T k) {
     T x = 0;
     for (size_t n = 0; n < z.size(); ++n)
       x += f[n] * 2 * cos(k * z[n]); // pos & neg freq pair.  use T cos!


### PR DESCRIPTION
This removes the temporary `phihatk` arrays in the `setpts` method for type 3 transforms. It also reduces the amount of large array accesses happening in this function.