### PR TITLE
Speed up gpuArray check in MATLAB interface

### DIFF
--- a/matlab/finufft_isgpuarray.m
+++ b/matlab/finufft_isgpuarray.m
@@ -1,15 +1,22 @@
 function is_gpuarray = finufft_isgpuarray(input)
-% FINUFFT_ISGPUARRAY    check if an array is an gpuArray.
-%
-% Note: this is currently unused since GPU codes have distinct cufinufft*
-% names.
+%FINUFFT_ISGPUARRAY   Check if an array is a gpuArray.
 
-% check if the isgpuarray function is available
-    if exist('isgpuarray') == 0
-      % return 0, since no parallel computing toolbox, can not use gpuarray
-      is_gpuarray = logical(0);
-    else
-      % call the parallel computing toolbox isgpuarray function
-      is_gpuarray = isgpuarray(input);
-    end
+try
+    % Try calling MATLAB's built-in isgpuarray routine. If isgpuarray does
+    % not exist (e.g., because we're in Octave) then this will throw an
+    % error, which we catch below.
+    is_gpuarray = isgpuarray(input);
+catch
+    is_gpuarray = false;
+end
+
+% % check if the isgpuarray function is available
+% if exist('isgpuarray') == 0
+%   % return 0, since no parallel computing toolbox, can not use gpuarray
+%   is_gpuarray = logical(0);
+% else
+%   % call the parallel computing toolbox isgpuarray function
+%   is_gpuarray = isgpuarray(input);
+% end
+
 end

--- a/matlab/finufft_isgpuarray.m
+++ b/matlab/finufft_isgpuarray.m
@@ -10,13 +10,4 @@ catch
     is_gpuarray = false;
 end
 
-% % check if the isgpuarray function is available
-% if exist('isgpuarray') == 0
-%   % return 0, since no parallel computing toolbox, can not use gpuarray
-%   is_gpuarray = logical(0);
-% else
-%   % call the parallel computing toolbox isgpuarray function
-%   is_gpuarray = isgpuarray(input);
-% end
-
 end


### PR DESCRIPTION
The MATLAB interface checks if inputs are `gpuArray` on every call to `setpts` and `execute`, via the routine `finufft_isgpuarray`. This routine operates by calling `exist('isgpuarray')`, which is slow. When performing many small NUFFTs, `finufft_isgpuarray` can actually be the bottleneck. This PR speeds up `finufft_isgpuarray` so the overhead is negligible.

Example:
```
N = 64;
M = 1e3;
plan = finufft_plan(2, [N N], 1, 1, 1e-9);

tic
for k = 1:10000
    x = 2*pi*rand(M,1);
    y = 2*pi*rand(M,1);
    c = randn(N)+1i*randn(N);
    plan.setpts(x,y);
    f = plan.execute(c);
end
toc
```

Before this PR:
```
Elapsed time is 28.521582 seconds.
```

After this PR:
```
Elapsed time is 5.723936 seconds.
```