### PR TITLE
Tune interpolation block size for small workloads

### DIFF
--- a/include/cufinufft/common_kernels.hpp
+++ b/include/cufinufft/common_kernels.hpp
@@ -215,8 +215,7 @@ void cuinterp_nuptsdriven(const cufinufft_plan_t<T> &d_plan, int blksize) {
   const T sigma   = d_plan.spopts.upsampfac;
 
   const dim3 threadsPerBlock{
-      std::min(optimal_block_threads(d_plan.opts.gpu_device_id), (unsigned)d_plan.M), 1u,
-      1u};
+      optimal_interp_block_threads(d_plan.opts.gpu_device_id, d_plan.M), 1u, 1u};
   const dim3 blocks{(d_plan.M + threadsPerBlock.x - 1) / threadsPerBlock.x, 1, 1};
 
   const auto launch = [&](auto kernel) {

--- a/include/cufinufft/utils.h
+++ b/include/cufinufft/utils.h
@@ -173,9 +173,8 @@ auto launch_dispatch_ns(Func &&func, int target_ns, Args &&...args) {
 }
 
 /**
- * Return an architecture-specific “good enough” thread-block size.
- * – Each branch is resolved at compile time (if-constexpr + __CUDA_ARCH__).
- * – Host-only translation units get the fall-back value.
+ * Return an architecture-specific upper bound for “good enough”
+ * thread-block sizes.
  * Rationale (rule-of-thumb):
  *   SM 9x / 8x : 16 warps  = 256 threads
  *   SM 7x      :  8 warps  = 128 threads
@@ -189,6 +188,21 @@ inline unsigned optimal_block_threads(int device) noexcept {
   if (major >= 8) return 256;
   if (major >= 7) return 128;
   return 64;
+}
+
+/**
+ * Choose a workload-aware block size for method-1 interpolation.
+ * The architecture-specific cap above is still a good upper bound, but tiny
+ * transforms often run better with fewer threads. Ramp up from one warp in
+ * power-of-two steps until we hit either the workload size or the device cap.
+ */
+inline unsigned optimal_interp_block_threads(int device, int M) noexcept {
+  const auto limit =
+      std::min(optimal_block_threads(device), static_cast<unsigned>(std::max(M, 32)));
+  if (limit >= 256) return 256;
+  if (limit >= 128) return 128;
+  if (limit >= 64) return 64;
+  return 32;
 }
 
 } // namespace utils


### PR DESCRIPTION
This reduces the slowdown observed in #846.

More investigation on pypy needed.