### PR TITLE
ducc - use github mirror

### DIFF
--- a/cmake/setupDUCC.cmake
+++ b/cmake/setupDUCC.cmake
@@ -2,9 +2,11 @@ CPMAddPackage(
     NAME
     ducc0
     GIT_REPOSITORY
-    https://gitlab.mpcdf.mpg.de/mtr/ducc.git
+    https://github.com/mreineck/ducc.git
     GIT_TAG
     ${DUCC0_VERSION}
+    GIT_SHALLOW
+    YES
     DOWNLOAD_ONLY
     YES
 )

--- a/makefile
+++ b/makefile
@@ -72,7 +72,7 @@ XSIMD_VERSION := 14.0.0
 XSIMD_DIR := $(DEPS_ROOT)/xsimd
 
 # DUCC sources optional dependency repo
-DUCC_URL := https://gitlab.mpcdf.mpg.de/mtr/ducc.git
+DUCC_URL := https://github.com/mreineck/ducc.git
 DUCC_VERSION := ducc0_0_39_1
 DUCC_DIR := $(DEPS_ROOT)/ducc
 # this dummy file used as empty target by make...


### PR DESCRIPTION
Upstream repository of DUCC is unfortunately pretty unreliable and slow.
In this PR I propose switching to the repo URL the Github mirror maintained by its author @mreineck .
Another alternative is making this configurable, but I don't think that's worth the extra complexity.