### PR TITLE
Python simple cuda

### DIFF
--- a/python/cufinufft/cufinufft/__init__.py
+++ b/python/cufinufft/cufinufft/__init__.py
@@ -1,7 +1,7 @@
 from cufinufft._plan import Plan
 
 from cufinufft._simple import (nufft1d1, nufft1d2, nufft1d3,
-                               nufft2d1, nufft2d2, nufft2d3
+                               nufft2d1, nufft2d2, nufft2d3,
                                nufft3d1, nufft3d2, nufft3d3)
 
 __all__ = ["nufft1d1", "nufft1d2", "nufft1d3",

--- a/python/cufinufft/cufinufft/__init__.py
+++ b/python/cufinufft/cufinufft/__init__.py
@@ -1,11 +1,12 @@
 from cufinufft._plan import Plan
 
-from cufinufft._simple import (nufft1d1, nufft1d2, nufft2d1, nufft2d2,
-                               nufft3d1, nufft3d2)
+from cufinufft._simple import (nufft1d1, nufft1d2, nufft1d3,
+                               nufft2d1, nufft2d2, nufft2d3
+                               nufft3d1, nufft3d2, nufft3d3)
 
-__all__ = ["nufft1d1", "nufft1d2",
-           "nufft2d1", "nufft2d2",
-           "nufft3d1", "nufft3d2",
+__all__ = ["nufft1d1", "nufft1d2", "nufft1d3",
+           "nufft2d1", "nufft2d2", "nufft2d3",
+           "nufft3d1", "nufft3d2", "nufft3d3",
            "Plan"]
 
 __version__ = '2.4.0beta1'

--- a/python/cufinufft/cufinufft/_simple.py
+++ b/python/cufinufft/cufinufft/_simple.py
@@ -22,17 +22,14 @@ def nufft3d1(x, y, z, data, n_modes=None, out=None, eps=1e-6, isign=1,
 def nufft3d2(x, y, z, data, out=None, eps=1e-6, isign=-1, **kwargs):
     return _invoke_plan(3, 2, x, y, z, data, None, None, None, out, isign, eps, None, kwargs)
 
-# Then nufft3d3 is as simple as:
 def nufft3d3(x, y, z, data, s, t, u, out=None, eps=1e-6, isign=1, **kwargs):
     return _invoke_plan(3, 3, x, y, z, data, s, t, u, out, isign, eps, None,  kwargs)
 
-# For 2d3:
 def nufft2d3(x, y, data, s, t, out=None, eps=1e-6, isign=1, **kwargs):
-    return _invoke_plan(2, 3, x, y, None, data, s, t, out, isign, eps, None, kwargs)
+    return _invoke_plan(2, 3, x, y, None, data, s, t, None, out, isign, eps, None, kwargs)
 
-# For 1d3:
 def nufft1d3(x, data, s, out=None, eps=1e-6, isign=1, **kwargs):
-    return _invoke_plan(1, 3, x, None, None, data, s, out, isign, eps, None,  kwargs)
+    return _invoke_plan(1, 3, x, None, None, data, s, None, None, out, isign, eps, None,  kwargs)
 
 def _invoke_plan(dim, nufft_type, x, y, z, data, s, t, u,  out, isign, eps,
         n_modes=None, kwargs=None):

--- a/python/cufinufft/cufinufft/_simple.py
+++ b/python/cufinufft/cufinufft/_simple.py
@@ -1,28 +1,40 @@
 from cufinufft import Plan, _compat
 
 def nufft1d1(x, data, n_modes=None, out=None, eps=1e-6, isign=1, **kwargs):
-    return _invoke_plan(1, 1, x, None, None, data, out, isign, eps, n_modes,
+    return _invoke_plan(1, 1, x, None, None, data, None, None, None, out, isign, eps, n_modes,
             kwargs)
 
 def nufft1d2(x, data, out=None, eps=1e-6, isign=-1, **kwargs):
-    return _invoke_plan(1, 2, x, None, None, data, out, isign, eps, None,
+    return _invoke_plan(1, 2, x, None, None, data, None, None, None, out, isign, eps, None,
             kwargs)
 
 def nufft2d1(x, y, data, n_modes=None, out=None, eps=1e-6, isign=1, **kwargs):
-    return _invoke_plan(2, 1, x, y, None, data, out, isign, eps, n_modes,
+    return _invoke_plan(2, 1, x, y, None, data, None, None, None, out, isign, eps, n_modes,
             kwargs)
 
 def nufft2d2(x, y, data, out=None, eps=1e-6, isign=-1, **kwargs):
-    return _invoke_plan(2, 2, x, y, None, data, out, isign, eps, None, kwargs)
+    return _invoke_plan(2, 2, x, y, None, data, None, None, None, out, isign, eps, None, kwargs)
 
 def nufft3d1(x, y, z, data, n_modes=None, out=None, eps=1e-6, isign=1,
         **kwargs):
-    return _invoke_plan(3, 1, x, y, z, data, out, isign, eps, n_modes, kwargs)
+    return _invoke_plan(3, 1, x, y, z, data, None, None, None, out, isign, eps, n_modes, kwargs)
 
 def nufft3d2(x, y, z, data, out=None, eps=1e-6, isign=-1, **kwargs):
-    return _invoke_plan(3, 2, x, y, z, data, out, isign, eps, None, kwargs)
+    return _invoke_plan(3, 2, x, y, z, data, None, None, None, out, isign, eps, None, kwargs)
 
-def _invoke_plan(dim, nufft_type, x, y, z, data, out, isign, eps,
+# Then nufft3d3 is as simple as:
+def nufft3d3(x, y, z, data, s, t, u, out=None, eps=1e-6, isign=1, **kwargs):
+    return _invoke_plan(3, 3, x, y, z, data, s, t, u, out, isign, eps, None,  kwargs)
+
+# For 2d3:
+def nufft2d3(x, y, data, s, t, out=None, eps=1e-6, isign=1, **kwargs):
+    return _invoke_plan(2, 3, x, y, None, data, s, t, out, isign, eps, None, kwargs)
+
+# For 1d3:
+def nufft1d3(x, data, s, out=None, eps=1e-6, isign=1, **kwargs):
+    return _invoke_plan(1, 3, x, None, None, data, s, out, isign, eps, None,  kwargs)
+
+def _invoke_plan(dim, nufft_type, x, y, z, data, s, t, u,  out, isign, eps,
         n_modes=None, kwargs=None):
     dtype = _compat.get_array_dtype(data)
 
@@ -32,10 +44,13 @@ def _invoke_plan(dim, nufft_type, x, y, z, data, out, isign, eps,
         n_modes = out.shape[-dim:]
     if nufft_type == 2:
         n_modes = data.shape[-dim:]
+        
+    if nufft_type == 3:
+        plan = Plan(nufft_type, dim, eps=eps, isign=isign, dtype=dtype, **kwargs)
+    else:
+        plan = Plan(nufft_type, n_modes, n_trans, eps, isign, dtype, **kwargs)
 
-    plan = Plan(nufft_type, n_modes, n_trans, eps, isign, dtype, **kwargs)
-
-    plan.setpts(x, y, z)
+    plan.setpts(x, y, z, s, t, u)
 
     if out is None:
         out = plan.execute(data)


### PR DESCRIPTION
This pull request introduces a simplified Python interface for Type 3 NUFFTs (nonuniform-to-nonuniform) in 1D, 2D, and 3D within the cufinufft library. The new functions—nufft1d3, nufft2d3, and nufft3d3—allow users to perform Type 3 transforms with minimal setup, similar to the existing Type 1 and Type 2 interfaces.
**Changes**

- Added nufft1d3, nufft2d3, and nufft3d3 to cufinufft/_simple.py, providing user-friendly access to Type 3 NUFFTs.
- Updated cufinufft/__init__.py to include the new functions in the module’s public API.
- Modified _invoke_plan to correctly handle Type 3 parameters (s, t, u) and plan creation for Type 3 transforms.

With this update, all NUFFT types (1, 2, and 3) now offer a consistent and simplified Python interface.
