### PR TITLE
using 2.00 when withing two digits of machine precision

### DIFF
--- a/include/finufft/heuristics.hpp
+++ b/include/finufft/heuristics.hpp
@@ -326,7 +326,7 @@ template<typename T>
 double bestUpsamplingFactor(const int nthreads, const double density, const int dim,
                             const int nufftType, const double epsilon) {
   // 1) For epsilons <= 1e-9, 1.25 is not supported
-  if (epsilon <= 1.0e-9) {
+  if (epsilon <= 1.0e-9 || epsilon <= std::numeric_limits<T>::epsilon() * 100) {
     return 2.0;
   }
 


### PR DESCRIPTION
Addresses https://github.com/flatironinstitute/finufft/pull/651#issuecomment-2845012866