### PR TITLE
fix FINUFFT_ALWAYS_INLINE for msvc

### DIFF
--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -43,7 +43,7 @@
 // inline macro, to force inlining of small functions
 // this avoids the use of macros to implement functions
 #if defined(_MSC_VER)
-#define FINUFFT_ALWAYS_INLINE __forceinline inline
+#define FINUFFT_ALWAYS_INLINE __forceinline
 #define FINUFFT_NEVER_INLINE  __declspec(noinline)
 #define FINUFFT_RESTRICT      __restrict
 #define FINUFFT_UNREACHABLE   __assume(0)


### PR DESCRIPTION
`inline` is not needed with `__forceinline` the way it is with gcc's `__attribute__((always_inline))`. In fact it leads to [warning C4141](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4141?view=msvc-170)