### PR TITLE
feat(cmake): make installed find_package(finufft) work + fix Windows (#494)

### DIFF
--- a/.github/workflows/cmake_ci.yml
+++ b/.github/workflows/cmake_ci.yml
@@ -259,9 +259,82 @@ jobs:
             done
           done
 
+  # Regression guard for installed find_package(finufft) consumption (issue #494).
+  # Installs FINUFFT to a staging prefix and builds a standalone downstream
+  # project against it on Linux + Windows, for both static and shared (DLL)
+  # linking. This is the test that catches missing transitive headers, a missing
+  # find_dependency() in the package config, and the Windows DLL export/runtime
+  # path. Kept on the DUCC backend (the Windows FFT backend; FFTW is not a matrix
+  # axis here by project convention).
+  consume-test:
+    name: consume find_package (${{ matrix.os }}, ${{ matrix.linking }})
+    runs-on: ${{ matrix.os }}
+    needs: [cache]
+    env:
+      CMAKE_GENERATOR: Ninja
+      CPM_SOURCE_CACHE: cpm
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2022]
+        linking: [Static, Shared]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Restore Cache
+        uses: actions/cache/restore@v4
+        with:
+          key: cpm-cache-00-${{ runner.os == 'windows' && 'windows-' || '' }}${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          enableCrossOsArchive: true
+          path: cpm
+      - name: Setup Cpp
+        uses: aminya/setup-cpp@v1
+        with:
+          vcvarsall: true
+          cmake: true
+          ninja: true
+      - name: Install FINUFFT and consume via find_package
+        shell: bash
+        run: |
+          set -euo pipefail
+          static=ON
+          [[ "${{ matrix.linking }}" == "Shared" ]] && static=OFF
+          stage="$PWD/_stage"
+
+          # Build and install FINUFFT to a staging prefix.
+          cmake -S . -B _build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DFINUFFT_USE_DUCC0=ON \
+            -DFINUFFT_STATIC_LINKING=$static \
+            -DFINUFFT_ENABLE_INSTALL=ON \
+            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded \
+            -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
+          cmake --build _build --config Release
+          cmake --install _build --prefix "$stage" --config Release
+
+          # The exported interface must not bake in build-machine absolute paths.
+          if grep -R "/usr/" "$stage"/lib*/cmake/finufft/finufftTargets*.cmake; then
+            echo "ERROR: absolute path leaked into exported finufftTargets"; exit 1
+          fi
+
+          # Consume it from a standalone project via find_package + the alias.
+          cmake -S test/cmake_consume -B _consume \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$stage" \
+            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded \
+            -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
+          cmake --build _consume --config Release
+
+          # Run the consumer; for the shared build help the loader find the library.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            ./_consume/app.exe
+          else
+            LD_LIBRARY_PATH="$stage/lib:$stage/lib64:${LD_LIBRARY_PATH:-}" ./_consume/app
+          fi
+
   cleanup:
     runs-on: ubuntu-22.04
-    needs: cmake-ci
+    needs: [cmake-ci, consume-test]
     steps:
       - name: Artifact cleanup
         uses: geekyeggo/delete-artifact@v5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,18 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 v2.6.0-dev
 
+* Installed `find_package(finufft)` consumption now works (issue #494): install
+  the transitive public headers (`finufft/finufft_eitherprec.h`,
+  `finufft_common/defines.h`), add `find_dependency()` to the package config so
+  `OpenMP`/FFT-backend targets resolve in a consumer, give `install(TARGETS)`
+  explicit ARCHIVE/LIBRARY/RUNTIME destinations, and stop leaking the absolute
+  `libm` path into the exported interface. A static install with the bundled
+  DUCC0 backend now exports `finufft_common` and `ducc0` so it links downstream.
+  Fixed the Windows shared/DLL build (`dll_EXPORTS` on `finufft_common`) and made
+  `copy_dll` refresh stale DLLs via a POST_BUILD `copy_if_different`. Removed the
+  stale `next235beven` declaration. Added a `test/cmake_consume` downstream
+  project and a CI job exercising find_package install consumption on Linux +
+  Windows, static + shared. (Barbone)
 * Refined sigma_min estimator and moved check to `setpts`; now throws
   `FINUFFT_ERR_EPS_TOO_SMALL` when upsampfac is too low for the requested
   tolerance. (Brodovič, Barbone)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,40 @@ message(STATUS "  CMAKE_CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
 if(FINUFFT_ENABLE_INSTALL)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
-    install(TARGETS ${INSTALL_TARGETS} EXPORT finufftTargets PUBLIC_HEADER)
+    install(
+        TARGETS ${INSTALL_TARGETS}
+        EXPORT finufftTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME
+            DESTINATION
+                ${CMAKE_INSTALL_BINDIR} # .dll on Windows
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+    # Static builds expose finufft's private FFT backend on the install interface
+    # (see src/CMakeLists.txt), so the backend targets must be part of the export.
+    # DUCC0 is bundled by FINUFFT; FFTW is not (a static + FFTW consumer supplies
+    # its own FFTW). A shared build bakes the backend in and exports nothing here.
+    if(FINUFFT_STATIC_LINKING AND FINUFFT_USE_DUCC0 AND TARGET ducc0)
+        install(TARGETS ducc0 finufft_fftlibs EXPORT finufftTargets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif()
+    # Public transitive headers that live in subdirectories and are therefore not
+    # matched by the flat finufft*.h PUBLIC_HEADER glob. finufft.h pulls in
+    # finufft/finufft_eitherprec.h, which (with finufft_errors.h) pulls in
+    # finufft_common/defines.h; without these an installed consumer cannot
+    # compile. Only these two subdir headers are part of the public surface; the
+    # rest of include/finufft and include/finufft_common are internal.
+    if(FINUFFT_USE_CPU)
+        install(
+            FILES ${PROJECT_SOURCE_DIR}/include/finufft/finufft_eitherprec.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/finufft
+        )
+        install(
+            FILES ${PROJECT_SOURCE_DIR}/include/finufft_common/defines.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/finufft_common
+        )
+    endif()
     install(EXPORT finufftTargets NAMESPACE finufft:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/finufft)
     configure_package_config_file(
         cmake/finufftConfig.cmake.in

--- a/cmake/finufftConfig.cmake.in
+++ b/cmake/finufftConfig.cmake.in
@@ -1,5 +1,30 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+# Re-discover the dependencies that the exported targets reference. For a SHARED
+# build everything is baked into the library, so only the (interface-propagated)
+# OpenMP runtime needs to be found. For a STATIC build the FFT backend and its
+# threading runtime are separate archives that the consumer must also link.
+if(@FINUFFT_USE_OPENMP@)
+    find_dependency(OpenMP COMPONENTS C CXX)
+endif()
+
+if(@FINUFFT_STATIC_LINKING@ AND @FINUFFT_USE_DUCC0@)
+    # DUCC0 is bundled by FINUFFT and exported alongside it (as finufft::ducc0).
+    # It only needs a threading runtime when OpenMP is not used.
+    if(NOT @FINUFFT_USE_OPENMP@)
+        find_dependency(Threads)
+    endif()
+endif()
+
+# Note: a STATIC build linked against FFTW (rather than the bundled DUCC0) does
+# not export or bundle FFTW. Such a consumer must make FFTW available themselves
+# (e.g. link it explicitly). We deliberately do not call find_dependency(FFTW)
+# here: FINUFFT locates FFTW via a bundled FindFFTW module that is not shipped
+# with the package, so the call would fail in a consumer. A SHARED build bakes
+# FFTW in and needs nothing.
+
 include("${CMAKE_CURRENT_LIST_DIR}/finufftTargets.cmake")
 
 check_required_components(finufft)

--- a/cmake/setupDUCC.cmake
+++ b/cmake/setupDUCC.cmake
@@ -19,7 +19,11 @@ if(ducc0_ADDED)
         ${ducc0_SOURCE_DIR}/src/ducc0/infra/threading.cc
         ${ducc0_SOURCE_DIR}/src/ducc0/infra/mav.cc
     )
-    target_include_directories(ducc0 PUBLIC ${ducc0_SOURCE_DIR}/src/)
+    # Build-tree only: finufft's TUs include ducc fft headers, but downstream
+    # consumers of an installed (static) finufft never do (the public API is plain
+    # C). Wrapping in BUILD_INTERFACE keeps the absolute source path out of the
+    # exported interface so ducc0 can be part of finufftTargets and stay relocatable.
+    target_include_directories(ducc0 PUBLIC $<BUILD_INTERFACE:${ducc0_SOURCE_DIR}/src/>)
     target_compile_options(ducc0 PRIVATE $<$<CONFIG:Release,RelWithDebInfo>:${FINUFFT_ARCH_FLAGS}>)
     target_compile_options(ducc0 PRIVATE $<$<CONFIG:Release>:${FINUFFT_CXX_FLAGS_RELEASE}>)
     target_compile_options(ducc0 PRIVATE $<$<CONFIG:RelWithDebInfo>:${FINUFFT_CXX_FLAGS_RELWITHDEBINFO}>)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -64,24 +64,18 @@ function(copy_dll source_target destination_target)
     if(NOT WIN32)
         return()
     endif()
-    # Get the binary directory of the destination target
+    # Place the shared library next to the consuming executable so it is found at
+    # runtime. Use a POST_BUILD copy_if_different (not a configure-time guard) so a
+    # rebuilt DLL is refreshed instead of leaving a stale copy in place.
     get_target_property(DESTINATION_DIR ${destination_target} BINARY_DIR)
-    set(DESTINATION_FILE ${DESTINATION_DIR}/$<TARGET_FILE_NAME:${source_target}>)
-    if(NOT EXISTS ${DESTINATION_FILE})
-        message(STATUS "Copying ${source_target} to ${DESTINATION_DIR} directory for ${destination_target}")
-        # Define the custom command to copy the source target to the destination
-        # directory
-        add_custom_command(
-            TARGET ${destination_target}
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${source_target}> ${DESTINATION_FILE}
-            COMMENT "Copying ${source_target} to ${destination_target} directory"
-        )
-    endif()
-    # Unset the variables to leave a clean state
-    unset(DESTINATION_DIR)
-    unset(SOURCE_FILE)
-    unset(DESTINATION_FILE)
+    add_custom_command(
+        TARGET ${destination_target}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${source_target}>
+            ${DESTINATION_DIR}/$<TARGET_FILE_NAME:${source_target}>
+        COMMENT "Copying ${source_target} DLL next to ${destination_target}"
+    )
 endfunction()
 
 if(FINUFFT_INTERPROCEDURAL_OPTIMIZATION)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -71,7 +71,7 @@ Then add the following to your ``CMakeLists.txt``:
     SYSTEM
   )
 
-  target_link_library(your_executable [PUBLIC|PRIVATE|INTERFACE] finufft)
+  target_link_libraries(your_executable [PUBLIC|PRIVATE|INTERFACE] finufft::finufft)
 
 Then CMake will automatically download FINUFFT and link it to your executable.
 
@@ -93,9 +93,29 @@ Add the following to your ``CMakeLists.txt``:
     FetchContent_MakeAvailable(finufft)
 
     # Optionally, link the finufft library to your target
-    target_link_libraries(your_executable [PUBLIC|PRIVATE|INTERFACE] finufft)
+    target_link_libraries(your_executable [PUBLIC|PRIVATE|INTERFACE] finufft::finufft)
 
 Then CMake will automatically download FINUFFT and link it to your executable.
+
+3) **Installed package via** ``find_package``. If FINUFFT has been built and
+installed (see :ref:`below <cmake-install>`), a downstream project can consume
+the installed package directly:
+
+.. code-block:: cmake
+
+    find_package(finufft REQUIRED)
+    target_link_libraries(your_executable [PUBLIC|PRIVATE|INTERFACE] finufft::finufft)
+
+Point CMake at the install prefix when configuring your project, e.g.
+``-DCMAKE_PREFIX_PATH=/path/to/install`` (or ``-Dfinufft_DIR=/path/to/install/lib/cmake/finufft``).
+The package config pulls in the required dependencies automatically
+(OpenMP, and for a *static* install the FFT backend). A **shared** install is
+fully self-contained — everything, including the FFT backend, is baked into the
+library (``libfinufft.so``/``.dylib`` or ``finufft.dll``), so only the OpenMP
+runtime is needed at link time. For a **static** install built with the bundled
+DUCC0 backend, the backend archive is installed and exported alongside FINUFFT;
+a static install built against **FFTW** instead requires the consumer to make
+FFTW discoverable themselves (a shared build avoids this).
 
 CMake based installation and compilation
 ----------------------------------------
@@ -141,6 +161,8 @@ Preset              When to use it
 
 See the `cmake-presets(7) <https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html>`_
 manual for the full preset reference.
+
+.. _cmake-install:
 
 Quick start without presets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/finufft_common/utils.h
+++ b/include/finufft_common/utils.h
@@ -165,15 +165,6 @@ decltype(auto) dispatch(Func &&func, ParamTuple &&params, Args &&...args) {
 } // namespace common
 } // namespace finufft
 
-namespace cufinufft::utils {
-// Smallest even n' >= n whose largest prime factor is <= 5 and which is a
-// multiple of b (b's prime factors must be in {2,3,5}). Defined alongside
-// gaussquad / leg_eval in src/common/utils.cpp; declared here so the decl
-// lives in the same shared header as the rest of src/common/utils.cpp's
-// public surface.
-FINUFFT_EXPORT long next235beven(long n, long b);
-} // namespace cufinufft::utils
-
 namespace finufft::utils {
 
 // Host versions of arrayrange / arraywidcen. The CUDA path has a separate

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,9 +99,25 @@ if(FINUFFT_USE_OPENMP)
     endif()
 endif()
 
+# For a STATIC build, finufft.a does not contain its private static dependencies
+# (finufft_common and the FFT backend), so an installed consumer must link them
+# too. Propagate them on the install interface; the targets themselves are added
+# to the finufftTargets export in the install block. (A SHARED build bakes these
+# in and needs nothing extra.) xsimd is intentionally excluded: it is header-only
+# and only needed while compiling finufft, not by downstream consumers.
+if(FINUFFT_STATIC_LINKING)
+    target_link_libraries(finufft INTERFACE $<INSTALL_INTERFACE:finufft_common>)
+    if(FINUFFT_USE_DUCC0)
+        target_link_libraries(finufft INTERFACE $<INSTALL_INTERFACE:finufft_fftlibs>)
+    endif()
+endif()
+
 find_library(MATH_LIBRARY m)
 if(MATH_LIBRARY)
-    target_link_libraries(finufft PRIVATE ${MATH_LIBRARY})
+    # Wrap in BUILD_INTERFACE so the absolute /usr/lib/.../libm.so path is not
+    # baked into the installed package's INTERFACE_LINK_LIBRARIES (which would
+    # happen for a STATIC archive and break relocatability).
+    target_link_libraries(finufft PRIVATE $<BUILD_INTERFACE:${MATH_LIBRARY}>)
 endif()
 
 target_include_directories(finufft SYSTEM INTERFACE $<INSTALL_INTERFACE:include>)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,14 +16,32 @@ set_target_properties(finufft_common PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # Visibility and compile options consistent with finufft
 if(FINUFFT_SHARED_LINKING)
     target_compile_definitions(finufft_common PRIVATE FINUFFT_DLL)
+    if(WIN32)
+        # Mirror src/cuda/CMakeLists.txt: dll_EXPORTS selects __declspec(dllexport)
+        # so FINUFFT_EXPORT symbols compiled here are exported, not imported.
+        target_compile_definitions(finufft_common PRIVATE dll_EXPORTS)
+    endif()
 endif()
 
 target_compile_features(finufft_common PRIVATE cxx_std_17)
 
-# If you need -lm etc.
+# If you need -lm etc. Wrap in BUILD_INTERFACE so the absolute libm path is not
+# propagated into the installed package interface (finufft_common is a static
+# archive and is exported for static consumers).
 find_library(MATH_LIBRARY m)
 if(MATH_LIBRARY)
-    target_link_libraries(finufft_common PRIVATE ${MATH_LIBRARY})
+    target_link_libraries(finufft_common PRIVATE $<BUILD_INTERFACE:${MATH_LIBRARY}>)
 endif()
 
 set_target_properties(finufft_common PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN YES)
+
+# finufft links finufft_common privately. For a SHARED build its objects are
+# baked into the library, but a STATIC finufft.a leaves them as unresolved
+# references, so a static consumer must also link finufft_common. Export it
+# (handled in the top-level install block) and propagate it on the install
+# interface in that case.
+if(FINUFFT_ENABLE_INSTALL AND FINUFFT_STATIC_LINKING)
+    set(_targets ${INSTALL_TARGETS})
+    list(APPEND _targets finufft_common)
+    set(INSTALL_TARGETS "${_targets}" PARENT_SCOPE)
+endif()

--- a/test/cmake_consume/CMakeLists.txt
+++ b/test/cmake_consume/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Standalone downstream project: verifies an *installed* FINUFFT can be consumed
+# via find_package(finufft) + target_link_libraries(finufft::finufft).
+#
+# This is intentionally NOT part of the main FINUFFT build. CI installs FINUFFT
+# to a staging prefix and then configures this project against it with
+#   -DCMAKE_PREFIX_PATH=<stage>   (or -Dfinufft_DIR=<stage>/lib/cmake/finufft)
+#
+# It is the regression guard for: missing transitive headers, missing
+# find_dependency() in the config, and the Windows DLL export/runtime path.
+cmake_minimum_required(VERSION 3.19)
+project(finufft_consume LANGUAGES C CXX)
+
+find_package(finufft REQUIRED)
+
+add_executable(app main.cpp)
+target_link_libraries(app PRIVATE finufft::finufft)
+target_compile_features(app PRIVATE cxx_std_17)
+
+# On Windows the finufft DLL must sit next to the executable at runtime.
+if(WIN32 AND TARGET finufft::finufft)
+    get_target_property(_finufft_type finufft::finufft TYPE)
+    if(_finufft_type STREQUAL "SHARED_LIBRARY")
+        add_custom_command(
+            TARGET app
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:finufft::finufft> $<TARGET_FILE_DIR:app>
+        )
+    endif()
+endif()

--- a/test/cmake_consume/fetchcontent/CMakeLists.txt
+++ b/test/cmake_consume/fetchcontent/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Second consume variant: pull FINUFFT in via FetchContent (the add_subdirectory
+# path) instead of an installed find_package. CI points FINUFFT_SOURCE_DIR at the
+# checked-out repo so no network access is needed; drop that define to fetch from
+# GitHub instead.
+cmake_minimum_required(VERSION 3.25)
+project(finufft_consume_fetchcontent LANGUAGES C CXX)
+
+set(FINUFFT_SOURCE_DIR "" CACHE PATH "Local FINUFFT checkout to consume")
+
+include(FetchContent)
+if(FINUFFT_SOURCE_DIR)
+    FetchContent_Declare(finufft SOURCE_DIR ${FINUFFT_SOURCE_DIR})
+else()
+    FetchContent_Declare(finufft GIT_REPOSITORY https://github.com/flatironinstitute/finufft.git GIT_TAG master)
+endif()
+FetchContent_MakeAvailable(finufft)
+
+add_executable(app ../main.cpp)
+target_link_libraries(app PRIVATE finufft::finufft)
+target_compile_features(app PRIVATE cxx_std_17)

--- a/test/cmake_consume/main.cpp
+++ b/test/cmake_consume/main.cpp
@@ -1,0 +1,33 @@
+// Minimal downstream consumer of an installed FINUFFT.
+//
+// Including <finufft.h> exercises the full public header chain
+// (finufft_opts.h, finufft_errors.h, finufft/finufft_eitherprec.h and their
+// transitive <finufft_common/defines.h>), so a missing installed header is a
+// hard compile error here. Calling finufft_default_opts links against the
+// installed library, exercising find_dependency() and the DLL export path.
+#include <finufft.h>
+
+#include <cstdio>
+
+int main() {
+  finufft_opts opts;
+  finufft_default_opts(&opts);
+
+  // A non-trivial round trip: a tiny type-1 1D transform.
+  const int64_t M = 8;
+  const int64_t N = 16;
+  double x[M];
+  std::complex<double> c[M];
+  std::complex<double> fk[N];
+  for (int64_t j = 0; j < M; ++j) {
+    x[j] = 0.0;
+    c[j] = {1.0, 0.0};
+  }
+  const int ier = finufft1d1(M, x, c, +1, 1e-6, N, fk, &opts);
+  if (ier != 0) {
+    std::printf("finufft1d1 returned error %d\n", ier);
+    return 1;
+  }
+  std::printf("finufft consume OK\n");
+  return 0;
+}


### PR DESCRIPTION
Close the gaps that broke an installed `find_package(finufft)` consumer and the Windows shared/.dll build:

- Install the transitive public headers that live in subdirs and are missed by the flat finufft*.h glob: finufft/finufft_eitherprec.h and finufft_common/defines.h. Without these an installed consumer cannot compile.
- Add CMakeFindDependencyMacro + conditional find_dependency to the package config so OpenMP (and, for static, the FFT backend's threading) resolve in a consumer. Shared builds are self-contained and only need OpenMP.
- Give install(TARGETS) explicit ARCHIVE/LIBRARY/RUNTIME/PUBLIC_HEADER/INCLUDES destinations (.dll lands in bin on Windows).
- Stop leaking the absolute libm path into the exported interface by wrapping MATH_LIBRARY in $<BUILD_INTERFACE:>.
- Make static builds linkable downstream: finufft.a does not contain its private static deps, so export finufft_common (and, for the DUCC backend, ducc0 + finufft_fftlibs) and propagate them on the static install interface. ducc0's include dir is wrapped in BUILD_INTERFACE to stay relocatable.
- Fix the Windows shared build: define dll_EXPORTS on finufft_common so its FINUFFT_EXPORT symbols are dllexport, not dllimport.
- copy_dll now uses a POST_BUILD copy_if_different so rebuilt DLLs refresh instead of leaving a stale copy.
- Remove the stale next235beven declaration (defined nowhere).
- Add a test/cmake_consume downstream project (find_package + FetchContent variants) and a consume-test CI job on Linux + Windows, static + shared.
- docs/install.rst: document find_package usage and fix a target_link_library typo; CHANGELOG entry.
