### PR TITLE
Python bindings store references when they should not

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,7 +51,9 @@ Master (working towards v2.5.0), 01/29/26
   reflect these changes. Horner evaluation now supports any `upsampfac`.
   (Barbone, #760)
 * Added bounds checks for CUDA method 3 to prevent segfault in single-precision
-  when the dimension is >= 1e8 (DiamonDinoia #802)
+  when the dimension is >= 1e8 (Barbone #802)
+* Fixed memory leak in python bindings due to storing input references for too long.
+  (Barbone #804)
 
 V 2.4.1 7/8/25
 

--- a/python/cufinufft/cufinufft/_plan.py
+++ b/python/cufinufft/cufinufft/_plan.py
@@ -261,7 +261,7 @@ class Plan:
 
         # We will also store references to these arrays.
         #   This keeps python from prematurely cleaning them up.
-        self._references.append(_x)
+        self._references = [_x]
         if self._dim >= 2:
             fpts_axes.insert(0, _compat.get_array_ptr(_y))
             self._references.append(_y)
@@ -374,7 +374,7 @@ class Plan:
         self._plan = None
 
         # Reset our reference.
-        self._references = []
+        self._references.clear()
 
 
 def _ensure_array_type(x, name, dtype, output=False):


### PR DESCRIPTION
Fixed memory leak in python bindings due to storing input references for too long.