### PR TITLE
Polyfit and & runtime coefficients fitting

### DIFF
--- a/.github/workflows/C++.yml
+++ b/.github/workflows/C++.yml
@@ -24,9 +24,9 @@ jobs:
         make test
 
   MacOS_clang:
-    runs-on: macos-13
+    runs-on: macos-14
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
     - uses: actions/checkout@v4
@@ -43,17 +43,17 @@ jobs:
         make test
 
   MacOS_gcc:
-    runs-on: macos-13
+    runs-on: macos-14
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Install gcc and fftw
       run: |
-        brew install gcc@12 fftw
-        cp make-platforms/make.inc.macosx_gcc-12 make.inc
+        brew install gcc@14 fftw
+        cp make-platforms/make.inc.macosx_gcc-14 make.inc
 
     - name: Compile C++ code
       run: |

--- a/.github/workflows/build_finufft_wheels.yml
+++ b/.github/workflows/build_finufft_wheels.yml
@@ -29,7 +29,7 @@ jobs:
         buildplat:
           - [ ubuntu-22.04, manylinux_x86_64 ]
           - [ ubuntu-22.04, musllinux_x86_64 ]
-          - [ macos-13, macosx_x86_64 ]
+#          - [ macos-13, macosx_x86_64 ]
           - [ macos-14, macosx_arm64 ]
           - [ windows-2022, win_amd64 ]
     steps:

--- a/.github/workflows/cmake_ci.yml
+++ b/.github/workflows/cmake_ci.yml
@@ -96,8 +96,6 @@ jobs:
           - { os: windows-2022, toolchain: msvc }
           - { os: windows-2022, toolchain: clang-19 }
 
-          - { os: macos-13, toolchain: llvm }
-          - { os: macos-13, toolchain: gcc-14 }
           - { os: macos-14, toolchain: llvm }
           - { os: macos-14, toolchain: gcc-14 }
           - { os: macos-15, toolchain: llvm }

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 List of features / changes made / release notes, in reverse chronological order.
 If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
-Master (working towards v2.5.0), 10/24/25
+Master (working towards v2.5.0), 11/16/25
 
 * Added real-valued function type-2 interpolation demos (Barnett, Unalmis #722)
 * Added functionality for adjoint execution of FINUFFT plans (Reinecke #633,
@@ -30,6 +30,13 @@ Master (working towards v2.5.0), 10/24/25
   included tightening default visibility in the makefile, introducing
   `FINUFFT_EXPORT_TEST` for test-only APIs, and ensuring FFT backends are linked
   through a dedicated `finufft_fftlibs` interface target. (Barbone, Reinecke #737)
+* Kernel polynomial coefficients are now fitted at runtime and the kernel implementation
+  has been moved to kernel.h and integrated into the spread/interp code path,
+  centralizing kernel evaluation and simplifying parameter handling.
+  spreadtestnd, spreadtestndall and test_spreadinterponly were updated to use
+  the public API and share a unified STL-based implementation for kersum,
+  mass and relative-error checks. This common kernel header also enables reuse
+  by the GPU. (Barbone, Barnett, Lu, PR #748)
 
 V 2.4.1 7/8/25
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ If you prefer to read text files, the source to generate the above documentation
 - `docs/c_gpu.rst`   : documentation of C++/C function API for GPU library
 - `docs/opts.rst`    : optional parameters
 - `docs/error.rst`   : error codes
-- `docs/trouble.rst` : troubleshooting advice
+- `docs/trouble.rst` : troubleshooting and accuracy advice
+- `docs/performance.rst` : CPU timing benchmarks compared to older versions
 - `docs/tut.rst` and `tutorial/*` : tutorial application examples
 - `docs/fortran.rst` : usage examples from Fortran, documentation of interface
 - `docs/matlab.rst` and `docs/matlabhelp.raw` : using the MATLAB/Octave interface
 - `docs/python.rst` and `python/*/_interfaces.py` : using the Python interface
 - `docs/python_gpu.rst` : Python interface to GPU library
 - `docs/julia.rst`   : information for Julia users
+- `docs/nfft_migr.rst` and `docs/cufinufft_migration` : guides for migration
+- `docs/impl_gpu.rst`: implementation notes for GPU code
 - `docs/devnotes.rst`: notes/guide for developers
 - `docs/related.rst` : other recommended NUFFT packages
 - `docs/users.rst`   : some known users of FINUFFT, dependent packages

--- a/docs/impl_gpu.rst
+++ b/docs/impl_gpu.rst
@@ -1,8 +1,8 @@
-Implementation details
-======================
+GPU code implementation details
+===============================
 
 This file contains detailed explanations of the algorithms and optimization strategies
-used in the library.
+used in the GPU version of the library.
 
 The focus is on clarity and reproducibility of the core computational techniques,
 including spreading/interpolation schemes, memory access patterns, and kernel launch
@@ -10,7 +10,7 @@ structures.
 
 .. note::
 
-   This is a living document. Implementation details are subject to change as
+   This is a living document, started in 2025 (v 2.4.1). Implementation details are subject to change as
    performance and accuracy improvements are integrated.
 
 Output Driven

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -169,7 +169,7 @@ PowerPC. The general procedure to download, then compile for a particular platfo
 Have a look in ``make-platforms/`` to see what is available, and/or edit your ``make.inc`` based on looking in the ``makefile`` and quirks of your local platform. We have continuous integration which tests the default (linux) settings in this ``makefile``, plus those in three OS-specific settings, currently::
 
   make-platforms/make.inc.macosx_clang
-  make-platforms/make.inc.macosx_gcc-12
+  make-platforms/make.inc.macosx_gcc-14
   make-platforms/make.inc.windows_msys
 
 Thus, those are the recommended files for OSX or Windows users to try as their ``make.inc``.
@@ -391,7 +391,7 @@ The GCC route
 This is less recommended, unless you need to link from ``gfortran``, when it
 appears to be essential. The basic idea is::
 
-  cp make-platforms/make.inc.macosx_gcc-12 make.inc
+  cp make-platforms/make.inc.macosx_gcc-14 make.inc
   make test -j
   make fortran
 
@@ -401,7 +401,7 @@ in your ``make.inc``.
 
 .. note::
 
-   A problem between GCC and the new XCode 15 requires a workaround to add ``LDFLAGS+=-ld64`` to force the old linker to be used. See the above file ``make.inc.macosx_gcc-12``.
+   A problem between GCC and the new XCode 15 requires a workaround to add ``LDFLAGS+=-ld64`` to force the old linker to be used. See the above file ``make.inc.macosx_gcc-14``.
 
 We find python may be built as :ref:`below<install-python>`.
 We found that octave interfaces do not work with GCC; please help.

--- a/include/finufft/finufft_core.h
+++ b/include/finufft/finufft_core.h
@@ -7,7 +7,6 @@
 
 #include "finufft_common/common.h"
 #include "finufft_errors.h"
-
 // All indexing in library that potentially can exceed 2^31 uses 64-bit signed.
 // This includes all calling arguments (eg M,N) that could be huge someday.
 using BIGINT  = int64_t;
@@ -129,6 +128,8 @@ private:
   // other internal structs
   std::unique_ptr<Finufft_FFT_plan<TF>> fftPlan;
 
+  alignas(64) std::array<TF, 16 * 19> horner_coeffs{0};
+
 public:
   const Finufft_FFT_plan<TF> &getFFTPlan() const { return *fftPlan; }
 
@@ -139,6 +140,8 @@ private:
 
   int execute_internal(TC *cj, TC *fk, bool adjoint = false, int ntrans_actual = -1,
                        TC *aligned_scratch = nullptr, size_t scratch_size = 0) const;
+
+  void precompute_horner_coeffs();
 
 public:
   FINUFFT_PLAN_T(int type, int dim, const BIGINT *n_modes, int iflag, int ntrans, TF tol,

--- a/include/finufft/spreadinterp.h
+++ b/include/finufft/spreadinterp.h
@@ -46,12 +46,12 @@ int indexSort(std::vector<BIGINT> &sort_indices, UBIGINT N1, UBIGINT N2, UBIGINT
               UBIGINT N, const T *kx, const T *ky, const T *kz,
               const finufft_spread_opts &opts);
 template<typename T>
-int spreadinterpSorted(const std::vector<BIGINT> &sort_indices, const UBIGINT N1,
-                       const UBIGINT N2, const UBIGINT N3, T *data_uniform,
-                       const UBIGINT M, const T *FINUFFT_RESTRICT kx,
-                       const T *FINUFFT_RESTRICT ky, const T *FINUFFT_RESTRICT kz,
-                       T *FINUFFT_RESTRICT data_nonuniform,
-                       const finufft_spread_opts &opts, int did_sort, bool adjoint);
+int spreadinterpSorted(
+    const std::vector<BIGINT> &sort_indices, const UBIGINT N1, const UBIGINT N2,
+    const UBIGINT N3, T *data_uniform, const UBIGINT M, const T *FINUFFT_RESTRICT kx,
+    const T *FINUFFT_RESTRICT ky, const T *FINUFFT_RESTRICT kz,
+    T *FINUFFT_RESTRICT data_nonuniform, const finufft_spread_opts &opts, int did_sort,
+    bool adjoint, const T *horner_coeffs);
 template<typename T> T evaluate_kernel(T x, const finufft_spread_opts &opts);
 template<typename T> T evaluate_kernel_horner(T x, const finufft_spread_opts &opts);
 

--- a/include/finufft_common/common.h
+++ b/include/finufft_common/common.h
@@ -2,4 +2,5 @@
 
 #include <finufft_common/constants.h>
 #include <finufft_common/defines.h>
+#include <finufft_common/kernel.h>
 #include <finufft_common/utils.h>

--- a/include/finufft_common/kernel.h
+++ b/include/finufft_common/kernel.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <finufft_common/constants.h>
+
+namespace finufft::kernel {
+
+template<class T, class F> std::vector<T> fit_monomials(F &&f, int n, T a, T b) noexcept {
+  static_assert(std::is_floating_point_v<T>, "T must be floating-point");
+
+  // map t∈[-1,1] ↔ x∈[a,b]
+  const T mid  = T(0.5) * (a + b);
+  const T half = T(0.5) * (b - a);
+
+  // 1) Chebyshev nodes t_k and mapped x_k, sample y_k = f(x_k)
+  std::vector<T> t(n), y(n);
+  for (int k = 0; k < n; ++k) {
+    t[k]       = std::cos((T(2 * k + 1) * common::PI) / (T(2) * T(n))); // in (-1,1)
+    const T xk = mid + half * t[k];
+    y[k]       = static_cast<T>(f(xk));
+  }
+
+  // 2) Newton divided differences on t: coef[j] = f[t0,..,tj]
+  std::vector<T> coef = y;
+  for (int j = 1; j < n; ++j)
+    for (int i = n - 1; i >= j; --i)
+      coef[i] = (coef[i] - coef[i - 1]) / (t[i] - t[i - j]);
+
+  // 3) Convert Newton form to monomial coeffs in t (low→high)
+  // Multiply a polynomial p(t) by (t - c).
+  // Input p holds coefficients low->high (p[0] + p[1] t + p[2] t^2 + ...).
+  // Returns r of length p.size()+1 so that r represents (t - c)*p(t).
+  // Concretely: r[i] = -c*p[i] + (i>0 ? p[i-1] : 0) for i=0..p.size()-1,
+  // and r[p.size()] = p[p.size()-1].
+  auto mul_by_linear = [](const std::vector<T> &p, T c) {
+    std::vector<T> r(p.size() + 1, T(0));
+    for (std::size_t i = 0; i < p.size(); ++i) {
+      r[i] += -c * p[i]; // (t - c)*p
+      r[i + 1] += p[i];
+    }
+    return r;
+  };
+
+  std::vector<T> c(n, T(0));  // output coefficients in t
+  std::vector<T> basis{T(1)}; // Π_{m<j} (t - t_m), low→high
+  c[0] += coef[0];
+  for (int j = 1; j < n; ++j) {
+    basis = mul_by_linear(basis, t[j - 1]);
+    for (std::size_t m = 0; m < basis.size(); ++m) c[m] += coef[j] * basis[m];
+  }
+  std::reverse(c.begin(), c.end());
+  return c;
+}
+
+template<uint8_t w> constexpr std::size_t horner_nc_200() noexcept {
+  static_assert(w >= 2 && w <= 16, "w must be in [2,16]");
+  return (w >= 2 && w <= 16) ? (std::size_t)(w + 2 + ((w >= 3 && w <= 7) ? 1 : 0)) : 0;
+}
+
+template<uint8_t w> constexpr std::size_t horner_nc_125() noexcept {
+  static_assert(w >= 2 && w <= 16, "w must be in [2,16]");
+  return static_cast<std::size_t>(w) + 2 - static_cast<std::size_t>(w >= 5) -
+         static_cast<std::size_t>(w >= 8) - static_cast<std::size_t>(w >= 11) -
+         static_cast<std::size_t>(w >= 15);
+}
+
+constexpr std::size_t horner_nc_200(uint8_t w) noexcept {
+  if (w < 2 || w > 16) return 0;
+  return static_cast<std::size_t>(w + 2 + ((w >= 3 && w <= 7) ? 1 : 0));
+}
+
+constexpr std::size_t horner_nc_125(uint8_t w) noexcept {
+  if (w < 2 || w > 16) return 0;
+  return static_cast<std::size_t>(w) + 2 - static_cast<std::size_t>(w >= 5) -
+         static_cast<std::size_t>(w >= 8) - static_cast<std::size_t>(w >= 11) -
+         static_cast<std::size_t>(w >= 15);
+}
+
+template<typename T> T evaluate_kernel(T x, T beta, T c) {
+  /* ES ("exp sqrt") kernel evaluation at single real argument:
+      phi(x) = exp(beta.(sqrt(1 - (2x/n_s)^2) - 1)),    for |x| < nspread/2
+     related to an asymptotic approximation to the Kaiser--Bessel, itself an
+     approximation to prolate spheroidal wavefunction (PSWF) of order 0.
+     This is the "reference implementation", used by eg finufft/onedim_* 2/17/17.
+     Rescaled so max is 1, Barnett 7/21/24
+  */
+  return std::exp(beta * (std::sqrt(T(1) - c * x * x) - T(1)));
+}
+
+} // namespace finufft::kernel

--- a/make-platforms/make.inc.macosx_clang
+++ b/make-platforms/make.inc.macosx_clang
@@ -23,14 +23,14 @@ CXX=clang++
 CC=clang
 
 # taken from makefile...
-CFLAGS   += -I include -I/usr/local/include -I/usr/local/opt/libomp/include -I/opt/homebrew/include
+CFLAGS   += -I include -I/usr/local/include -I$(shell brew --prefix libomp)/include -I$(shell brew --prefix)/include
 FFLAGS   = $(CFLAGS)
 CXXFLAGS = $(CFLAGS)
-LIBS += -L/usr/local/lib -L/opt/homebrew/lib
+LIBS += -L/usr/local/lib -L$(shell brew --prefix)/lib
 
 # OpenMP with clang needs following...
 OMPFLAGS = -Xpreprocessor -fopenmp
-OMPLIBS = -L/usr/local/lib -L/usr/local/opt/libomp/lib -lomp
+OMPLIBS = -L/usr/local/lib -L$(shell brew --prefix libomp)/lib -lomp
 # since fftw3_omp doesn't work in OSX, we need...
 FFTWOMPSUFFIX=threads
 

--- a/make-platforms/make.inc.macosx_gcc-14
+++ b/make-platforms/make.inc.macosx_gcc-14
@@ -1,31 +1,31 @@
-# Makefile variable overrides for Mac OSX compilation with GCC v.12
+# Makefile variable overrides for Mac OSX compilation with GCC v.14
 #
 # Use this if you'll need to link against gfortran.
 #
 # Barnett 10/27/18. Input from Yu-Hsuan Shih, Amit Moskovich.
-# Lu minor modification for gcc-10 12/06/2020
+# Lu minor modification for gcc-14 11/06/2025
 # Leslie and Dan F found XCode linking problem, workaround 10/5/23.
 
 # By default we use clang/LLVM (which is aliased to /usr/lib/gcc, etc).
 # This make.inc is if you want to override this.
 # Get gcc from brew then use, eg:
-CXX=g++-12
-CC=gcc-12
+CXX=g++-14
+CC=gcc-14
 FC=gfortran
 
 # as in makefile, but with the brew /usr/local/ stuff...
-CFLAGS   += -I src -I/usr/local/include -I/opt/homebrew/include
+CFLAGS   += -I src -I/usr/local/include -I$(shell brew --prefix)/include
 FFLAGS   = $(CFLAGS)
 CXXFLAGS = $(CFLAGS)
-LIBS += -L/usr/local/lib -L/opt/homebrew/lib
+LIBS += -L/usr/local/lib -L$(shell brew --prefix)/lib
 # Workaround to force old linker to be used due to XCode15 (Issue #360):
 LDFLAGS+=-ld64
 
 # If you're getting warning messages of the form:
 #    ld: warning: object file (lib-static/libfinufft.a(finufft1d.o)) was built for
-#    newer OSX version (10.13) than being linked (10.9)
+#    newer OSX version (14.0) than being linked (11.0)
 # Then you can uncomment the following two lines with the older version number
-# (in this example -mmacosx-version-min=10.9)
+# (in this example -mmacosx-version-min=11.0)
 #
 #CFLAGS += "-mmacosx-version-min=<OLDER OSX VERSION NUMBER>"
 
@@ -37,7 +37,7 @@ FFTWOMPSUFFIX=threads
 
 # MATLAB interface:
 # some of these will depend on your FFTW library location...
-MFLAGS += -I/usr/local/include  -I/opt/homebrew/include -L/usr/local/lib -L/opt/homebrew/lib -lm
+MFLAGS += -I/usr/local/include  -I$(shell brew --prefix)/include -L/usr/local/lib -L$(shell brew --prefix)/lib -lm
 # edit for your MATLAB version location...
 MEX = $(shell ls -d /Applications/MATLAB_R20**.app)/bin/mex
 # Also see docs/install.rst for possible edits to MATLAB's MEX XML file.

--- a/perftest/spreadtestnd.cpp
+++ b/perftest/spreadtestnd.cpp
@@ -1,77 +1,82 @@
-#include "finufft/finufft_utils.hpp"
-#include <finufft/spreadinterp.h>
-#include <finufft/test_defs.h>
-
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdio>
+#include <numeric>
 #include <vector>
 
-#include "finufft/finufft_utils.hpp"
-using namespace finufft::spreadinterp;
+#include <finufft/test_defs.h>
+
 using namespace std;
 using namespace finufft::utils;
 
-void usage() {
-  printf("usage: spreadtestnd dims [M N [tol [sort [flags [debug [kerpad [kerevalmeth "
-         "[upsampfac]]]]]]]]\n\twhere dims=1,2 or 3\n\tM=# nonuniform pts\n\tN=# uniform "
-         "pts\n\ttol=requested accuracy\n\tsort=0 (don't sort NU pts), 1 (do), or 2 "
-         "(maybe sort; default)\n\tflags: expert timing flags, 0 is default (see "
-         "spreadinterp.h)\n\tdebug=0 (less text out), 1 (more), 2 (lots)\n\tkerpad=0 (no "
-         "pad to mult of 4), 1 (do, for kerevalmeth=0 only)\n\tkerevalmeth=0 (direct), 1 "
-         "(Horner ppval)\n\tupsampfac>1; 2 or 1.25 for Horner\n\nexample: ./spreadtestnd "
-         "1 1e6 1e6 1e-6 2 0 1\n");
+/* clang-format off */
+static void usage() {
+  printf(
+    "usage: spreadtestnd dims [M N [tol [sort [flags [spread_debug [kerpad [kerevalmeth [upsampfac]]]]]]]]\n"
+    "\twhere dims=1,2 or 3\n"
+    "\tM=# nonuniform pts\n"
+    "\tN=# uniform pts (rough total; per-dim N=round(N^(1/d)))\n"
+    "\ttol=requested accuracy\n"
+    "\tsort=0 (no), 1 (yes), 2 (auto; default)\n"
+    "\tflags: expert timing flags, 0 default (see spreadinterp.h)\n"
+    "\tspread_debug=0,1,...\n"
+    "\tkerpad=0 (no pad), 1 (pad; for kerevalmeth=0 only)\n"
+    "\tkerevalmeth=0 (direct), 1 (Horner)\n"
+    "\tupsampfac>1; 2 or 1.25 typical for Horner\n"
+    "\nexample: ./spreadtestnd 3 8e6 8e6 1e-6 2 0 1\n");
 }
+/* clang-format on */
 
-int main(int argc, char *argv[])
-/* Test executable for the 1D, 2D, or 3D C++ spreader, both directions.
+int main(int argc, char *argv[]) {
+  /* Test executable for the 1D, 2D, or 3D C++ spreader, both directions.
  * It checks speed, and basic correctness via the grid sum of the result.
  * See usage() for usage.  Note it currently tests only pirange=0, which is not
  * the use case in finufft, and can differ in speed (see devel/foldrescale*)
  *
  * Example: spreadtestnd 3 8e6 8e6 1e-6 2 0 1
  *
- * Compilation (also check ../makefile):
- *    g++ spreadtestnd.cpp ../src/spreadinterp.o ../src/utils.o -o spreadtestnd -fPIC
- * -Ofast -funroll-loops -fopenmp
- *
  * Magland; expanded by Barnett 1/14/17. Better cmd line args 3/13/17
  * indep setting N 3/27/17. parallel rand() & sort flag 3/28/17
  * timing_flags 6/14/17. debug control 2/8/18. sort=2 opt 3/5/18, pad 4/24/18.
  * ier=1 warning not error, upsampfac 6/14/20.
  * Barbone, removed pirange 05/09/24.
+ * Barbone switched to public FINUFFT API 11/07/2025
  */
-{
-  int d = 3;             // Cmd line args & their defaults:  default #dims
-  double w, tol = 1e-6;  // default (eg 1e-6 has nspread=7)
-  BIGINT M        = 1e6; // default # NU pts
-  BIGINT roughNg  = 1e6; // default # U pts
-  int sort        = 2;   // spread_sort
-  int flags       = 0;   // default
-  int debug       = 0;   // default
-  int kerpad      = 0;   // default
-  int kerevalmeth = 1;   // default: Horner
-  FLT upsampfac   = 2.0; // standard
+  int d = 3;
+  double w;
+  double tol      = 1e-6;
+  BIGINT M        = 1e6;
+  BIGINT roughNg  = 1e6;
+  int sort        = 2;
+  int flags       = 0;
+  int spread_debug= 0;
+  int kerpad      = 0;
+  int kerevalmeth = 1;
+  FLT upsampfac   = 2.0;
 
   if (argc < 2 || argc == 3 || argc > 11) {
     usage();
     return (argc > 1);
   }
-  sscanf(argv[1], "%d", &d);
-  if (d < 1 || d > 3) {
+  if (sscanf(argv[1], "%d", &d) != 1 || d < 1 || d > 3) {
     printf("d must be 1, 2 or 3!\n");
     usage();
     return 1;
   }
   if (argc > 2) {
-    sscanf(argv[2], "%lf", &w);
-    M = (BIGINT)w; // to read "1e6" right!
+    if (sscanf(argv[2], "%lf", &w) != 1) {
+      usage();
+      return 1;
+    }
+    M = (BIGINT)w; // supports inputs like "1e6"
     if (M < 1) {
       printf("M (# NU pts) must be positive!\n");
       usage();
       return 1;
     }
-    sscanf(argv[3], "%lf", &w);
+    if (sscanf(argv[3], "%lf", &w) != 1) {
+      usage();
+      return 1;
+    }
     roughNg = (BIGINT)w;
     if (roughNg < 1) {
       printf("N (# U pts) must be positive!\n");
@@ -79,223 +84,203 @@ int main(int argc, char *argv[])
       return 1;
     }
   }
-  if (argc > 4) sscanf(argv[4], "%lf", &tol);
+  if (argc > 4) {
+    if (sscanf(argv[4], "%lf", &tol) != 1) {
+      usage();
+      return 1;
+    }
+  }
   if (argc > 5) {
-    sscanf(argv[5], "%d", &sort);
-    if ((sort != 0) && (sort != 1) && (sort != 2)) {
+    if (sscanf(argv[5], "%d", &sort) != 1 || (sort != 0 && sort != 1 && sort != 2)) {
       printf("sort must be 0, 1 or 2!\n");
       usage();
       return 1;
     }
   }
-  if (argc > 6) sscanf(argv[6], "%d", &flags);
+  if (argc > 6) {
+    if (sscanf(argv[6], "%d", &flags) != 1) {
+      usage();
+      return 1;
+    }
+  }
   if (argc > 7) {
-    sscanf(argv[7], "%d", &debug);
-    if ((debug < 0) || (debug > 2)) {
-      printf("debug must be 0, 1 or 2!\n");
+    if (sscanf(argv[7], "%d", &spread_debug) != 1 || spread_debug < 0) {
+      printf("spread_debug must be at least 0!\n");
       usage();
       return 1;
     }
   }
   if (argc > 8) {
-    sscanf(argv[8], "%d", &kerpad);
-    if ((kerpad < 0) || (kerpad > 1)) {
+    if (sscanf(argv[8], "%d", &kerpad) != 1 || kerpad < 0 || kerpad > 1) {
       printf("kerpad must be 0 or 1!\n");
       usage();
       return 1;
     }
   }
   if (argc > 9) {
-    sscanf(argv[9], "%d", &kerevalmeth);
-    if ((kerevalmeth < 0) || (kerevalmeth > 1)) {
+    if (sscanf(argv[9], "%d", &kerevalmeth) != 1 || kerevalmeth < 0 || kerevalmeth > 1) {
       printf("kerevalmeth must be 0 or 1!\n");
       usage();
       return 1;
     }
   }
   if (argc > 10) {
-    sscanf(argv[10], "%lf", &w);
+    if (sscanf(argv[10], "%lf", &w) != 1) {
+      usage();
+      return 1;
+    }
     upsampfac = (FLT)w;
-    if (upsampfac <= 1.0) {
+    if (upsampfac <= (FLT)1.0) {
       printf("upsampfac must be >1.0!\n");
       usage();
       return 1;
     }
   }
 
-  int dodir1 = true;                                   // control if dir=1 tested at all
-  BIGINT N   = (BIGINT)round(pow(roughNg, 1.0 / d));   // Fourier grid size per dim
-  BIGINT Ng  = (BIGINT)pow(N, d);                      // actual total grid points
-  BIGINT N2 = (d >= 2) ? N : 1, N3 = (d == 3) ? N : 1; // the y and z grid sizes
-  std::vector<FLT> kx(M), ky(1), kz(1), d_nonuniform(2 * M); // NU, Re & Im
-  if (d > 1) ky.resize(M);                                   // only alloc needed coords
-  if (d > 2) kz.resize(M);
-  std::vector<FLT> d_uniform(2 * Ng);                        // Re and Im
+  // Derive per-dim size and total U-grid size
+  const auto N  = (BIGINT)llround(pow((long double)roughNg, 1.0L / (long double)d));
+  const auto Ng = (BIGINT)pow((long double)N, (long double)d);
 
-  finufft_spread_opts opts;
-  int ier_set = setup_spreader(opts, (FLT)tol, upsampfac, kerevalmeth, debug, 1, d, 1);
-  if (ier_set > 1) { // exit gracefully if can't set up.
-    printf("error when setting up spreader (ier_set=%d)!\n", ier_set);
-    return ier_set;
-  }
-  opts.debug        = debug; // print more diagnostics?
-  opts.sort         = sort;
-  opts.flags        = flags;
-  opts.kerpad       = kerpad;
-  opts.upsampfac    = upsampfac;
-  opts.nthreads     = 0; // max # threads used, or 0 to use what's avail
-  opts.sort_threads = 0;
-  // opts.max_subproblem_size = 1e5;
-  FLT maxerr, ansmod;
+  // Allocate NU coords and data
+  vector<FLT> kx(M), ky(d > 1 ? M : 1), kz(d > 2 ? M : 1);
+  vector<CPX> d_nonuniform(M), d_uniform(Ng);
 
-  // spread a single source, only for reference accuracy check...
-  opts.spread_direction = 1;
-  d_nonuniform[0]       = 1.0;
-  d_nonuniform[1]       = 0.0; // unit strength
-  kx[0] = ky[0] = kz[0] = 0.0; // at center (probably doesn't matter); domain is
-                               // [-pi,pi)^d
-  int ier = spreadinterp(N,
-                         N2,
-                         N3,
-                         d_uniform.data(),
-                         1,
-                         kx.data(),
-                         ky.data(),
-                         kz.data(),
-                         d_nonuniform.data(),
-                         opts); // vector::data officially C++11 but works
-  if (ier != 0) {
-    printf("error when spreading M=1 pt for ref acc check (ier=%d)!\n", ier);
+  // Options
+  FINUFFT_PLAN plan{};
+  finufft_opts opts;
+  FINUFFT_DEFAULT_OPTS(&opts);
+  opts.upsampfac          = upsampfac;
+  opts.spread_kerevalmeth = kerevalmeth;
+  opts.spread_debug       = spread_debug;
+  opts.spread_sort        = sort;
+  opts.spread_kerpad      = kerpad;
+  opts.showwarn           = 1;
+  opts.spreadinterponly   = 1;
+
+  BIGINT nmodes[3] = {N, N, N};
+
+  // Make plan for type-1 (NU -> U). With spread/interp only, we can use adjoint too.
+  int ier = FINUFFT_MAKEPLAN(1, d, nmodes, 1, 1, tol, &plan, &opts);
+  if (ier > 1) {
+    printf("error when creating the plan (ier=%d)!\n", ier);
     return ier;
   }
-  FLT kersumre = 0.0, kersumim = 0.0; // sum kernel on uniform grid
-  for (BIGINT i = 0; i < Ng; ++i) {
-    kersumre += d_uniform[2 * i];
-    kersumim += d_uniform[2 * i + 1]; // in case the kernel isn't real!
-  }
 
-  // now do the large-scale test w/ random sources..
-  printf("making random data...\n");
-  FLT strre = 0.0, strim = 0.0; // also sum the strengths
-#pragma omp parallel
-  {
-    unsigned int se = MY_OMP_GET_THREAD_NUM(); // needed for parallel random #s
-#pragma omp for schedule(dynamic, 1000000) reduction(+ : strre, strim)
-    for (BIGINT i = 0; i < M; ++i) {
-      kx[i] = randm11r(&se) * 3 * PI;
-      // kx[i]=2.0*kx[i] - 50.0;      //// to test folding within +-1 period
-      if (d > 1) ky[i] = randm11r(&se) * 3 * PI; // only fill needed coords
-      if (d > 2) kz[i] = randm11r(&se) * 3 * PI;
-      d_nonuniform[i * 2]     = randm11r(&se);
-      d_nonuniform[i * 2 + 1] = randm11r(&se);
-      strre += d_nonuniform[2 * i];
-      strim += d_nonuniform[2 * i + 1];
-    }
-  }
-  CNTime timer;
-  double t;
-  if (dodir1) { // test direction 1 (NU -> U spreading) ......................
-    printf("spreadinterp %dD, %.3g U pts, dir=%d, tol=%.3g: nspread=%d\n",
-           d,
-           (double)Ng,
-           opts.spread_direction,
-           tol,
-           opts.nspread);
-    timer.start();
-    ier = spreadinterp(N,
-                       N2,
-                       N3,
-                       d_uniform.data(),
-                       M,
-                       kx.data(),
-                       ky.data(),
-                       kz.data(),
-                       d_nonuniform.data(),
-                       opts);
-    t   = timer.elapsedsec();
-    if (ier != 0) {
-      printf("error (ier=%d)!\n", ier);
-      return ier;
-    } else
-      printf("    %.3g NU pts in %.3g s \t%.3g pts/s \t%.3g spread pts/s\n",
-             (double)M,
-             t,
-             M / t,
-             pow(opts.nspread, d) * M / t);
-
-    FLT sumre = 0.0, sumim = 0.0; // check spreading accuracy, wrapping
-#pragma omp parallel for reduction(+ : sumre, sumim)
-    for (BIGINT i = 0; i < Ng; ++i) {
-      sumre += d_uniform[2 * i];
-      sumim += d_uniform[2 * i + 1];
-    }
-    FLT pre    = kersumre * strre - kersumim * strim; // pred ans, complex mult
-    FLT pim    = kersumim * strre + kersumre * strim;
-    FLT maxerr = std::max(fabs(sumre - pre), fabs(sumim - pim));
-    FLT ansmod = sqrt(sumre * sumre + sumim * sumim);
-    printf("    rel err in total over grid:      %.3g\n", maxerr / ansmod);
-    // note this is weaker than below dir=2 test, but is good indicator that
-    // periodic wrapping is correct
-  }
-
-  // test direction 2 (U -> NU interpolation) ..............................
-  printf("making more random NU pts...\n");
-  for (BIGINT i = 0; i < Ng; ++i) { // unit grid data
-    d_uniform[2 * i]     = 1.0;
-    d_uniform[2 * i + 1] = 0.0;
-  }
-#pragma omp parallel
-  {
-    unsigned int se = MY_OMP_GET_THREAD_NUM(); // needed for parallel random #s
-#pragma omp for schedule(dynamic, 1000000)
-    for (BIGINT i = 0; i < M; ++i) {           // random target pts
-      // kx[i]=10+.9*rand01r(&s)*N;   // or if want to keep ns away from edges
-      kx[i] = randm11r(&se) * 3 * PI;
-      if (d > 1) ky[i] = randm11r(&se) * 3 * PI;
-      if (d > 2) kz[i] = randm11r(&se) * 3 * PI;
-    }
-  }
-
-  opts.spread_direction = 2;
-  printf("spreadinterp %dD, %.3g U pts, dir=%d, tol=%.3g: nspread=%d\n",
-         d,
-         (double)Ng,
-         opts.spread_direction,
-         tol,
-         opts.nspread);
-  timer.restart();
-  ier = spreadinterp(N,
-                     N2,
-                     N3,
-                     d_uniform.data(),
-                     M,
-                     kx.data(),
-                     ky.data(),
-                     kz.data(),
-                     d_nonuniform.data(),
-                     opts);
-  t   = timer.elapsedsec();
+  // Initialize NU points (will be overwritten later), and set in plan
+  ier = FINUFFT_SETPTS(plan, M, kx.data(), ky.data(), kz.data(), 0, nullptr, nullptr,
+                       nullptr);
   if (ier != 0) {
-    printf("error (ier=%d)!\n", ier);
-    return 1;
-  } else
-    printf("    %.3g NU pts in %.3g s \t%.3g pts/s \t%.3g spread pts/s\n",
-           (double)M,
-           t,
-           M / t,
-           pow(opts.nspread, d) * M / t);
-
-  // math test is worst-case error from pred value (kersum) on interp pts:
-  maxerr = 0.0;
-  for (BIGINT i = 0; i < M; ++i) {
-    FLT err = std::max(fabs(d_nonuniform[2 * i] - kersumre),
-                       fabs(d_nonuniform[2 * i + 1] - kersumim));
-    if (err > maxerr) maxerr = err;
+    printf("error when setting NU pts (ier=%d)!\n", ier);
+    FINUFFT_DESTROY(plan);
+    return ier;
   }
-  ansmod = sqrt(kersumre * kersumre + kersumim * kersumim);
-  printf("    max rel err in values at NU pts: %.3g\n", maxerr / ansmod);
-  // this is stronger test than for dir=1, since it tests sum of kernel for
-  // each NU pt. However, it cannot detect reading
-  // from wrong grid pts (they are all unity)
+
+  // Reference: spread a single source at origin to get kernel sum over grid
+  d_nonuniform.assign(M, CPX(0.0, 0.0));
+  d_nonuniform[0] = CPX(1.0, 0.0);
+  kx[0]           = 0.0;
+  if (d > 1) ky[0] = 0.0;
+  if (d > 2) kz[0] = 0.0;
+
+  ier = FINUFFT_EXECUTE(plan, d_nonuniform.data(), d_uniform.data());
+  if (ier != 0) {
+    printf("error when spreading M=1 pt for ref acc check (ier=%d)!\n", ier);
+    FINUFFT_DESTROY(plan);
+    return ier;
+  }
+  const CPX kersum = std::accumulate(d_uniform.begin(), d_uniform.end(), CPX(0.0, 0.0));
+
+  // -------- Type-1 test (spread) --------
+  printf("Config: d=%d, per-dim N=%lld, total Ng=%.3g, M=%.3g, tol=%.3g, kereval=%d, "
+         "upsamp=%.3g, sort=%d\n",
+         d, (long long)N, (double)Ng, (double)M, tol, kerevalmeth, (double)upsampfac,
+         sort);
+
+  printf("making random data for dir=1...\n");
+#pragma omp parallel
+  {
+    unsigned int se = MY_OMP_GET_THREAD_NUM();
+#pragma omp for schedule(static)
+    for (BIGINT i = 0; i < M; ++i) {
+      // Stress periodic wrapping: coordinates in [-3π, 3π]
+      kx[i] = randm11r(&se) * (FLT)(3 * PI);
+      if (d > 1) ky[i] = randm11r(&se) * (FLT)(3 * PI);
+      if (d > 2) kz[i] = randm11r(&se) * (FLT)(3 * PI);
+      d_nonuniform[i] = crandm11r(&se);
+    }
+  }
+  const CPX strsum =
+      std::accumulate(d_nonuniform.begin(), d_nonuniform.end(), CPX(0.0, 0.0));
+
+  CNTime timer{};
+  timer.start();
+  ier = FINUFFT_SETPTS(plan, M, kx.data(), ky.data(), kz.data(), 0, nullptr, nullptr,
+                       nullptr);
+  ier = FINUFFT_EXECUTE(plan, d_nonuniform.data(), d_uniform.data());
+  const double t1 = timer.elapsedsec();
+  if (ier != 0) {
+    printf("error in dir=1 execute (ier=%d)!\n", ier);
+    FINUFFT_DESTROY(plan);
+    return ier;
+  }
+  const CPX sum_grid = std::accumulate(d_uniform.begin(), d_uniform.end(), CPX(0.0, 0.0));
+    // Compute total input strength and total output mass, compare with kersum
+    CPX csum = std::accumulate(d_nonuniform.begin(), d_nonuniform.end(), CPX(0.0, 0.0));
+    CPX mass = std::accumulate(d_uniform.begin(), d_uniform.end(), CPX(0.0, 0.0));
+    FLT relerr = std::abs(mass - kersum * csum) / std::abs(mass);
+    printf("\trel err in total over grid: %.3g\n", relerr);
+    (void)strsum; // keep unused var silence if any
+
+  // -------- Type-2 test (U -> NU) using a separate type-2 plan --------
+  printf("making random NU pts for dir=2...\n");
+  std::fill(d_uniform.begin(), d_uniform.end(), CPX(1.0, 0.0));
+#pragma omp parallel
+  {
+    unsigned int se = MY_OMP_GET_THREAD_NUM();
+#pragma omp for schedule(static)
+    for (BIGINT i = 0; i < M; ++i) {
+      kx[i] = randm11r(&se) * (FLT)(3 * PI);
+      if (d > 1) ky[i] = randm11r(&se) * (FLT)(3 * PI);
+      if (d > 2) kz[i] = randm11r(&se) * (FLT)(3 * PI);
+    }
+  }
+  // Create a separate plan for type-2 (U -> NU) and use it instead of the
+  // adjoint call on the type-1 plan. This matches the public API usage where
+  // a type-2 plan is created and executed.
+  FINUFFT_PLAN plan2{};
+  ier = FINUFFT_MAKEPLAN(2, d, nmodes, 1, 1, tol, &plan2, &opts);
+  if (ier > 1) {
+    printf("error when creating the type-2 plan (ier=%d)!\n", ier);
+    FINUFFT_DESTROY(plan);
+    return ier;
+  }
+
+  timer.restart();
+  ier = FINUFFT_SETPTS(plan2, M, kx.data(), ky.data(), kz.data(), 0, nullptr, nullptr,
+                       nullptr);
+  if (ier != 0) {
+    printf("error when setting NU pts for type-2 plan (ier=%d)!\n", ier);
+    FINUFFT_DESTROY(plan);
+    FINUFFT_DESTROY(plan2);
+    return ier;
+  }
+
+  ier = FINUFFT_EXECUTE(plan2, d_nonuniform.data(), d_uniform.data());
+  const double t2 = timer.elapsedsec();
+  if (ier != 0) {
+    printf("error in dir=2 execute (ier=%d)!\n", ier);
+    FINUFFT_DESTROY(plan);
+    FINUFFT_DESTROY(plan2);
+    return ier;
+  }
+  // interp-only check: set grid ones was done above, execute adjoint produced
+  // values at NU points in d_nonuniform. Compute sup error vs kersum.
+  CPX csum2 = std::accumulate(d_nonuniform.begin(), d_nonuniform.end(), CPX(0.0, 0.0));
+  FLT superr = 0.0;
+  for (auto &cj : d_nonuniform) superr = std::max(superr, std::abs(cj - kersum));
+  FLT relsuperr = superr / std::abs(kersum);
+  printf("\trel sup err %.3g\n", relsuperr);
+  FINUFFT_DESTROY(plan);
+  FINUFFT_DESTROY(plan2);
   return 0;
 }

--- a/python/finufft/test/fig_accuracy.py
+++ b/python/finufft/test/fig_accuracy.py
@@ -1,0 +1,59 @@
+# python/finufft/test/fig_accuracy.py
+# Plots err = ||f_nufft - f_exact||_2 / ||f_exact||_2 vs tol.
+
+import numpy as np
+import matplotlib.pyplot as plt
+import finufft
+
+def finufft1d_accuracy_plot(M=10_000, N=100, isign=+1, upsampfac=2.00, seed=42, hold_inputs=False):
+    rng = np.random.default_rng(seed)
+
+    # Tolerances: 10.^(-1:-0.02:-15)
+    exps = np.arange(-1.0, -15.0 - 1e-12, -0.02, dtype=np.float64)
+    tols = np.power(10.0, exps, dtype=np.float64)
+    errs = np.empty_like(tols)
+
+    # Mode indices: k = ceil(-N/2) : floor((N-1)/2)
+    kmin = int(np.ceil(-N / 2))
+    kmax = int(np.floor((N - 1) / 2))
+    ns = np.arange(kmin, kmax + 1, dtype=np.int64)  # length N
+
+    # Optionally hold inputs fixed across tolerances
+    if hold_inputs:
+        x = rng.uniform(-np.pi, np.pi, size=M)                  # no dtype kw
+        c = rng.normal(size=M) + 1j * rng.normal(size=M)
+        x = np.asarray(x, dtype=np.float64)
+        c = np.asarray(c, dtype=np.complex128)
+
+    for t, tol in enumerate(tols):
+        if not hold_inputs:
+            x = rng.uniform(-np.pi, np.pi, size=M)
+            c = rng.normal(size=M) + 1j * rng.normal(size=M)
+            x = np.asarray(x, dtype=np.float64)
+            c = np.asarray(c, dtype=np.complex128)
+
+        # FINUFFT type-1. Pass (N,) not N. Pass opts via 'opts=...'.
+        f_nufft = finufft.nufft1d1(x, c, N, eps=tol, upsampfac=upsampfac)
+
+        # Exact result: fe[k] = sum_j c_j * exp(i*isign*k*x_j)
+        fe = np.exp(1j * isign * (ns[:, None] * x[None, :])) @ c
+
+        errs[t] = np.linalg.norm(f_nufft - fe) / np.linalg.norm(fe)
+
+    # Plot
+    plt.figure()
+    plt.loglog(tols, errs, '+', label='measured')
+    plt.plot(tols, tols, '-', label='y=x')
+    plt.xlabel('tol')
+    plt.ylabel('err')
+    plt.title(rf'1d1: $\|\tilde f - f\|_2 / \|f\|_2$, M={M}, N={N}')
+    plt.grid(True, which='both')
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+    return tols, errs
+
+if __name__ == "__main__":
+    # Default: new x,c per tol; set hold_inputs=True to reuse inputs.
+    finufft1d_accuracy_plot()

--- a/src/cuda/memtransfer_wrapper.cu
+++ b/src/cuda/memtransfer_wrapper.cu
@@ -382,7 +382,7 @@ int allocgpumem3d_nupts(cufinufft_plan_t<T> *d_plan)
   int M = d_plan->M;
 
   CUDA_FREE_AND_NULL(d_plan->sortidx, stream, d_plan->supports_pools);
-  CUDA_FREE_AND_NULL(d_plan->idxnupts, stream, d_plan->supports_pools)
+  CUDA_FREE_AND_NULL(d_plan->idxnupts, stream, d_plan->supports_pools);
 
   switch (d_plan->opts.gpu_method) {
   case 1: {

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -83,11 +83,11 @@ int main(int argc, char *argv[]) {
   }
   constexpr FLT EPSILON = std::numeric_limits<FLT>::epsilon();
   FLT relerr            = 2.0 * EPSILON; // 1 ULP, fine since 1.0 rep exactly
-  if (abs(infnorm(M, &a[0]) - 1.0) > relerr) return 1;
-  if (abs(twonorm(M, &a[0]) - sqrt((FLT)M)) > relerr * sqrt((FLT)M)) return 1;
+  if (std::abs(infnorm(M, &a[0]) - 1.0) > relerr) return 1;
+  if (std::abs(twonorm(M, &a[0]) - std::sqrt((FLT)M)) > relerr * std::sqrt((FLT)M)) return 1;
   b[0] = CPX(0.0, 0.0); // perturb b from a
-  if (abs(errtwonorm(M, &a[0], &b[0]) - 1.0) > relerr) return 1;
-  if (abs(sqrt((FLT)M) * relerrtwonorm(M, &a[0], &b[0]) - 1.0) > relerr) return 1;
+  if (std::abs(errtwonorm(M, &a[0], &b[0]) - 1.0) > relerr) return 1;
+  if (std::abs(std::sqrt((FLT)M) * relerrtwonorm(M, &a[0], &b[0]) - 1.0) > relerr) return 1;
 
 #ifdef SINGLE
   printf("testutilsf passed.\n");


### PR DESCRIPTION
1. ~adding polyfit as a dependency~
2. using polyfit style procedure to compute the horner coefficients
3. no tweaks to kernel and kernel parameters. Kept simple for now

Caveats: I cannot delete the headers with precomputed coefficients because evaluate_kernel_horner uses it. However, this function is not used anywhere. Can we remove it? It was added to use horner in onedim_fseries_kernel. I don't really see why we should use horner there. Or should I integrate the new horner coefficients there too?

Any change to the analytical kernel will be reflected in both now. Since horner and analytical are accurate enough to be interchangeable. 

@ahbarnett what do you think?

~The performance of this might be slightly worse (not tested yet) because nc is chosen conservatively (as w+3, from the paper). However, for the precomputed coeffs @ahbarnett tweaks nc to meet accuracy for any ns.~

~PS: this can  be fixed by using the eps interface to polyfit bu it requires some more dispatching from compile time to runtime so it will be a separate PR.~

