### PR TITLE
Reduce number of exported symbols in shred library

### DIFF
--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -25,7 +25,7 @@
 #define FINUFFT_EXPORT __declspec(dllimport)
 #endif
 #else
-#define FINUFFT_EXPORT
+#define FINUFFT_EXPORT __attribute__((visibility("default")))
 #endif
 
 /* specify calling convention (Windows only)

--- a/include/finufft_eitherprec.h
+++ b/include/finufft_eitherprec.h
@@ -55,7 +55,7 @@
 #define FINUFFT_EXPORT __declspec(dllimport)
 #endif
 #else
-#define FINUFFT_EXPORT
+#define FINUFFT_EXPORT __attribute__((visibility("default")))
 #endif
 
 /* specify calling convention (Windows only)

--- a/makefile
+++ b/makefile
@@ -31,7 +31,7 @@ PYTHON = python3
 #           they allow gcc to vectorize the code more effectively
 CFLAGS := -O3 -funroll-loops -march=native -fcx-limited-range -ffp-contract=fast\
 		  -fno-math-errno -fno-signed-zeros -fno-trapping-math -fassociative-math\
-		  -freciprocal-math -fmerge-all-constants -ftree-vectorize $(CFLAGS) -Wfatal-errors
+		  -freciprocal-math -fmerge-all-constants -ftree-vectorize $(CFLAGS) -Wfatal-errors -fvisibility=hidden
 FFLAGS := $(CFLAGS) $(FFLAGS)
 CXXFLAGS := $(CFLAGS) $(CXXFLAGS)
 # FFTW base name, and math linking...


### PR DESCRIPTION
At one of the last meetings @ahbarnett noted that the number of symbols exported from `libfinufft.so` increases by a lot when `ducc` is used for FFTs.
This can most likely be fixed by compiling the sources with "-fvisibility=hidden" under Linux and using the already existing `FINUFFT_EXPORT` macros to explicitly make functions visible under Linux, very similar to what happens under Windows.

The current state of the branch demonstrates this when compiling with the `makefile`; you can check the resulting shared library using `nm -C -D -U lib/libfinufft.so` to see the exported symbols.
I don't think there is much I can do about the exported weak symbols (`w`/`W`), but the overall number goes down from 1000+ to about 130 when using the `ducc` back end, which is at least some progress.

Still to do:
- support this in `cmake`
- see whether there are non-Windows compilers which don't understand the visiblity flags/attributes, and disable the mechanism for them.