### PR TITLE
Optimize bin size and np for output driven

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,29 +3,9 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 Master (working towards v2.5.0), 01/29/26
 
-* Major overhaul of spreading (gridding) kernel function choice, parameters,
-  and code logic, to exploit the new on-the-fly kernel polynomial fitting:
-  Switch default kernel to PSWF (prolate) with constant shift from the cutoff
-  shape parameter, improving by 0.3-0.6 digit at the same w (width).
-  Comparisons against many kernels (KB, cosh, cont variants...) done.
-  The logic of choosing ns from tol is improved to give lower and
-  more predictable error across types, sigma (upsampfac), and dimensions.
-  NOTE: this is a math change, and will affect the answers FINUFFT gives!
-  (at the level of the tolerance). In almost all cases the change will be to
-  a more accurate result. tol is now a better upper bound on relative error;
-  hence users may want to adjust tol (slightly) in their codes.
-  See https://github.com/flatironinstitute/finufft/discussions/798
-  Legacy (2017-2025) ES kernel and parameters are available
-  via (new) option field opts.spread_kerformula=1 (with default of 0).
-  Simplified kernel definition to [-1,1], simplified old ES-specific spopts.
-  Added several new MATLAB tolerance-sweeping error-measure tools, and CI:
-  tolsweeptest.m is run in CI & has a multi-fig plot option (to test/results/)
-  Kernel-comparison-vs-w mean rel err plotter wsweepkerrcomp.m (Barnett #787).
-* fix no-setpts bug in perftest/spreadtestndall, better perftests (Barnett #791)
-* exhaustive tolerance testing in CI via new tolsweep.cpp (Barnett, #780)
+* Moved finufft_spread_opts.h from public-facing to private header (Barnett).
+* fixed no-setpts bug in perftest/spreadtestndall, updated perftests (Barnett).
 * Added real-valued function type-2 interpolation demos (Barnett, Unalmis #722)
-* Moved finufft_spread_opts.h from public-facing to private header, allowing
-  easy changes without affecting the API. (Barnett #791)
 * Added functionality for adjoint execution of FINUFFT plans (Reinecke #633,
   addresses #566 and #571).
   Work arrays are now only allocated during plan execution, reducing overall
@@ -58,7 +38,7 @@ Master (working towards v2.5.0), 01/29/26
   spreadtestnd, spreadtestndall and test_spreadinterponly were updated to use
   the public API and share a unified STL-based implementation for kersum,
   mass and relative-error checks. This common kernel header will also enable
-  reuse by the GPU. (Barbone, Barnett, Lu, PR #748 and some in #791)
+  reuse by the GPU. (Barbone, Barnett, Lu, PR #748)
 * Purged legacy `TF_OMIT_*` timing flags from headers and core source and
   removed timing-related omission flags. Deprecated `kerevalmeth` and
   `kerpad` are retained only for API compatibility but are ignored; the
@@ -72,9 +52,12 @@ Master (working towards v2.5.0), 01/29/26
   (Barbone, #760)
 * Added bounds checks for CUDA method 3 to prevent segfault in single-precision
   when the dimension is >= 1e8 (Barbone #802)
-* Fixed memory leak in python bindings due to storing input references for too
-  long (Barbone #804)
-* Added support to clone a specific commit in makefile (Barbone #806)
+* Fixed memory leak in python bindings due to storing input references for too long.
+  (Barbone #804)
+* Reduced shared-memory usage for Method 2/3 in 3D double-precision (15-digit) runs,
+  preventing crashes on systems with very small available shmem.
+  Added benchmarking-based autotuning to select binsize and np for best performance.
+  Cleaned up and consolidated debug printing output. (Barbone #807)
 
 V 2.4.1 7/8/25
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,9 +3,29 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 Master (working towards v2.5.0), 01/29/26
 
-* Moved finufft_spread_opts.h from public-facing to private header (Barnett).
-* fixed no-setpts bug in perftest/spreadtestndall, updated perftests (Barnett).
+* Major overhaul of spreading (gridding) kernel function choice, parameters,
+  and code logic, to exploit the new on-the-fly kernel polynomial fitting:
+  Switch default kernel to PSWF (prolate) with constant shift from the cutoff
+  shape parameter, improving by 0.3-0.6 digit at the same w (width).
+  Comparisons against many kernels (KB, cosh, cont variants...) done.
+  The logic of choosing ns from tol is improved to give lower and
+  more predictable error across types, sigma (upsampfac), and dimensions.
+  NOTE: this is a math change, and will affect the answers FINUFFT gives!
+  (at the level of the tolerance). In almost all cases the change will be to
+  a more accurate result. tol is now a better upper bound on relative error;
+  hence users may want to adjust tol (slightly) in their codes.
+  See https://github.com/flatironinstitute/finufft/discussions/798
+  Legacy (2017-2025) ES kernel and parameters are available
+  via (new) option field opts.spread_kerformula=1 (with default of 0).
+  Simplified kernel definition to [-1,1], simplified old ES-specific spopts.
+  Added several new MATLAB tolerance-sweeping error-measure tools, and CI:
+  tolsweeptest.m is run in CI & has a multi-fig plot option (to test/results/)
+  Kernel-comparison-vs-w mean rel err plotter wsweepkerrcomp.m (Barnett #787).
+* fix no-setpts bug in perftest/spreadtestndall, better perftests (Barnett #791)
+* exhaustive tolerance testing in CI via new tolsweep.cpp (Barnett, #780)
 * Added real-valued function type-2 interpolation demos (Barnett, Unalmis #722)
+* Moved finufft_spread_opts.h from public-facing to private header, allowing
+  easy changes without affecting the API. (Barnett #791)
 * Added functionality for adjoint execution of FINUFFT plans (Reinecke #633,
   addresses #566 and #571).
   Work arrays are now only allocated during plan execution, reducing overall
@@ -38,7 +58,7 @@ Master (working towards v2.5.0), 01/29/26
   spreadtestnd, spreadtestndall and test_spreadinterponly were updated to use
   the public API and share a unified STL-based implementation for kersum,
   mass and relative-error checks. This common kernel header will also enable
-  reuse by the GPU. (Barbone, Barnett, Lu, PR #748)
+  reuse by the GPU. (Barbone, Barnett, Lu, PR #748 and some in #791)
 * Purged legacy `TF_OMIT_*` timing flags from headers and core source and
   removed timing-related omission flags. Deprecated `kerevalmeth` and
   `kerpad` are retained only for API compatibility but are ignored; the
@@ -52,8 +72,9 @@ Master (working towards v2.5.0), 01/29/26
   (Barbone, #760)
 * Added bounds checks for CUDA method 3 to prevent segfault in single-precision
   when the dimension is >= 1e8 (Barbone #802)
-* Fixed memory leak in python bindings due to storing input references for too long.
-  (Barbone #804)
+* Fixed memory leak in python bindings due to storing input references for too
+  long (Barbone #804)
+* Added support to clone a specific commit in makefile (Barbone #806)
 * Reduced shared-memory usage for Method 2/3 in 3D double-precision (15-digit) runs,
   preventing crashes on systems with very small available shmem.
   Added benchmarking-based autotuning to select binsize and np for best performance.

--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -197,20 +197,11 @@ int cufinufft_makeplan_impl(int type, int dim, int *nmodes, int iflag, int ntran
       goto finalize;
     }
   }
-  if (d_plan->opts.debug) {
-    printf("[cufinufft] bin size x: %d", d_plan->opts.gpu_binsizex);
-    if (dim > 1) printf(" bin size y: %d", d_plan->opts.gpu_binsizey);
-    if (dim > 2) printf(" bin size z: %d", d_plan->opts.gpu_binsizez);
-    printf("\n");
-    // shared memory required for the spreader vs available shared memory
-    int shared_mem_per_block{};
-    cudaDeviceGetAttribute(&shared_mem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin,
-                           device_id);
-    const auto mem_required = shared_memory_required<T>(
-        dim, d_plan->spopts.nspread, d_plan->opts.gpu_binsizex, d_plan->opts.gpu_binsizey,
-        d_plan->opts.gpu_binsizez, d_plan->opts.gpu_np);
-    printf("[cufinufft] shared memory required for the spreader: %ld\n", mem_required);
-    printf("[cufinufft] gpu_Np = %ld\n", d_plan->opts.gpu_np);
+  // Bin size and memory info now printed in cufinufft_setup_binsize() (common.cu)
+  // Additional runtime info at debug level 2
+  if (d_plan->opts.debug >= 2) {
+    printf("[cufinufft] Runtime: grid=(%ld,%ld,%ld), M=%ld\n", d_plan->nf1, d_plan->nf2,
+           d_plan->nf3, d_plan->M);
   }
 
   // dynamically request the maximum amount of shared memory available

--- a/perftest/cuda/CMakeLists.txt
+++ b/perftest/cuda/CMakeLists.txt
@@ -10,3 +10,16 @@ set_target_properties(
         CUDA_STANDARD 17
         CUDA_STANDARD_REQUIRED ON
 )
+
+add_executable(binsize_sweep binsize_sweep.cu)
+target_include_directories(binsize_sweep PUBLIC ${CUFINUFFT_INCLUDE_DIRS})
+target_link_libraries(binsize_sweep PRIVATE cufinufft CUDA::cufft CUDA::cudart $<BUILD_INTERFACE:finufft_common>)
+target_compile_features(binsize_sweep PRIVATE cxx_std_17)
+set_target_properties(
+    binsize_sweep
+    PROPERTIES
+        LINKER_LANGUAGE CUDA
+        CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
+        CUDA_STANDARD 17
+        CUDA_STANDARD_REQUIRED ON
+)

--- a/perftest/cuda/binsize_sweep.cu
+++ b/perftest/cuda/binsize_sweep.cu
@@ -1,0 +1,430 @@
+// Comprehensive benchmark to find optimal bin size and np for cufinufft methods
+// Tests all methods, dimensions, tolerances with various bin sizes
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <cufinufft.h>
+#include <cufinufft/types.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+using namespace std;
+
+static size_t shared_memory_per_point(int dim, int ns) {
+  return ns * sizeof(double) * dim  // kernel evaluations
+         + sizeof(int) * dim        // indexes
+         + sizeof(cuDoubleComplex); // strength
+}
+
+static size_t shared_memory_required(int dim, int ns, int bin_size_x, int bin_size_y,
+                                     int bin_size_z, int np) {
+  const auto shmem_per_point = shared_memory_per_point(dim, ns);
+  const int ns_2             = (ns + 1) / 2;
+  size_t grid_size           = bin_size_x + 2 * ns_2;
+  if (dim > 1) grid_size *= bin_size_y + 2 * ns_2;
+  if (dim > 2) grid_size *= bin_size_z + 2 * ns_2;
+  return grid_size * sizeof(cuDoubleComplex) + shmem_per_point * np;
+}
+
+static int find_bin_size(size_t mem_size, int dim, int ns) {
+  const auto elements        = mem_size / sizeof(cuDoubleComplex);
+  const auto padded_bin_size = int(floor(pow(elements, 1.0 / dim)));
+  const auto bin_size        = padded_bin_size - (2 * (ns + 1) / 2);
+  return bin_size;
+}
+
+static int binsize_from_percent(int dim, int ns, int shmem_limit, int percent, int np) {
+  const auto shmem_per_point = shared_memory_per_point(dim, ns);
+  const auto target_shmem    = (shmem_limit * percent) / 100;
+  const auto available       = int(target_shmem - shmem_per_point * np);
+  if (available <= 0) return 0;
+  return find_bin_size(static_cast<size_t>(available), dim, ns);
+}
+
+struct BenchResult {
+  int method;
+  int dim;
+  int type;
+  double tol;
+  int ns;
+  int binsize_x, binsize_y, binsize_z;
+  int np;
+  int shmem_used;
+  int shmem_limit;
+  int shmem_percent;
+  int shmem_target_percent;
+  double exec_time_ms;
+  double throughput;
+  bool valid;
+  string error_msg;
+};
+
+BenchResult run_benchmark(int dim, int type, int method, double tol, int64_t N, int64_t M,
+                          int binsize_override, int np_override, int shmem_target_percent,
+                          vector<BenchResult> &results) {
+
+  cufinufft_opts opts;
+  cufinufft_default_opts(&opts);
+  opts.gpu_method = method;
+
+  // Override bin sizes if requested
+  if (binsize_override > 0) {
+    opts.gpu_binsizex = binsize_override;
+    opts.gpu_binsizey = binsize_override;
+    opts.gpu_binsizez = binsize_override;
+  }
+
+  // Override np for method 3
+  if (method == 3 && np_override > 0) {
+    opts.gpu_np = np_override;
+  }
+
+  // Allocate host and device arrays
+  int64_t N_total = (dim == 1) ? N : (dim == 2) ? N * N : N * N * N;
+
+  thrust::host_vector<double> h_x(M), h_y(M), h_z(M);
+  thrust::host_vector<cuDoubleComplex> h_c(M), h_fk(N_total);
+
+  // Initialize random points
+  for (int64_t i = 0; i < M; i++) {
+    h_x[i]   = M_PI * (2.0 * rand() / RAND_MAX - 1.0);
+    h_y[i]   = M_PI * (2.0 * rand() / RAND_MAX - 1.0);
+    h_z[i]   = M_PI * (2.0 * rand() / RAND_MAX - 1.0);
+    h_c[i].x = 2.0 * rand() / RAND_MAX - 1.0;
+    h_c[i].y = 2.0 * rand() / RAND_MAX - 1.0;
+  }
+
+  // Copy to device
+  thrust::device_vector<double> d_x          = h_x;
+  thrust::device_vector<double> d_y          = h_y;
+  thrust::device_vector<double> d_z          = h_z;
+  thrust::device_vector<cuDoubleComplex> d_c = h_c;
+  thrust::device_vector<cuDoubleComplex> d_fk(N_total);
+
+  // Create plan
+  cufinufft_plan plan;
+  int ier = 0;
+
+  int64_t nmodes[3] = {N, (dim >= 2) ? N : 1, (dim >= 3) ? N : 1};
+
+  ier = cufinufft_makeplan(type, dim, nmodes, 1, 1, tol, &plan, &opts);
+
+  BenchResult result          = {};
+  result.method               = method;
+  result.dim                  = dim;
+  result.type                 = type;
+  result.tol                  = tol;
+  result.shmem_target_percent = shmem_target_percent;
+  cudaDeviceGetAttribute(&result.shmem_limit, cudaDevAttrMaxSharedMemoryPerBlockOptin,
+                         opts.gpu_device_id);
+
+  if (ier != 0) {
+    result.method    = method;
+    result.dim       = dim;
+    result.tol       = tol;
+    result.valid     = false;
+    result.error_msg = "makeplan failed: " + to_string(ier);
+    results.push_back(result);
+    return result;
+  }
+
+  // Cast to internal type to access fields
+  auto *plan_internal = reinterpret_cast<cufinufft_plan_t<double> *>(plan);
+
+  // Set points (pass device pointers)
+  ier = cufinufft_setpts(
+      plan, M, thrust::raw_pointer_cast(d_x.data()), thrust::raw_pointer_cast(d_y.data()),
+      thrust::raw_pointer_cast(d_z.data()), 0, nullptr, nullptr, nullptr);
+
+  if (ier != 0) {
+    result.ns        = plan_internal->spopts.nspread;
+    result.binsize_x = plan_internal->opts.gpu_binsizex;
+    result.binsize_y = plan_internal->opts.gpu_binsizey;
+    result.binsize_z = plan_internal->opts.gpu_binsizez;
+    result.np        = plan_internal->opts.gpu_np;
+    result.valid     = false;
+    result.error_msg = "setpts failed: " + to_string(ier);
+    results.push_back(result);
+    cufinufft_destroy(plan);
+    return result;
+  }
+
+  // Warmup
+  ier = cufinufft_execute(plan, thrust::raw_pointer_cast(d_c.data()),
+                          thrust::raw_pointer_cast(d_fk.data()));
+  if (ier != 0) {
+    result.ns        = plan_internal->spopts.nspread;
+    result.binsize_x = plan_internal->opts.gpu_binsizex;
+    result.binsize_y = plan_internal->opts.gpu_binsizey;
+    result.binsize_z = plan_internal->opts.gpu_binsizez;
+    result.np        = plan_internal->opts.gpu_np;
+    result.valid     = false;
+    result.error_msg = "execute failed: " + to_string(ier);
+    results.push_back(result);
+    cufinufft_destroy(plan);
+    return result;
+  }
+
+  // Benchmark (10 runs)
+  const int n_runs = 10;
+  cudaDeviceSynchronize();
+  auto start = chrono::high_resolution_clock::now();
+
+  for (int i = 0; i < n_runs; i++) {
+    cufinufft_execute(plan, thrust::raw_pointer_cast(d_c.data()),
+                      thrust::raw_pointer_cast(d_fk.data()));
+  }
+
+  cudaDeviceSynchronize();
+  auto end          = chrono::high_resolution_clock::now();
+  double elapsed_ms = chrono::duration<double, milli>(end - start).count() / n_runs;
+  double throughput = M / (elapsed_ms / 1000.0);
+
+  // Record result
+  result.ns           = plan_internal->spopts.nspread;
+  result.binsize_x    = plan_internal->opts.gpu_binsizex;
+  result.binsize_y    = plan_internal->opts.gpu_binsizey;
+  result.binsize_z    = plan_internal->opts.gpu_binsizez;
+  result.np           = plan_internal->opts.gpu_np;
+  result.exec_time_ms = elapsed_ms;
+  result.throughput   = throughput;
+  result.valid        = true;
+
+  cudaDeviceGetAttribute(&result.shmem_limit, cudaDevAttrMaxSharedMemoryPerBlockOptin,
+                         plan_internal->opts.gpu_device_id);
+  result.shmem_used = static_cast<int>(shared_memory_required(
+      dim, result.ns, result.binsize_x, result.binsize_y, result.binsize_z, result.np));
+  result.shmem_percent =
+      result.shmem_limit > 0 ? int(100.0 * result.shmem_used / result.shmem_limit) : 0;
+
+  results.push_back(result);
+
+  // Cleanup
+  cufinufft_destroy(plan);
+  // Device vectors automatically freed
+  return result;
+}
+
+void print_csv(const vector<BenchResult> &results) {
+  cout << "\n========== CSV OUTPUT ==========\n" << endl;
+  cout << "method,dim,tol,ns,binsize_x,binsize_y,binsize_z,np,shmem_used,shmem_limit,"
+       << "shmem_used_pct,shmem_target_pct,exec_ms,throughput,valid,error" << endl;
+
+  for (const auto &r : results) {
+    if (!r.valid) {
+      cout << r.method << "," << r.dim << "," << scientific << r.tol << "," << r.ns << ","
+           << r.binsize_x << "," << r.binsize_y << "," << r.binsize_z << "," << r.np
+           << ",0,0,0," << r.shmem_target_percent << ",0,0,false," << r.error_msg << endl;
+    } else {
+      cout << r.method << "," << r.dim << "," << scientific << r.tol << "," << r.ns << ","
+           << r.binsize_x << "," << r.binsize_y << "," << r.binsize_z << "," << r.np
+           << "," << r.shmem_used << "," << r.shmem_limit << "," << r.shmem_percent << ","
+           << r.shmem_target_percent << "," << fixed << setprecision(3) << r.exec_time_ms
+           << "," << scientific << r.throughput << ",true," << endl;
+    }
+  }
+}
+
+void print_summary_by_method_dim(const vector<BenchResult> &results) {
+  cout << "\n========== PERFORMANCE BY METHOD & DIMENSION ==========\n" << endl;
+
+  for (int method = 1; method <= 3; method++) {
+    for (int dim = 1; dim <= 3; dim++) {
+      // Get results for this method/dim
+      vector<BenchResult> group;
+      for (const auto &r : results) {
+        if (r.valid && r.method == method && r.dim == dim) {
+          group.push_back(r);
+        }
+      }
+
+      if (group.empty()) continue;
+
+      cout << "\nMethod " << method << ", " << dim << "D:" << endl;
+      cout << string(80, '-') << endl;
+      cout << setw(6) << "Tol" << setw(4) << "ns" << setw(10) << "BinSize" << setw(5)
+           << "np" << setw(8) << "Shmem" << setw(12) << "Time(ms)" << setw(14)
+           << "Throughput" << setw(10) << "Speedup" << endl;
+      cout << string(80, '-') << endl;
+
+      // Find baseline (first entry with natural bin size for each tolerance)
+      map<int, double> baseline_times; // ns -> baseline_time
+      for (const auto &r : group) {
+        if (baseline_times.find(r.ns) == baseline_times.end()) {
+          baseline_times[r.ns] = r.exec_time_ms;
+        }
+      }
+
+      for (const auto &r : group) {
+        string binsize = to_string(r.binsize_x);
+        if (dim > 1) binsize += "x" + to_string(r.binsize_y);
+        if (dim > 2) binsize += "x" + to_string(r.binsize_z);
+
+        double baseline = baseline_times[r.ns];
+        double speedup  = baseline / r.exec_time_ms;
+
+        cout << scientific << setprecision(0) << setw(6) << r.tol << fixed << setw(4)
+             << r.ns << setw(10) << binsize << setw(5) << r.np << setw(7)
+             << r.shmem_percent << "%" << setw(12) << fixed << setprecision(2)
+             << r.exec_time_ms << setw(14) << scientific << setprecision(2)
+             << r.throughput << setw(9) << fixed << setprecision(3) << speedup << "x";
+
+        if (speedup > 1.05) cout << " ★";
+        if (speedup < 0.95) cout << " ⚠";
+        cout << endl;
+      }
+    }
+  }
+}
+
+void print_best_shmem_percent(const vector<BenchResult> &results) {
+  cout << "\n========== BEST SHMEM PERCENT BY METHOD/DIM/TOL ==========\n" << endl;
+
+  for (int method = 1; method <= 3; method++) {
+    for (int dim = 1; dim <= 3; dim++) {
+      map<double, BenchResult> best_by_tol;
+      for (const auto &r : results) {
+        if (!r.valid || r.method != method || r.dim != dim) continue;
+        auto it = best_by_tol.find(r.tol);
+        if (it == best_by_tol.end() || r.throughput > it->second.throughput) {
+          best_by_tol[r.tol] = r;
+        }
+      }
+
+      if (best_by_tol.empty()) continue;
+
+      cout << "\nMethod " << method << ", " << dim << "D:" << endl;
+      cout << string(70, '-') << endl;
+      cout << setw(6) << "Tol" << setw(4) << "ns" << setw(10) << "BinSize" << setw(5)
+           << "np" << setw(8) << "Shmem" << setw(12) << "Time(ms)" << setw(14)
+           << "Throughput" << endl;
+      cout << string(70, '-') << endl;
+
+      for (const auto &[tol, r] : best_by_tol) {
+        string binsize = to_string(r.binsize_x);
+        if (dim > 1) binsize += "x" + to_string(r.binsize_y);
+        if (dim > 2) binsize += "x" + to_string(r.binsize_z);
+
+        cout << scientific << setprecision(0) << setw(6) << tol << fixed << setw(4)
+             << r.ns << setw(10) << binsize << setw(5) << r.np << setw(7)
+             << r.shmem_percent << "%" << setw(12) << fixed << setprecision(2)
+             << r.exec_time_ms << setw(14) << scientific << setprecision(2)
+             << r.throughput << endl;
+      }
+    }
+  }
+}
+
+int main(int argc, char **argv) {
+  cout << "========================================" << endl;
+  cout << "  CUFINUFFT BIN SIZE PERFORMANCE SWEEP  " << endl;
+  cout << "========================================\n" << endl;
+
+  srand(42); // Reproducible
+  vector<BenchResult> results;
+
+  int type = 1; // Type 1 transform
+
+  // Quick debug mode: test only one config
+  bool debug_mode = (argc > 1 && string(argv[1]) == "--debug");
+
+  vector<double> tolerances =
+      debug_mode ? vector<double>{1e-6} : vector<double>{1e-3, 1e-6, 1e-9, 1e-12};
+
+  vector<tuple<int, int64_t, int64_t>> configs =
+      debug_mode ? vector<tuple<int, int64_t, int64_t>>{{3, 128, 100000}} : // Quick 3D
+                                                                            // test
+          vector<tuple<int, int64_t, int64_t>>{
+              {1, 1 << 20, 1e8}, {2, 2048, 1e8}, {3, 256, 1e8}};
+
+  for (auto [dim, N, M] : configs) {
+    cout << "\n" << dim << "D case (";
+    if (dim == 1)
+      cout << N;
+    else if (dim == 2)
+      cout << N << "x" << N;
+    else
+      cout << N << "x" << N << "x" << N;
+    cout << " modes, " << M << " points)" << endl;
+    cout << string(60, '=') << endl;
+
+    for (double tol : tolerances) {
+      cout << "\nTolerance " << scientific << tol << ":" << endl;
+
+      for (int method : {1, 2, 3}) {
+        cout << "  Method " << method << ": natural";
+        BenchResult baseline =
+            run_benchmark(dim, type, method, tol, N, M, 0, 0, 0, results);
+        if (!baseline.valid) {
+          cout << " (failed) ✓" << endl;
+          continue;
+        }
+
+        const int ns                     = baseline.ns;
+        const int shmem_limit            = baseline.shmem_limit;
+        const vector<int> shmem_percents = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+
+        if (method != 3) {
+          for (int percent : shmem_percents) {
+            int binsize = binsize_from_percent(dim, ns, shmem_limit, percent, 0);
+            if (binsize < 1) continue;
+            cout << " " << percent << "%";
+            run_benchmark(dim, type, method, tol, N, M, binsize, 0, percent, results);
+          }
+        } else {
+          const auto shmem_per_point = shared_memory_per_point(dim, ns);
+          const int max_np           = (shmem_limit / shmem_per_point) & ~15;
+          const int np_step          = max(16, (max_np / 16) & ~15);
+          vector<int> np_candidates;
+          for (int np = 16; np <= max_np; np += np_step) {
+            np_candidates.push_back(np & ~15);
+          }
+          if (!np_candidates.empty() && np_candidates.back() != max_np && max_np >= 16) {
+            np_candidates.push_back(max_np);
+          }
+          np_candidates.erase(unique(np_candidates.begin(), np_candidates.end()),
+                              np_candidates.end());
+
+          for (int percent : shmem_percents) {
+            cout << " [p=" << percent << "%";
+            for (int np : np_candidates) {
+              int binsize = binsize_from_percent(dim, ns, shmem_limit, percent, np);
+              if (binsize < 1) continue;
+              cout << " np=" << np;
+              run_benchmark(dim, type, method, tol, N, M, binsize, np, percent, results);
+            }
+            cout << "]";
+          }
+        }
+
+        cout << " ✓" << endl;
+      }
+    }
+  }
+
+  // Print results
+  print_summary_by_method_dim(results);
+  print_best_shmem_percent(results);
+  print_csv(results);
+
+  cout << "\n========================================" << endl;
+  cout << "LEGEND:" << endl;
+  cout << "  ★ = >5% faster than baseline" << endl;
+  cout << "  ⚠ = >5% slower than baseline" << endl;
+  cout << "\nRECOMMENDATION:" << endl;
+  cout << "  Analyze speedup column to find optimal bin sizes." << endl;
+  cout << "  CSV output above can be imported for further analysis." << endl;
+  cout << "========================================\n" << endl;
+
+  return 0;
+}

--- a/perftest/cuda/binsize_sweep.cu
+++ b/perftest/cuda/binsize_sweep.cu
@@ -1,5 +1,7 @@
-// Comprehensive benchmark to find optimal bin size and np for cufinufft methods
+// Benchmark to find optimal bin size and np for cufinufft methods
 // Tests all methods, dimensions, tolerances with various bin sizes
+// Designed by Marco Barbone but printing and refactoring by
+// Claude Sonnet 4.5
 
 #include <algorithm>
 #include <chrono>
@@ -345,7 +347,7 @@ int main(int argc, char **argv) {
       debug_mode ? vector<tuple<int, int64_t, int64_t>>{{3, 128, 100000}} : // Quick 3D
                                                                             // test
           vector<tuple<int, int64_t, int64_t>>{
-              {1, 1 << 20, 1e8}, {2, 2048, 1e8}, {3, 256, 1e8}};
+              {1, 1 << 20, 1e7}, {2, 2048, 1e7}, {3, 256, 1e7}};
 
   for (auto [dim, N, M] : configs) {
     cout << "\n" << dim << "D case (";

--- a/src/cuda/cufinufft.cu
+++ b/src/cuda/cufinufft.cu
@@ -128,7 +128,7 @@ void cufinufft_default_opts(cufinufft_opts *opts)
   opts->gpu_binsizey       = 0;
   opts->gpu_binsizez       = 0;
   opts->gpu_maxbatchsize   = 0;
-  opts->gpu_np             = 32;
+  opts->gpu_np             = 0;
   opts->debug              = 0;
   opts->gpu_stream         = cudaStreamDefault;
   // sphinx tag (don't remove): @gpu_defopts_end

--- a/src/cuda/cufinufft.cu
+++ b/src/cuda/cufinufft.cu
@@ -106,6 +106,7 @@ void cufinufft_default_opts(cufinufft_opts *opts)
     2) Sphinx sucks the below code block into the web docs, hence keep it clean.
 
     Melody Shih 07/25/19; Barnett 2/5/21, tidied for sphinx 7/2/24.
+    Barbone Jan/29/26: tweaked np default to 32. Increases performance by 15-21%.
 */
 {
   // sphinx tag (don't remove): @gpu_defopts_start
@@ -127,7 +128,7 @@ void cufinufft_default_opts(cufinufft_opts *opts)
   opts->gpu_binsizey       = 0;
   opts->gpu_binsizez       = 0;
   opts->gpu_maxbatchsize   = 0;
-  opts->gpu_np             = 16;
+  opts->gpu_np             = 32;
   opts->debug              = 0;
   opts->gpu_stream         = cudaStreamDefault;
   // sphinx tag (don't remove): @gpu_defopts_end


### PR DESCRIPTION
On my laptop, with very small shmem I could not use method 2/3 in 3D double precision 15 digits because it was running out of shmem.

This PR allows these methods to run with less shmem in those cases instead of crashing out-right. 

Also it benchmarks and tunes the binsize and np for best performance.

It tidies up the debug print too. 