### PR TITLE
Add a workflow to build cufinufft wheels

### DIFF
--- a/.github/workflows/cufinufft_build_python_wheels.yml
+++ b/.github/workflows/cufinufft_build_python_wheels.yml
@@ -1,0 +1,30 @@
+name: Build cuFINUFFT Python wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels_linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.19.2
+        with:
+          package-dir: 'python/cufinufft'
+        env:
+          CIBW_BEFORE_ALL_LINUX: |
+            # See: https://stackoverflow.com/questions/77197213/cibuildwheel-and-cuda
+            yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+            rpm --import https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/D42D0685.pub
+            yum clean all
+            yum -y install cuda-toolkit-11-4
+            /usr/local/cuda/bin/nvcc --version
+          CIBW_ENVIRONMENT_LINUX: >
+            CUDACXX=/usr/local/cuda/bin/nvcc
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-ubuntu-latest
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/cufinufft_build_python_wheels.yml
+++ b/.github/workflows/cufinufft_build_python_wheels.yml
@@ -26,5 +26,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-ubuntu-latest
+          name: cufinufft-wheels-ubuntu-latest
           path: ./wheelhouse/*.whl

--- a/.github/workflows/finufft_build_python_wheels.yml
+++ b/.github/workflows/finufft_build_python_wheels.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}
+          name: finufft-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_wheels_macos_arm64:
@@ -68,7 +68,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-macos-arm64
+          name: finufft-wheels-macos-arm64
           path: ./wheelhouse/*.whl
 
   build_wheels_win:
@@ -95,5 +95,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-windows
+          name: finufft-wheels-windows
           path: ./wheelhouse/*.whl

--- a/.github/workflows/finufft_build_python_wheels.yml
+++ b/.github/workflows/finufft_build_python_wheels.yml
@@ -1,4 +1,4 @@
-name: Build and test Python wheels
+name: Build and test FINUFFT Python wheels
 
 on: [push, pull_request]
 

--- a/python/cufinufft/pyproject.toml
+++ b/python/cufinufft/pyproject.toml
@@ -73,3 +73,13 @@ sdist.include = ["src/cuda"]
 # Instead of hardcoding the version here, extract it from the source files.
 provider = "scikit_build_core.metadata.regex"
 input = "cufinufft/__init__.py"
+
+[tool.cibuildwheel]
+# Make sure we see what's going on.
+build-verbosity = 1
+# Skip building for PyPi and musllinux.
+skip = "pp* *musllinux*"
+
+[tool.cibuildwheel.linux]
+archs = "x86_64"
+config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "-march=x86-64", "cmake.define.CMAKE_VERBOSE_MAKEFILE" = "ON", "cmake.define.CMAKE_CUDA_ARCHITECTURES" = "50;60;70;80", "cmake.define.CMAKE_CUDA_FLAGS" ="-Wno-deprecated-gpu-targets"}


### PR DESCRIPTION
Adds a GitHub Actions workflow that compiles and packages the cufinufft Python wheels, then uploads them as an artifact.

I've tested these on the FI cluster using V100 and A100 cards. So far everything checks out.

The resulting wheels are quite large (~350 MB), however, compared to the ones we were building before (~110 MB). I've confirmed that when building the wheels locally (using `tools/cufinufft/distribution_helper.sh`), I get the smaller wheels, so there must be something about the new pipeline that's generating larger wheels.