### PR TITLE
remove include from public interface

### DIFF
--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -1,8 +1,6 @@
 #ifndef FINUFFT_CORE_H
 #define FINUFFT_CORE_H
 
-#include <xsimd/xsimd.hpp>
-
 #include <array>
 #include <finufft_errors.h>
 #include <memory>


### PR DESCRIPTION
`finufft_core.h` is not strictly *public*, but I don't think it's its job to include this