### PR TITLE
Get optimal thread count skip

### DIFF
--- a/include/finufft/finufft_utils.hpp
+++ b/include/finufft/finufft_utils.hpp
@@ -63,12 +63,6 @@ private:
 
 FINUFFT_NEVER_INLINE int getOptimalThreadCount();
 
-// Wrapper to cache the optimal thread count using a static variable.
-inline int getCachedOptimalThreadCount() {
-  static const int cached_value = getOptimalThreadCount();
-  return cached_value;
-}
-
 FINUFFT_NEVER_INLINE int get_num_threads_parallel_block();
 
 } // namespace finufft::utils

--- a/include/finufft/finufft_utils.hpp
+++ b/include/finufft/finufft_utils.hpp
@@ -63,6 +63,12 @@ private:
 
 FINUFFT_NEVER_INLINE int getOptimalThreadCount();
 
+// Wrapper to cache the optimal thread count using a static variable.
+inline int getCachedOptimalThreadCount() {
+  static const int cached_value = getOptimalThreadCount();
+  return cached_value;
+}
+
 FINUFFT_NEVER_INLINE int get_num_threads_parallel_block();
 
 } // namespace finufft::utils

--- a/src/finufft_core.cpp
+++ b/src/finufft_core.cpp
@@ -589,7 +589,7 @@ FINUFFT_PLAN_T<TF>::FINUFFT_PLAN_T(int type_, int dim_, const BIGINT *n_modes, i
 
 #ifdef _OPENMP
   // choose overall # threads...
-  int ompmaxnthr = getOptimalThreadCount();
+  int ompmaxnthr = getCachedOptimalThreadCount(); // get # phys cores (cached)
   int nthr       = ompmaxnthr; // default: use as many physical cores as possible
   // (the above could be set, or suggested set, to 1 for small enough problems...)
   if (opts.nthreads > 0) {
@@ -600,7 +600,6 @@ FINUFFT_PLAN_T<TF>::FINUFFT_PLAN_T(int type_, int dim_, const BIGINT *n_modes, i
               "available; note large nthreads can be slower.\n",
               __func__, nthr, ompmaxnthr);
   }
-
 #else
   int nthr = 1; // always 1 thread (avoid segfault)
   if (opts.nthreads > 1)

--- a/src/finufft_core.cpp
+++ b/src/finufft_core.cpp
@@ -541,6 +541,12 @@ void finufft_default_opts_t(finufft_opts *o)
   // sphinx tag (don't remove): @defopts_end
 }
 
+// Wrapper to cache the optimal thread count using a static variable.
+int getCachedOptimalThreadCount() {
+  static const int cached_value = getOptimalThreadCount();
+  return cached_value;
+}
+
 // PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
 template<typename TF>
 FINUFFT_PLAN_T<TF>::FINUFFT_PLAN_T(int type_, int dim_, const BIGINT *n_modes, int iflag,

--- a/src/finufft_core.cpp
+++ b/src/finufft_core.cpp
@@ -589,7 +589,7 @@ FINUFFT_PLAN_T<TF>::FINUFFT_PLAN_T(int type_, int dim_, const BIGINT *n_modes, i
 
 #ifdef _OPENMP
   // choose overall # threads...
-  int ompmaxnthr = getCachedOptimalThreadCount(); // get # phys cores (cached)
+  int ompmaxnthr = getCachedOptimalThreadCount();
   int nthr       = ompmaxnthr; // default: use as many physical cores as possible
   // (the above could be set, or suggested set, to 1 for small enough problems...)
   if (opts.nthreads > 0) {


### PR DESCRIPTION
This PR introduces an inline helper function getCachedOptimalThreadCount() that caches the result of getOptimalThreadCount() using a static local variable.

As discussed in #693 by @lgarrison , @DiamonDinoia and @lu1and10 , the previous implementation invoked getOptimalThreadCount() at each plan call, triggering redundant system calls. Caching its result avoids this overhead by ensuring the thread count is computed only once.