### PR TITLE
Fix segfault for 1e8 points in single precision

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 List of features / changes made / release notes, in reverse chronological order.
 If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
-Master (working towards v2.5.0), 1/12/26
+Master (working towards v2.5.0), 01/29/26
 
 * Moved finufft_spread_opts.h from public-facing to private header (Barnett).
 * fixed no-setpts bug in perftest/spreadtestndall, updated perftests (Barnett).
@@ -50,6 +50,8 @@ Master (working towards v2.5.0), 1/12/26
   no-ops. Documentation, examples, and Fortran/C headers were updated to
   reflect these changes. Horner evaluation now supports any `upsampfac`.
   (Barbone, #760)
+* Added bounds checks for CUDA method 3 to prevent segfault in single-precision
+  when the dimension is >= 1e8 (DiamonDinoia #802)
 
 V 2.4.1 7/8/25
 

--- a/src/cuda/1d/spreadinterp1d.cuh
+++ b/src/cuda/1d/spreadinterp1d.cuh
@@ -156,7 +156,7 @@ __global__ void spread_1d_output_driven(
       for (int idx = threadIdx.x; idx < total; idx += blockDim.x) {
         const int ix = xstart + idx + ns_2;
         if constexpr (std::is_same_v<T, float>) {
-          if (ix >= (bin_size_x + rounded_ns) || ix < 0) break;
+          if (ix >= (padded_size_x) || ix < 0) break;
         }
         // separable window weights
         const auto kervalue = kerevals(i, idx);

--- a/src/cuda/2d/spreadinterp2d.cuh
+++ b/src/cuda/2d/spreadinterp2d.cuh
@@ -293,6 +293,10 @@ __global__ void spread_2d_output_driven(
         const int iy = real_yy + ns_2;
         const int ix = real_xx + ns_2;
 
+        if constexpr (std::is_same_v<T, float>) {
+          if (ix >= (padded_size_x) || ix < 0) break;
+          if (iy >= (padded_size_y) || iy < 0) break;
+        }
         // separable window weights
         const auto kervalue = kerevals(i, 0, xx) * kerevals(i, 1, yy);
 


### PR DESCRIPTION
I think this is only an issue in 1D/2D. I think it is quite unlikely for this to happen in 3D given the 80Gb max of VRAM available on GPUs. 