### PR TITLE
This allows clang-format to run only on modified lines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,14 @@
 repos:
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v21.1.7'
+  - repo: local
     hooks:
-      - id: clang-format
-        types_or: [c++, c, cuda]
+      - id: git-clang-format-staged
+        name: git clang-format (staged only)
+        entry: git-clang-format --staged
+        language: python
+        additional_dependencies:
+          - clang-format
+        pass_filenames: false
+        types_or: [ c++, c, cuda ]
         files: \.(c|cc|cpp|h|hpp|cu|cuh)$
         exclude: '(^|/)(matlab/.*)$'
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
@lu1and10 this should address the spurious changes done by the hook. I tested it locally by messing some files and restoring them