### PR TITLE
Update to ducc0 0.39.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ include(toolchain) # finds cmake/toolchain.cmake
 set(CPM_DOWNLOAD_VERSION "0.42.0" CACHE STRING "Version of CPM.cmake to use")
 set(FFTW_VERSION "3.3.10" CACHE STRING "Version of FFTW to use")
 set(XSIMD_VERSION "13.2.0" CACHE STRING "Version of xsimd to use")
-set(DUCC0_VERSION "ducc0_0_38_0" CACHE STRING "Version of ducc0 to use")
+set(DUCC0_VERSION "ducc0_0_39_1" CACHE STRING "Version of ducc0 to use")
 set(CUDA11_CCCL_VERSION "2.8.5" CACHE STRING "Version of FINUFFT-cccl for cuda 11 to use")
 set(CUDA12_CCCL_VERSION "3.0.2" CACHE STRING "Version of FINUFFT-cccl for cuda 12 to use")
 

--- a/makefile
+++ b/makefile
@@ -66,7 +66,7 @@ XSIMD_DIR := $(DEPS_ROOT)/xsimd
 
 # DUCC sources optional dependency repo
 DUCC_URL := https://gitlab.mpcdf.mpg.de/mtr/ducc.git
-DUCC_VERSION := ducc0_0_38_0
+DUCC_VERSION := ducc0_0_39_1
 DUCC_DIR := $(DEPS_ROOT)/ducc
 # this dummy file used as empty target by make...
 DUCC_COOKIE := $(DUCC_DIR)/.finufft_has_ducc


### PR DESCRIPTION
Ducc0 0.38 has a few lines of code that are not strictly compliant with the C++17 standard. Up to now, compilers didn't care about this, but gcc 15 is more observant and will complain, breaking compilation.

This has been fixed in ducc0 0.39.1, so I recommend that finufft switched to this version.

The change is tiny, but I'd still appreciate a second pair of eyes, in case I have missed a place that also needs to be updated.