### PR TITLE
cufinufft type 3: fix GPU memory leak and pointer ownership issue

### DIFF
--- a/include/cufinufft/impl.h
+++ b/include/cufinufft/impl.h
@@ -491,19 +491,16 @@ int cufinufft_setpts_impl(int M, T *d_kx, T *d_ky, T *d_kz, int N, T *d_s, T *d_
     fprintf(stderr, "[%s] Error: d_s is nullptr but dim > 0.\n", __func__);
     return FINUFFT_ERR_INVALID_ARGUMENT;
   }
-  d_plan->d_Sp = d_plan->dim > 0 ? d_s : nullptr;
 
   if (d_plan->dim > 1 && d_t == nullptr) {
     fprintf(stderr, "[%s] Error: d_t is nullptr but dim > 1.\n", __func__);
     return FINUFFT_ERR_INVALID_ARGUMENT;
   }
-  d_plan->d_Tp = d_plan->dim > 1 ? d_t : nullptr;
 
   if (d_plan->dim > 2 && d_u == nullptr) {
     fprintf(stderr, "[%s] Error: d_u is nullptr but dim > 2.\n", __func__);
     return FINUFFT_ERR_INVALID_ARGUMENT;
   }
-  d_plan->d_Up = d_plan->dim > 2 ? d_u : nullptr;
 
   const auto dim = d_plan->dim;
   // no need to set the params to zero, as they are already zeroed out in the plan


### PR DESCRIPTION
In flatironinstitute/jax-finufft#207, a user reported a memory leak in type 3 cufinufft `setpts`. I traced it to `checked_free` in `impl.h`, which simply had `if (!x)` where the test should have been `if (x)`:

https://github.com/flatironinstitute/finufft/blob/f97c9194be70134f3068768f522d2811ff5dde51/include/cufinufft/impl.h#L579-L582

Fixing this revealed another issue: early in the `setpts` call, the code was saving the user-provided device pointers in the plan:

https://github.com/flatironinstitute/finufft/blob/f97c9194be70134f3068768f522d2811ff5dde51/include/cufinufft/impl.h#L494

Then shortly after, we were reallocing those pointers, causing them to be freed, thus invalidating the user's input:

https://github.com/flatironinstitute/finufft/blob/f97c9194be70134f3068768f522d2811ff5dde51/include/cufinufft/impl.h#L596

I think the fix is to simply not store the user pointers in the plan; the rest of that function is already allocating new memory in `d_plan->d_Sp` and then writing the scaled `d_s` into it. I would appreciate if the cufinufft experts could double-check this, though.
