### PR TITLE
Don't include Fortran sources by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,8 +254,12 @@ if(FINUFFT_USE_CPU)
         src/finufft_core.cpp
         src/c_interface.cpp
         src/finufft_utils.cpp
-        fortran/finufftfort.cpp
     )
+
+    if(FINUFFT_BUILD_FORTRAN)
+        list(APPEND FINUFFT_SOURCES fortran/finufftfort.cpp)
+    endif()
+
     # Main finufft libraries
     if(NOT FINUFFT_STATIC_LINKING)
         add_library(finufft SHARED ${FINUFFT_SOURCES})


### PR DESCRIPTION
This is needed to avoid shipping extraneous code related to the Fortran interface in the Python sdist. We should only add Fortran-specific source files when the FINUFFT_BUILD_FORTRAN flag is passed to cmake.