### PR TITLE
cufinufft: cache simple API plans and add control API

### DIFF
--- a/python/cufinufft/cufinufft/__init__.py
+++ b/python/cufinufft/cufinufft/__init__.py
@@ -1,12 +1,13 @@
 from cufinufft._plan import Plan
 
-from cufinufft._simple import (nufft1d1, nufft1d2, nufft1d3,
+from cufinufft._simple import (clear_plan_cache,
+                               nufft1d1, nufft1d2, nufft1d3,
                                nufft2d1, nufft2d2, nufft2d3,
                                nufft3d1, nufft3d2, nufft3d3)
 
 __all__ = ["nufft1d1", "nufft1d2", "nufft1d3",
            "nufft2d1", "nufft2d2", "nufft2d3",
            "nufft3d1", "nufft3d2", "nufft3d3",
-           "Plan"]
+           "Plan", "clear_plan_cache"]
 
 __version__ = '2.6.0-dev'

--- a/python/cufinufft/cufinufft/_simple.py
+++ b/python/cufinufft/cufinufft/_simple.py
@@ -1,4 +1,78 @@
+import os
+import threading
+from collections import OrderedDict
+
 from cufinufft import Plan, _compat
+
+_PLAN_CACHE_ENABLED = os.environ.get("CUFINUFFT_SIMPLE_PLAN_CACHE", "1") != "0"
+_PLAN_CACHE_MAX_SIZE = int(os.environ.get("CUFINUFFT_SIMPLE_PLAN_CACHE_SIZE", "16"))
+_PLAN_CACHE_LOCK = threading.Lock()
+_PLAN_CACHE = OrderedDict()
+
+
+def clear_plan_cache():
+    """Clear cached simple-API plans created by cufinufft.nufft*d* helpers."""
+    with _PLAN_CACHE_LOCK:
+        _PLAN_CACHE.clear()
+
+
+def _freeze_opt_value(value):
+    if isinstance(value, dict):
+        return tuple(sorted((k, _freeze_opt_value(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_opt_value(v) for v in value)
+    if hasattr(value, "value"):
+        return value.value
+    return value
+
+
+def _plan_cache_key(dim, nufft_type, n_modes, n_trans, eps, isign, dtype, kwargs):
+    opts_key = tuple(sorted((k, _freeze_opt_value(v)) for k, v in kwargs.items()))
+    if nufft_type == 3:
+        n_modes_key = dim
+    else:
+        n_modes_key = tuple(int(v) for v in n_modes)
+    return (
+        threading.get_ident(),
+        dim,
+        nufft_type,
+        n_modes_key,
+        int(n_trans),
+        float(eps),
+        int(isign),
+        str(dtype),
+        opts_key,
+    )
+
+
+def _create_plan(dim, nufft_type, n_modes, n_trans, eps, isign, dtype, kwargs):
+    if nufft_type == 3:
+        return Plan(nufft_type, dim, n_trans, eps, isign, dtype, **kwargs)
+    return Plan(nufft_type, n_modes, n_trans, eps, isign, dtype, **kwargs)
+
+
+def _get_or_create_plan(dim, nufft_type, n_modes, n_trans, eps, isign, dtype, kwargs):
+    if (not _PLAN_CACHE_ENABLED) or _PLAN_CACHE_MAX_SIZE <= 0:
+        return _create_plan(dim, nufft_type, n_modes, n_trans, eps, isign, dtype, kwargs)
+
+    key = _plan_cache_key(dim, nufft_type, n_modes, n_trans, eps, isign, dtype, kwargs)
+    with _PLAN_CACHE_LOCK:
+        plan = _PLAN_CACHE.pop(key, None)
+        if plan is None:
+            plan = _create_plan(
+                dim,
+                nufft_type,
+                n_modes,
+                n_trans,
+                eps,
+                isign,
+                dtype,
+                kwargs,
+            )
+        _PLAN_CACHE[key] = plan
+        while len(_PLAN_CACHE) > _PLAN_CACHE_MAX_SIZE:
+            _PLAN_CACHE.popitem(last=False)
+    return plan
 
 def nufft1d1(x, data, n_modes=None, out=None, eps=1e-6, isign=1, **kwargs):
     return _invoke_plan(1, 1, x, None, None, data, None, None, None, out, isign, eps, n_modes,
@@ -33,6 +107,9 @@ def nufft1d3(x, data, s, out=None, eps=1e-6, isign=1, **kwargs):
 
 def _invoke_plan(dim, nufft_type, x, y, z, data, s, t, u,  out, isign, eps,
         n_modes=None, kwargs=None):
+    if kwargs is None:
+        kwargs = {}
+
     dtype = _compat.get_array_dtype(data)
 
     n_trans = _get_ntrans(dim, nufft_type, data)
@@ -42,10 +119,8 @@ def _invoke_plan(dim, nufft_type, x, y, z, data, s, t, u,  out, isign, eps,
     if nufft_type == 2:
         n_modes = data.shape[-dim:]
 
-    if nufft_type == 3:
-        plan = Plan(nufft_type, dim, n_trans, eps, isign, dtype, **kwargs)
-    else:
-        plan = Plan(nufft_type, n_modes, n_trans, eps, isign, dtype, **kwargs)
+    plan = _get_or_create_plan(dim, nufft_type, n_modes, n_trans, eps, isign,
+            dtype, kwargs)
 
     plan.setpts(x, y, z, s, t, u)
 

--- a/python/cufinufft/tests/test_simple.py
+++ b/python/cufinufft/tests/test_simple.py
@@ -113,3 +113,36 @@ def test_cufinufft3_simple(to_gpu, to_cpu, dtype, dim, n_source_pts, n_target_pt
     target_coefs = to_cpu(target_coefs_gpu)
 
     utils.verify_type3(source_pts, source_coefs, target_pts, target_coefs, tol)
+
+
+def test_simple_plan_cache_reuses_plans(monkeypatch, to_gpu):
+    shape = (8, 8, 8)
+    M = 128
+    tol = 1e-3
+
+    k, c = utils.type1_problem(np.complex64, shape, M, n_trans=(2,))
+    _, fk = utils.type2_problem(np.complex64, shape, M, n_trans=(2,))
+
+    k_gpu = to_gpu(k)
+    c_gpu = to_gpu(c)
+    fk_gpu = to_gpu(fk)
+
+    import cufinufft._simple as _simple
+
+    orig_plan = _simple.Plan
+    plan_create_count = {"n": 0}
+
+    def counted_plan(*args, **kwargs):
+        plan_create_count["n"] += 1
+        return orig_plan(*args, **kwargs)
+
+    monkeypatch.setattr(_simple, "Plan", counted_plan)
+    monkeypatch.setattr(_simple, "_PLAN_CACHE_ENABLED", True)
+    monkeypatch.setattr(_simple, "_PLAN_CACHE_MAX_SIZE", 8)
+    _simple.clear_plan_cache()
+
+    for _ in range(3):
+        cufinufft.nufft3d1(*k_gpu, c_gpu, shape, eps=tol)
+        cufinufft.nufft3d2(*k_gpu, fk_gpu, eps=tol)
+
+    assert plan_create_count["n"] == 2


### PR DESCRIPTION
This pull request introduces a plan caching mechanism to the simple NUFFT API in `cufinufft`, improving performance by reusing plan objects across repeated transforms with identical parameters. It also adds a utility to clear the cache and a test to verify the cache behavior.

**Plan Caching Implementation:**

* Added a thread-safe LRU cache for simple-API plans in `cufinufft/_simple.py`, controlled by environment variables for enabling/disabling and cache size. Plans are now reused across repeated calls with the same parameters, reducing plan creation overhead. (`[python/cufinufft/cufinufft/_simple.pyR1-R76](diffhunk://#diff-7f225fbb809d020aff2870923445b6e89729aed2274c010924f7044d8c0b1985R1-R76)`)
* Introduced the `clear_plan_cache` function to allow users to manually clear the plan cache. (`[[1]](diffhunk://#diff-7f225fbb809d020aff2870923445b6e89729aed2274c010924f7044d8c0b1985R1-R76)`, `[[2]](diffhunk://#diff-fc2919bcd8557e3ec76ef23fa7ac52bd8293f8d2027f836bf79a45a919ccc80fL3-R11)`)
* Updated the plan creation logic in `_invoke_plan` to use the new cache via `_get_or_create_plan`. (`[python/cufinufft/cufinufft/_simple.pyL45-R123](diffhunk://#diff-7f225fbb809d020aff2870923445b6e89729aed2274c010924f7044d8c0b1985L45-R123)`)
* Exported `clear_plan_cache` in the package’s public API (`__init__.py`). (`[python/cufinufft/cufinufft/__init__.pyL3-R11](diffhunk://#diff-fc2919bcd8557e3ec76ef23fa7ac52bd8293f8d2027f836bf79a45a919ccc80fL3-R11)`)

**Testing:**

* Added a test (`test_simple_plan_cache_reuses_plans`) to confirm that the plan cache reuses plans and avoids unnecessary plan creation. (`[python/cufinufft/tests/test_simple.pyR116-R148](diffhunk://#diff-3e3ce07e2704c141988d938e50d98f1bad86623cf3fbed95742866cda7eb3e49R116-R148)`)

**Bug Fix:**

* Fixed a possible bug in `_invoke_plan` by ensuring `kwargs` is always a dictionary. (`[python/cufinufft/cufinufft/_simple.pyR110-R112](diffhunk://#diff-7f225fbb809d020aff2870923445b6e89729aed2274c010924f7044d8c0b1985R110-R112)`)