### PR TITLE
minor update on python doc generation

### DIFF
--- a/docs/python_gpu.rst
+++ b/docs/python_gpu.rst
@@ -67,3 +67,9 @@ Full documentation
     :members:
     :member-order: bysource
     :undoc-members:
+    :exclude-members: Plan
+
+.. autoclass:: cufinufft.Plan
+    :members:
+    :member-order: bysource
+    :undoc-members:

--- a/python/finufft/finufft/_interfaces.py
+++ b/python/finufft/finufft/_interfaces.py
@@ -864,22 +864,22 @@ def _set_nufft_doc(f, dim, tp, example='python/finufft/test/accuracy_speed_tests
     v['pt_spacing'] = ' ' * (len(v['pt_idx']) - 2)
     v['pt_inner'] = ' + '.join('k{0} {1}(j)'.format(i, x) for i, x in zip(dims, pts[:dim]))
     v['pt_constraint'] = ', '.join('-N{0}/2 <= k{0} <= (N{0}-1)/2'.format(i) for i in dims)
-    v['pts_doc'] = '\n'.join('{}(float[M]): nonuniform points, in [-pi, pi), values outside will be folded'.format(x) for x in pts[:dim])
+    v['pts_doc'] = '\n'.join('      {}(float[M]): nonuniform points, in [-pi, pi), values outside will be folded'.format(x) for x in pts[:dim]) + '\n'
 
     # for example
     v['pts'] = ', '.join(str(x) for x in pts[:dim])
-    v['pts_generate'] = '\n'.join('{} = 2 * np.pi * np.random.uniform(size=M)'.format(x) for x in pts[:dim])
+    v['pts_generate'] = '\n'.join('      {} = 2 * np.pi * np.random.uniform(size=M)'.format(x) for x in pts[:dim])
     v['sample_modes'] = ', '.join(str(n) for n in sample_modes[:dim])
     v['example'] = example
 
     # for type 3 only
-    v['src_pts_doc'] = '\n'.join('{}(float[M]): nonuniform points, valid in [-pi, pi), values outside will be folded'.format(x) for x in pts[:dim])
-    v['target_pts_doc'] = '\n'.join('{}(float[N]): nonuniform target points.'.format(x) for x in target_pts[:dim])
+    v['src_pts_doc'] = '\n'.join('      {}(float[M]): nonuniform points, valid in [-pi, pi), values outside will be folded'.format(x) for x in pts[:dim]) + '\n'
+    v['target_pts_doc'] = '\n'.join('      {}(float[N]): nonuniform target points.'.format(x) for x in target_pts[:dim]) + '\n'
     v['pt_inner_type3'] = ' + '.join('{0}[k] {1}[j]'.format(s, x) for s, x in zip(target_pts[:dim], pts[:dim]))
 
     # for type 3 example only
     v['target_pts'] = ', '.join(str(x) for x in target_pts[:dim])
-    v['target_pts_generate'] = '\n'.join('{} = 2 * np.pi * np.random.uniform(size=N)'.format(x) for x in target_pts[:dim])
+    v['target_pts_generate'] = '\n'.join('      {} = 2 * np.pi * np.random.uniform(size=N)'.format(x) for x in target_pts[:dim])
 
     if dim > 1:
         v['pt_inner'] = '(' + v['pt_inner'] + ')'


### PR DESCRIPTION
fix the python doc indent format issue mentioned in https://github.com/flatironinstitute/finufft/issues/749#issuecomment-3517157874
preview: https://doc-test-run.readthedocs.io/en/latest/python.html#module-finufft

group 5 properties(dim, dtype, n_modes, n_trans and type) of Plan
preview: https://doc-test-run.readthedocs.io/en/latest/python_gpu.html#cufinufft.Plan.type