### PR TITLE
fix(cuda): restore batched type-2 perf #846

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,21 +10,16 @@ v2.6.0-dev
   (Barbone)
 * cuFINUFFT: fixed the batched (many-transform) type-2 performance regression of #846.
   `gpu_maxbatchsize=0` (the default) now sizes the batch from the fine grid and the
-  device's L2 cache instead of the fixed `min(ntransf, 8)`, a type 3's outer
-  spread-only plan is no longer batched and its inner type 2 is pinned to the outer
-  batch instead of re-deciding, the auto batch is evened out across batches so the
-  last one is not mostly stale grids that cuFFT transforms anyway (1.04-1.11x at
-  `ntransf` just past a batch boundary, e.g. 9 or 17 with an L2 cap of 8), and a
-  user-supplied `gpu_maxbatchsize` is honored as given, capped at `ntransf` (negative
-  values are now rejected instead of silently clamped). Device attributes are queried
-  once per plan into a `GpuCapabilities` struct shared by the binsize and batchsize
-  heuristics. Measured against the regressed master over 26 shapes on
-  Blackwell/H100/A100/Ada: type-2 mean 2.1-10.4x, up to 96x at small N with large
-  `ntransf`; no shape slower. Against v2.4.1, which predates the regression, the
-  batched type-2 shapes are back to 0.95-0.97x of their old time, i.e. this is a
-  restore rather than a new speedup. (Barbone)
-* cuFINUFFT: `cuperftest` takes `--maxbatchsize` to force a batch size, so one binary
-  can benchmark every batch size. (Barbone)
+  device's L2 cache instead of the fixed `min(ntransf, 8)`, and spreads the transforms
+  evenly over the batches; a user-supplied value is honored, capped at `ntransf`, and
+  negative values are rejected. A type 3 no longer batches its outer spread-only plan,
+  pins its inner type 2 to the outer batch, and shares one device buffer between the
+  pre-phase array and that inner plan's `fw`. Against the regressed master: type-2 mean
+  2.1-10.4x over 26 shapes on Blackwell/H100/A100/Ada, up to 96x; type 3 geomean 1.04x
+  over seven shapes on Ada; no shape slower. Against v2.4.1 the batched type-2 shapes
+  return to 0.95-0.97x of their old time, so this restores rather than adds.
+  `cuperftest` gains `--maxbatchsize`.
+  (Barbone)
 * The spread/interp kernel is now PSWF (prolate) only: opts.spread_kerformula
   takes 0 (default) or 7,8,9 (PSWF shape-parameter choices); the legacy ES (1,2),
   Kaiser-Bessel (3,4) and cosh-type (5,6) formulas are removed and now return

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,23 @@ v2.6.0-dev
   from the CMake build, the single-precision ones asked for more modes than float
   can resolve, four leaked their opts and the CUDA ones ignored every return code.
   (Barbone)
+* cuFINUFFT: fixed the batched (many-transform) type-2 performance regression of #846.
+  `gpu_maxbatchsize=0` (the default) now sizes the batch from the fine grid and the
+  device's L2 cache instead of the fixed `min(ntransf, 8)`, a type 3's outer
+  spread-only plan is no longer batched and its inner type 2 is pinned to the outer
+  batch instead of re-deciding, the auto batch is evened out across batches so the
+  last one is not mostly stale grids that cuFFT transforms anyway (1.04-1.11x at
+  `ntransf` just past a batch boundary, e.g. 9 or 17 with an L2 cap of 8), and a
+  user-supplied `gpu_maxbatchsize` is honored as given, capped at `ntransf` (negative
+  values are now rejected instead of silently clamped). Device attributes are queried
+  once per plan into a `GpuCapabilities` struct shared by the binsize and batchsize
+  heuristics. Measured against the regressed master over 26 shapes on
+  Blackwell/H100/A100/Ada: type-2 mean 2.1-10.4x, up to 96x at small N with large
+  `ntransf`; no shape slower. Against v2.4.1, which predates the regression, the
+  batched type-2 shapes are back to 0.95-0.97x of their old time, i.e. this is a
+  restore rather than a new speedup. (Barbone)
+* cuFINUFFT: `cuperftest` takes `--maxbatchsize` to force a batch size, so one binary
+  can benchmark every batch size. (Barbone)
 * The spread/interp kernel is now PSWF (prolate) only: opts.spread_kerformula
   takes 0 (default) or 7,8,9 (PSWF shape-parameter choices); the legacy ES (1,2),
   Kaiser-Bessel (3,4) and cosh-type (5,6) formulas are removed and now return

--- a/docs/c_gpu.rst
+++ b/docs/c_gpu.rst
@@ -412,7 +412,7 @@ Algorithm performance options
 
 **gpu_{o}binsize{x,y,z}**: various binsizes for sorting (GM-sort) or SM subproblem methods. Values of ``-1`` trigger the heuristically set default values. Leave at default unless you know what you're doing. [To be documented]
 
-**gpu_maxbatchsize**: ``0`` use heuristically defined batch size for vectorized (many-transforms with same NU points) interface, else set this batch size.
+**gpu_maxbatchsize**: for the vectorized (many-transforms with same NU points) interface, the largest batch of transforms to process per FFT. ``0`` (default) chooses it heuristically from the fine-grid size and the device's L2 cache size; a positive value is used as given, capped at ``ntransf``. Negative values are invalid.
 
 **gpu_stream**: ``cudaStream_t`` (cast to ``void*``) on which all of the plan's work is issued; ``nullptr`` (the default) means the default stream. See :ref:`CUDA streams<gpu_streams>`.
 

--- a/docs/c_gpu.rst
+++ b/docs/c_gpu.rst
@@ -412,7 +412,7 @@ Algorithm performance options
 
 **gpu_{o}binsize{x,y,z}**: various binsizes for sorting (GM-sort) or SM subproblem methods. Values of ``-1`` trigger the heuristically set default values. Leave at default unless you know what you're doing. [To be documented]
 
-**gpu_maxbatchsize**: ``0`` use heuristically defined batch size for vectorized (many-transforms with same NU points) interface, else set this batch size.
+**gpu_maxbatchsize**: for the vectorized (many-transforms with same NU points) interface, the largest batch of transforms to process per FFT. ``0`` (default) chooses it heuristically from the fine-grid size and the device's L2 cache and memory bus width; a positive value is used as given, capped at ``ntransf``. Negative values are invalid.
 
 **gpu_stream**: CUDA stream to use. Leave at default unless you know what you're doing.
 

--- a/include/cufinufft/cufinufft_plan_t.hpp
+++ b/include/cufinufft/cufinufft_plan_t.hpp
@@ -181,6 +181,26 @@ public:
 
 template<typename T> using gpu_array = thrust::device_vector<T, ThrustAllocatorAsync<T>>;
 
+// Device scratch (RAII, stream-ordered): gpu_array's allocator without
+// thrust::device_vector's value-initialization, for buffers the callee overwrites before
+// reading. Size 0 allocates nothing and data() returns nullptr.
+template<typename T> class gpu_scratch {
+  ThrustAllocatorAsync<T> alloc_;
+  thrust::device_ptr<T> ptr_{};
+  std::size_t n_{};
+
+public:
+  gpu_scratch(std::size_t n, ThrustAllocatorAsync<T> alloc) : alloc_(alloc), n_(n) {
+    if (n_) ptr_ = alloc_.allocate(n_);
+  }
+  ~gpu_scratch() {
+    if (n_) alloc_.deallocate(ptr_, n_);
+  }
+  gpu_scratch(const gpu_scratch &) = delete;
+  gpu_scratch &operator=(const gpu_scratch &) = delete;
+  T *data() const { return n_ ? thrust::raw_pointer_cast(ptr_) : nullptr; }
+};
+
 template<typename T> inline T *dethrust(gpu_array<T> &arr) {
   return thrust::raw_pointer_cast(arr.data());
 }

--- a/include/cufinufft/cufinufft_plan_t.hpp
+++ b/include/cufinufft/cufinufft_plan_t.hpp
@@ -182,6 +182,26 @@ public:
 
 template<typename T> using gpu_array = thrust::device_vector<T, ThrustAllocatorAsync<T>>;
 
+// Device scratch (RAII, stream-ordered): gpu_array's allocator without
+// thrust::device_vector's value-initialization, for buffers the callee overwrites before
+// reading. Size 0 allocates nothing and data() returns nullptr.
+template<typename T> class gpu_scratch {
+  ThrustAllocatorAsync<T> alloc_;
+  thrust::device_ptr<T> ptr_{};
+  std::size_t n_{};
+
+public:
+  gpu_scratch(std::size_t n, ThrustAllocatorAsync<T> alloc) : alloc_(alloc), n_(n) {
+    if (n_) ptr_ = alloc_.allocate(n_);
+  }
+  ~gpu_scratch() {
+    if (n_) alloc_.deallocate(ptr_, n_);
+  }
+  gpu_scratch(const gpu_scratch &) = delete;
+  gpu_scratch &operator=(const gpu_scratch &) = delete;
+  T *data() const { return n_ ? thrust::raw_pointer_cast(ptr_) : nullptr; }
+};
+
 template<typename T> inline T *dethrust(gpu_array<T> &arr) {
   return thrust::raw_pointer_cast(arr.data());
 }

--- a/include/cufinufft/cufinufft_plan_t.hpp
+++ b/include/cufinufft/cufinufft_plan_t.hpp
@@ -220,6 +220,9 @@ template<typename T> struct cufinufft_plan_t {
   cufinufft_opts opts;
   finufft_spread_opts spopts;
 
+  // Must precede `alloc` below, which reads it.
+  GpuCapabilities gpu;
+
   // Dynamic shared-memory bytes required per kernel launch for spread/interp.
   // Public because per-method drivers (spreadinterp.hpp) and shared-memory
   // setup (common.hpp::cufinufft_set_shared_memory) call it from outside the
@@ -288,10 +291,8 @@ private:
   friend void cufinufft::common::cufinufft_set_shared_memory(V *,
                                                              const cufinufft_plan_t<U> &);
 
-  bool supports_pools = false;
-
   ThrustAllocatorAsync<std::byte> alloc{(cudaStream_t)opts.gpu_stream, opts.gpu_device_id,
-                                        supports_pools};
+                                        gpu.memory_pools_supported != 0};
 
   // Plan-config invariants — set in the ctor's member-initializer list and
   // never mutated thereafter.

--- a/include/cufinufft/cufinufft_plan_t.hpp
+++ b/include/cufinufft/cufinufft_plan_t.hpp
@@ -377,10 +377,12 @@ private:
   cudaStream_t stream = 0;
 
   void execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d_fk) const;
-  // The "ntransf_override" parameter is only needed when a type 3 plan calls
-  // its inner type 2 plan. Leave at default in all other circumstances!
+  // The "ntransf_override" and "fw_scratch" parameters are only needed when a type 3
+  // plan calls its inner type 2 plan. Leave at default in all other circumstances!
+  // fw_scratch must hold at least nf*batchsize.
   void execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d_fk,
-                     std::optional<int> ntransf_override = std::optional<int>()) const;
+                     std::optional<int> ntransf_override = std::optional<int>(),
+                     cuda_complex<T> *fw_scratch = nullptr) const;
   void execute_type3(cuda_complex<T> *d_c, cuda_complex<T> *d_fk) const;
 
   void deconvolve(cuda_complex<T> *fw, cuda_complex<T> *fk, int blksize) const;

--- a/include/cufinufft/cufinufft_plan_t.hpp
+++ b/include/cufinufft/cufinufft_plan_t.hpp
@@ -221,6 +221,9 @@ template<typename T> struct cufinufft_plan_t {
   finufft_spread_opts spopts;
   bool eps_too_small = false;
 
+  // Must precede `alloc` below, which reads it.
+  GpuCapabilities gpu;
+
   // Dynamic shared-memory bytes required per kernel launch for spread/interp.
   // Public because per-method drivers (spreadinterp.hpp) and shared-memory
   // setup (common.hpp::cufinufft_set_shared_memory) call it from outside the
@@ -289,10 +292,8 @@ private:
   friend void cufinufft::common::cufinufft_set_shared_memory(V *,
                                                              const cufinufft_plan_t<U> &);
 
-  bool supports_pools = false;
-
   ThrustAllocatorAsync<std::byte> alloc{(cudaStream_t)opts.gpu_stream, opts.gpu_device_id,
-                                        supports_pools};
+                                        gpu.memory_pools_supported != 0};
 
   // Plan-config invariants — set in the ctor's member-initializer list and
   // never mutated thereafter.

--- a/include/cufinufft/heuristics.hpp
+++ b/include/cufinufft/heuristics.hpp
@@ -2,6 +2,7 @@
 #define CUFINUFFT_HEURISTICS_HPP
 
 #include <cstddef>
+
 #include <cstdio>
 
 #include <cuda_runtime.h>
@@ -24,17 +25,16 @@ std::size_t shared_memory_required(int dim, int ns, int bin_size_x, int bin_size
 // opts->gpu_device_id. Mutates opts in place. Mirrors finufft::heuristics on
 // the CPU side.
 template<typename T>
-void cufinufft_setup_binsize(int type, int ns, int dim, cufinufft_opts *opts);
+void cufinufft_setup_binsize(const GpuCapabilities &gpu, int type, int ns, int dim,
+                             cufinufft_opts *opts);
 
 // Opt this kernel into the dynamic shared memory the plan needs, throwing
 // FINUFFT_ERR_INSUFFICIENT_SHMEM if the device cannot satisfy the request.
 // WARNING: does not handle CUDA errors; the caller must check them.
 template<typename T, typename V>
 void cufinufft_set_shared_memory(V *kernel, const cufinufft_plan_t<T> &d_plan) {
-  int shared_mem_per_block{};
   const auto shared_mem_required = d_plan.shared_memory_required();
-  cudaDeviceGetAttribute(&shared_mem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin,
-                         d_plan.opts.gpu_device_id);
+  const int shared_mem_per_block = d_plan.gpu.max_smem_per_block_optin;
   if (shared_mem_required > unsigned(shared_mem_per_block)) {
     fprintf(stderr,
             "Error: Shared memory required per block is %zu bytes, but the device "

--- a/include/cufinufft/heuristics.hpp
+++ b/include/cufinufft/heuristics.hpp
@@ -2,6 +2,7 @@
 #define CUFINUFFT_HEURISTICS_HPP
 
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 
 #include <cuda_runtime.h>
@@ -27,12 +28,12 @@ template<typename T>
 void cufinufft_setup_binsize(const GpuCapabilities &gpu, int type, int ns, int dim,
                              cufinufft_opts *opts);
 
-// How many transforms to batch into one FFT / spread pass, in [1, ntransf].
+// How many transforms to batch into one FFT / spread pass, in [1, ntransf]. Needs the
+// fine grid, so it is called once nf is known.
 // opts.gpu_maxbatchsize == 0 means auto; > 0 is honored (capped at ntransf).
-// Pass nf == 0 when the fine grid is not known yet: the L2 refinement is then skipped.
 template<typename T>
 int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf,
-                     CUFINUFFT_BIGINT nf);
+                     std::int64_t nf);
 
 // Opt this kernel into the dynamic shared memory the plan needs, throwing
 // FINUFFT_ERR_INSUFFICIENT_SHMEM if the device cannot satisfy the request.

--- a/include/cufinufft/heuristics.hpp
+++ b/include/cufinufft/heuristics.hpp
@@ -2,7 +2,7 @@
 #define CUFINUFFT_HEURISTICS_HPP
 
 #include <cstddef>
-
+#include <cstdint>
 #include <cstdio>
 
 #include <cuda_runtime.h>
@@ -27,6 +27,11 @@ std::size_t shared_memory_required(int dim, int ns, int bin_size_x, int bin_size
 template<typename T>
 void cufinufft_setup_binsize(const GpuCapabilities &gpu, int type, int ns, int dim,
                              cufinufft_opts *opts);
+
+// How many transforms to batch into one FFT / spread pass, in [1, ntransf].
+// opts.gpu_maxbatchsize == 0 means auto; > 0 is honored (capped at ntransf).
+template<typename T>
+int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf);
 
 // Opt this kernel into the dynamic shared memory the plan needs, throwing
 // FINUFFT_ERR_INSUFFICIENT_SHMEM if the device cannot satisfy the request.

--- a/include/cufinufft/heuristics.hpp
+++ b/include/cufinufft/heuristics.hpp
@@ -2,7 +2,6 @@
 #define CUFINUFFT_HEURISTICS_HPP
 
 #include <cstddef>
-#include <cstdint>
 #include <cstdio>
 
 #include <cuda_runtime.h>
@@ -30,8 +29,10 @@ void cufinufft_setup_binsize(const GpuCapabilities &gpu, int type, int ns, int d
 
 // How many transforms to batch into one FFT / spread pass, in [1, ntransf].
 // opts.gpu_maxbatchsize == 0 means auto; > 0 is honored (capped at ntransf).
+// Pass nf == 0 when the fine grid is not known yet: the L2 refinement is then skipped.
 template<typename T>
-int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf);
+int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf,
+                     CUFINUFFT_BIGINT nf);
 
 // Opt this kernel into the dynamic shared memory the plan needs, throwing
 // FINUFFT_ERR_INSUFFICIENT_SHMEM if the device cannot satisfy the request.

--- a/include/cufinufft/types.hpp
+++ b/include/cufinufft/types.hpp
@@ -6,6 +6,7 @@
 #include <finufft_common/common.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cuComplex.h>
 #include <cuda_runtime.h>
 #include <limits>
@@ -96,6 +97,12 @@ struct GpuCapabilities {
 
   // Ada (8.9), Ampere 8.6, Blackwell workstation (12.0).
   bool is_small_smem() const { return max_smem_per_block_optin <= 110 * 1024; }
+
+  // Complex elements in the ~1/3 of L2 the batchsize heuristic budgets for the working
+  // set (in + out + twiddle).
+  template<typename T> std::int64_t l2_complex_budget() const {
+    return l2_cache_size / 3 / std::int64_t(sizeof(cuda_complex<T>));
+  }
 
   // Upper bound for "good enough" thread-block sizes:
   //   SM 9x / 8x : 16 warps = 256 threads

--- a/include/cufinufft/types.hpp
+++ b/include/cufinufft/types.hpp
@@ -6,6 +6,7 @@
 #include <finufft_common/common.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cuComplex.h>
 #include <cuda_runtime.h>
 #include <limits>
@@ -94,6 +95,12 @@ struct GpuCapabilities {
 
   // Ada (8.9), Ampere 8.6, Blackwell workstation (12.0).
   bool is_small_smem() const { return max_smem_per_block_optin <= 110 * 1024; }
+
+  // Complex elements in the ~1/3 of L2 the batchsize heuristic budgets for the working
+  // set (in + out + twiddle).
+  template<typename T> std::int64_t l2_complex_budget() const {
+    return l2_cache_size / 3 / std::int64_t(sizeof(cuda_complex<T>));
+  }
 
   // Upper bound for "good enough" thread-block sizes:
   //   SM 9x / 8x : 16 warps = 256 threads

--- a/include/cufinufft/types.hpp
+++ b/include/cufinufft/types.hpp
@@ -5,7 +5,9 @@
 #include <cufinufft_opts.h>
 #include <finufft_common/common.h>
 
+#include <algorithm>
 #include <cuComplex.h>
+#include <cuda_runtime.h>
 #include <limits>
 
 // FIXME: If cufft ever takes N > INT_MAX...
@@ -41,5 +43,86 @@ static inline cufftResult cufft_ex(cufftHandle plan, cufftDoubleComplex *idata,
                                    cufftDoubleComplex *odata, int direction) {
   return cufftExecZ2Z(plan, idata, odata, direction);
 }
+
+// Method 3 couples shared-memory footprint with work granularity, so it needs finer
+// buckets than the is_hopper_like()/is_small_smem() split Method 2 uses.
+enum class Method3Category {
+  AMPERE_LARGE, // A100: CC 8.0, prefers low shmem, small np
+  HOPPER,       // H100/H200: CC 9.0, can use larger np
+  ADA_DESKTOP,  // Small-SMEM desktop/workstation: Ada/Blackwell, high SM count
+  ADA_MOBILE,   // Small-SMEM mobile: low SM count
+  UNKNOWN       // Fallback
+};
+
+// Device attributes the heuristics and launch paths need, queried once per plan with
+// cudaDeviceGetAttribute. cudaGetDeviceProperties is far slower, so it stays in the
+// debug print.
+struct GpuCapabilities {
+  int device_id{};
+  int cc_major{}, cc_minor{};
+  int max_smem_per_block_optin{}; // bytes
+  int max_smem_per_sm{};          // bytes
+  int max_threads_per_sm{};
+  int multiprocessor_count{};
+  int l2_cache_size{};        // bytes
+  int global_mem_bus_width{}; // bits; GDDR reports <= 512, HBM >= 4096
+  int memory_pools_supported{};
+
+  static GpuCapabilities query(int device_id) {
+    GpuCapabilities gpu{};
+    gpu.device_id = device_id;
+    const auto get = [device_id](int *dst, cudaDeviceAttr attr) {
+      cudaDeviceGetAttribute(dst, attr, device_id);
+    };
+    get(&gpu.cc_major, cudaDevAttrComputeCapabilityMajor);
+    get(&gpu.cc_minor, cudaDevAttrComputeCapabilityMinor);
+    get(&gpu.max_smem_per_block_optin, cudaDevAttrMaxSharedMemoryPerBlockOptin);
+    get(&gpu.max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor);
+    get(&gpu.max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor);
+    get(&gpu.multiprocessor_count, cudaDevAttrMultiProcessorCount);
+    get(&gpu.l2_cache_size, cudaDevAttrL2CacheSize);
+    get(&gpu.global_mem_bus_width, cudaDevAttrGlobalMemoryBusWidth);
+    get(&gpu.memory_pools_supported, cudaDevAttrMemoryPoolsSupported);
+    return gpu;
+  }
+
+  int max_warps_per_sm() const { return max_threads_per_sm / 32; }
+
+  // "Hopper-like" = large shared memory (>=200 KB/block) AND high occupancy
+  // (>=64 warps/SM). Matches H100/H200 (9.0) and Blackwell datacenter (10.0).
+  bool is_hopper_like() const {
+    return max_smem_per_block_optin >= 200 * 1024 && max_warps_per_sm() >= 64;
+  }
+
+  // Ada (8.9), Ampere 8.6, Blackwell workstation (12.0).
+  bool is_small_smem() const { return max_smem_per_block_optin <= 110 * 1024; }
+
+  // Upper bound for "good enough" thread-block sizes:
+  //   SM 9x / 8x : 16 warps = 256 threads
+  //   SM 7x      :  8 warps = 128 threads
+  //   SM 6x-     :  4 warps =  64 threads
+  unsigned optimal_block_threads() const {
+    if (cc_major >= 8) return 256;
+    if (cc_major >= 7) return 128;
+    return 64;
+  }
+
+  // Workload-aware block size for method-1 interpolation: optimal_block_threads() is
+  // still the cap, but tiny transforms run better with fewer threads. Ramp up from one
+  // warp in power-of-two steps until we hit the workload size or the device cap.
+  unsigned interp_block_threads(int M) const {
+    const auto limit =
+        std::min(optimal_block_threads(), static_cast<unsigned>(std::max(M, 32)));
+    if (limit >= 256) return 256;
+    if (limit >= 128) return 128;
+    if (limit >= 64) return 64;
+    return 32;
+  }
+
+  // Defined in heuristics.cu: keeps the Method-3 table and <cstdio> out of this header.
+  Method3Category method3_category() const;
+  const char *method3_category_name() const;
+  void print_classification(int debug_level) const;
+};
 
 #endif

--- a/include/cufinufft/types.hpp
+++ b/include/cufinufft/types.hpp
@@ -5,7 +5,9 @@
 #include <cufinufft_opts.h>
 #include <finufft_common/common.h>
 
+#include <algorithm>
 #include <cuComplex.h>
+#include <cuda_runtime.h>
 #include <limits>
 
 // FIXME: If cufft ever takes N > INT_MAX...
@@ -41,5 +43,84 @@ static inline cufftResult cufft_ex(cufftHandle plan, cufftDoubleComplex *idata,
                                    cufftDoubleComplex *odata, int direction) {
   return cufftExecZ2Z(plan, idata, odata, direction);
 }
+
+// Method 3 couples shared-memory footprint with work granularity, so it needs finer
+// buckets than the is_hopper_like()/is_small_smem() split Method 2 uses.
+enum class Method3Category {
+  AMPERE_LARGE, // A100: CC 8.0, prefers low shmem, small np
+  HOPPER,       // H100/H200: CC 9.0, can use larger np
+  ADA_DESKTOP,  // Small-SMEM desktop/workstation: Ada/Blackwell, high SM count
+  ADA_MOBILE,   // Small-SMEM mobile: low SM count
+  UNKNOWN       // Fallback
+};
+
+// Device attributes the heuristics and launch paths need, queried once per plan with
+// cudaDeviceGetAttribute. cudaGetDeviceProperties is far slower, so it stays in the
+// debug print.
+struct GpuCapabilities {
+  int device_id{};
+  int cc_major{}, cc_minor{};
+  int max_smem_per_block_optin{}; // bytes
+  int max_smem_per_sm{};          // bytes
+  int max_threads_per_sm{};
+  int multiprocessor_count{};
+  int l2_cache_size{}; // bytes
+  int memory_pools_supported{};
+
+  static GpuCapabilities query(int device_id) {
+    GpuCapabilities gpu{};
+    gpu.device_id = device_id;
+    const auto get = [device_id](int *dst, cudaDeviceAttr attr) {
+      cudaDeviceGetAttribute(dst, attr, device_id);
+    };
+    get(&gpu.cc_major, cudaDevAttrComputeCapabilityMajor);
+    get(&gpu.cc_minor, cudaDevAttrComputeCapabilityMinor);
+    get(&gpu.max_smem_per_block_optin, cudaDevAttrMaxSharedMemoryPerBlockOptin);
+    get(&gpu.max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor);
+    get(&gpu.max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor);
+    get(&gpu.multiprocessor_count, cudaDevAttrMultiProcessorCount);
+    get(&gpu.l2_cache_size, cudaDevAttrL2CacheSize);
+    get(&gpu.memory_pools_supported, cudaDevAttrMemoryPoolsSupported);
+    return gpu;
+  }
+
+  int max_warps_per_sm() const { return max_threads_per_sm / 32; }
+
+  // "Hopper-like" = large shared memory (>=200 KB/block) AND high occupancy
+  // (>=64 warps/SM). Matches H100/H200 (9.0) and Blackwell datacenter (10.0).
+  bool is_hopper_like() const {
+    return max_smem_per_block_optin >= 200 * 1024 && max_warps_per_sm() >= 64;
+  }
+
+  // Ada (8.9), Ampere 8.6, Blackwell workstation (12.0).
+  bool is_small_smem() const { return max_smem_per_block_optin <= 110 * 1024; }
+
+  // Upper bound for "good enough" thread-block sizes:
+  //   SM 9x / 8x : 16 warps = 256 threads
+  //   SM 7x      :  8 warps = 128 threads
+  //   SM 6x-     :  4 warps =  64 threads
+  unsigned optimal_block_threads() const {
+    if (cc_major >= 8) return 256;
+    if (cc_major >= 7) return 128;
+    return 64;
+  }
+
+  // Workload-aware block size for method-1 interpolation: optimal_block_threads() is
+  // still the cap, but tiny transforms run better with fewer threads. Ramp up from one
+  // warp in power-of-two steps until we hit the workload size or the device cap.
+  unsigned interp_block_threads(int M) const {
+    const auto limit =
+        std::min(optimal_block_threads(), static_cast<unsigned>(std::max(M, 32)));
+    if (limit >= 256) return 256;
+    if (limit >= 128) return 128;
+    if (limit >= 64) return 64;
+    return 32;
+  }
+
+  // Defined in heuristics.cu: keeps the Method-3 table and <cstdio> out of this header.
+  Method3Category method3_category() const;
+  const char *method3_category_name() const;
+  void print_classification(int debug_level) const;
+};
 
 #endif

--- a/include/cufinufft/utils.hpp
+++ b/include/cufinufft/utils.hpp
@@ -147,39 +147,6 @@ auto launch_dispatch_ndim_ns(Func &&func, int target_ndim, int target_ns,
   return poet::dispatch(std::forward<Func>(func), params, std::forward<Args>(args)...);
 }
 
-/**
- * Return an architecture-specific upper bound for “good enough”
- * thread-block sizes.
- * Rationale (rule-of-thumb):
- *   SM 9x / 8x : 16 warps  = 256 threads
- *   SM 7x      :  8 warps  = 128 threads
- *   SM 6x-     :  4 warps  = 64 threads
- */
-inline unsigned optimal_block_threads(int device) noexcept {
-  cudaGetDevice(&device);
-  cudaDeviceProp prop;
-  cudaGetDeviceProperties(&prop, device);
-  int major = prop.major;
-  if (major >= 8) return 256;
-  if (major >= 7) return 128;
-  return 64;
-}
-
-/**
- * Choose a workload-aware block size for method-1 interpolation.
- * The architecture-specific cap above is still a good upper bound, but tiny
- * transforms often run better with fewer threads. Ramp up from one warp in
- * power-of-two steps until we hit either the workload size or the device cap.
- */
-inline unsigned optimal_interp_block_threads(int device, int M) noexcept {
-  const auto limit =
-      std::min(optimal_block_threads(device), static_cast<unsigned>(std::max(M, 32)));
-  if (limit >= 256) return 256;
-  if (limit >= 128) return 128;
-  if (limit >= 64) return 64;
-  return 32;
-}
-
 } // namespace utils
 } // namespace cufinufft
 

--- a/include/cufinufft_opts.h
+++ b/include/cufinufft_opts.h
@@ -24,7 +24,8 @@ typedef struct cufinufft_opts { // see cufinufft_default_opts() for defaults
 
   int gpu_spreadinterponly; // 0: NUFFT, 1: spread or interpolation only
 
-  int gpu_maxbatchsize;
+  int gpu_maxbatchsize; // transforms per FFT: 0 auto, >0 used as given (capped at
+                        // ntransf), <0 invalid
 
   /* multi-gpu support */
   int gpu_device_id;

--- a/perftest/cuda/cuperftest.cu
+++ b/perftest/cuda/cuperftest.cu
@@ -32,9 +32,12 @@ struct test_options_t {
   int32_t N[3];
   int M;
   int ntransf;
+  int dim;
+  double X, S;
   int kerevalmethod;
   int method;
   int sort;
+  int maxbatchsize;
   double tol;
   int debug;
 
@@ -54,6 +57,10 @@ struct test_options_t {
           {"N3", required_argument, 0, 0},
           {"M", required_argument, 0, 0},
           {"ntransf", required_argument, 0, 0},
+          {"dim", required_argument, 0, 0},
+          {"X", required_argument, 0, 0},
+          {"S", required_argument, 0, 0},
+          {"maxbatchsize", required_argument, 0, 0},
           {"tol", required_argument, 0, 0},
           {"method", required_argument, 0, 0},
           {"kerevalmethod", required_argument, 0, 0},
@@ -84,7 +91,11 @@ struct test_options_t {
     N[2]          = std::stof(get_or(options_map, "N3", "1"));
     M             = std::stof(get_or(options_map, "M", "2E6"));
     ntransf       = std::stoi(get_or(options_map, "ntransf", "1"));
-    method        = std::stoi(get_or(options_map, "method", "1"));
+    dim = std::stoi(get_or(options_map, "dim", "0"));
+    X = std::stof(get_or(options_map, "X", "100"));
+    S = std::stof(get_or(options_map, "S", "10"));
+    maxbatchsize = std::stoi(get_or(options_map, "maxbatchsize", "0"));
+    method = std::stoi(get_or(options_map, "method", type == 3 ? "0" : "1"));
     kerevalmethod = std::stoi(get_or(options_map, "kerevalmethod", "1"));
     sort          = std::stoi(get_or(options_map, "sort", "1"));
     tol           = std::stof(get_or(options_map, "tol", "1E-5"));
@@ -100,6 +111,10 @@ struct test_options_t {
                 << "# N3 = " << opts.N[2] << "\n"
                 << "# M = " << opts.M << "\n"
                 << "# ntransf = " << opts.ntransf << "\n"
+                << "# dim = " << opts.dim << "\n"
+                << "# X = " << opts.X << "\n"
+                << "# S = " << opts.S << "\n"
+                << "# maxbatchsize = " << opts.maxbatchsize << "\n"
                 << "# method = " << opts.method << "\n"
                 << "# kerevalmethod = " << opts.kerevalmethod << "\n"
                 << "# sort = " << opts.sort << "\n"
@@ -193,10 +208,20 @@ template<typename T> void run_test(test_options_t &test_opts) {
   const int type      = test_opts.type;
   constexpr int iflag = 1;
 
+  // Type 3 has no mode grid: N is its number of frequency targets, spread over [-S, S],
+  // and the dimension cannot be inferred from N, so --dim is required.
+  const int nk = type == 3 ? N : 0;
+  if (type == 3 && !test_opts.dim) {
+    std::cerr << "type 3 needs an explicit --dim (1, 2 or 3)\n";
+    return;
+  }
+
   thrust::host_vector<T> x(M * ntransf), y(M * ntransf), z(M * ntransf);
+  thrust::host_vector<T> s(nk), t(nk), u(nk);
   thrust::host_vector<thrust::complex<T>> c(M * ntransf), fk(N * ntransf);
 
   thrust::device_vector<T> d_x(M * ntransf), d_y(M * ntransf), d_z(M * ntransf);
+  thrust::device_vector<T> d_s(nk), d_t(nk), d_u(nk);
   thrust::device_vector<thrust::complex<T>> d_c(M * ntransf), d_fk(N * ntransf);
 
   std::default_random_engine eng(1);
@@ -205,11 +230,13 @@ template<typename T> void run_test(test_options_t &test_opts) {
     return dist11(eng);
   };
 
-  // Making data
+  // Making data. Type 1/2 need x in [-pi,pi); type 3 takes any real, and the source
+  // half-width matters as much as S -- their product sets the fine grid.
+  const T half_width = type == 3 ? T(test_opts.X) : T(PI);
   for (int64_t i = 0; i < M; i++) {
-    x[i] = PI * randm11(); // x in [-pi,pi)
-    y[i] = PI * randm11();
-    z[i] = PI * randm11();
+    x[i] = half_width * randm11();
+    y[i] = half_width * randm11();
+    z[i] = half_width * randm11();
   }
   for (int64_t i = M; i < M * ntransf; ++i) {
     int64_t j = i % M;
@@ -218,12 +245,11 @@ template<typename T> void run_test(test_options_t &test_opts) {
     z[i]      = z[j];
   }
 
-  if (type == 1) {
+  if (type == 1 || type == 3) {
     for (int i = 0; i < M * ntransf; i++) {
       c[i].real(randm11());
       c[i].imag(randm11());
     }
-
   } else if (type == 2) {
     for (int i = 0; i < N * ntransf; i++) {
       fk[i].real(randm11());
@@ -233,17 +259,25 @@ template<typename T> void run_test(test_options_t &test_opts) {
     std::cerr << "Invalid type " << type << " supplied\n";
     return;
   }
+  for (int k = 0; k < nk; ++k) {
+    s[k] = test_opts.S * randm11();
+    t[k] = test_opts.S * randm11();
+    u[k] = test_opts.S * randm11();
+  }
 
   gpu_warmup();
 
   cufinufft_opts opts;
-  int dim = 0;
-  for (int i = 0; i < 3; ++i) dim = test_opts.N[i] > 1 ? i + 1 : dim;
+  // Type 3 has no mode grid to infer the dimension from, so --dim is required there.
+  int dim = test_opts.dim;
+  if (!dim)
+    for (int i = 0; i < 3; ++i) dim = test_opts.N[i] > 1 ? i + 1 : dim;
 
   cufinufft_default_opts(&opts);
   opts.gpu_method      = test_opts.method;
   opts.gpu_sort        = test_opts.sort;
   opts.gpu_kerevalmeth = test_opts.kerevalmethod;
+  opts.gpu_maxbatchsize = test_opts.maxbatchsize;
   opts.debug           = test_opts.debug;
 
   cufinufft_plan_t<T> *dplan;
@@ -253,28 +287,32 @@ template<typename T> void run_test(test_options_t &test_opts) {
     amortized_timer.start();
     h2d_timer.start();
     d_x = x, d_y = y, d_z = z;
-    if (type == 1) d_c = c;
+    d_s = s, d_t = t, d_u = u;
+    if (type == 1 || type == 3) d_c = c;
     if (type == 2) d_fk = fk;
     h2d_timer.stop();
 
     T *d_x_p                = dim >= 1 ? d_x.data().get() : nullptr;
     T *d_y_p                = dim >= 2 ? d_y.data().get() : nullptr;
     T *d_z_p                = dim == 3 ? d_z.data().get() : nullptr;
+    T *d_s_p = nk && dim >= 1 ? d_s.data().get() : nullptr;
+    T *d_t_p = nk && dim >= 2 ? d_t.data().get() : nullptr;
+    T *d_u_p = nk && dim == 3 ? d_u.data().get() : nullptr;
     cuda_complex<T> *d_c_p  = (cuda_complex<T> *)d_c.data().get();
     cuda_complex<T> *d_fk_p = (cuda_complex<T> *)d_fk.data().get();
 
     timeit(makeplan<T>, makeplan_timer, test_opts.type, dim, test_opts.N, iflag, ntransf,
            test_opts.tol, opts, &dplan);
     for (int i = 0; i < test_opts.n_runs; ++i) {
-      timeit(std::bind(&cufinufft_plan_t<T>::setpts, dplan, M, d_x_p, d_y_p, d_z_p, 0,
-                       nullptr, nullptr, nullptr),
+      timeit(std::bind(&cufinufft_plan_t<T>::setpts, dplan, M, d_x_p, d_y_p, d_z_p, nk,
+                       d_s_p, d_t_p, d_u_p),
              setpts_timer);
       timeit(std::bind(&cufinufft_plan_t<T>::execute, dplan, d_c_p, d_fk_p),
              execute_timer);
     }
 
     d2h_timer.start();
-    if (type == 1) fk = d_fk;
+    if (type == 1 || type == 3) fk = d_fk;
     if (type == 2) c = d_c;
     d2h_timer.stop();
 
@@ -318,7 +356,9 @@ int main(int argc, char *argv[]) {
                  "           float or double precision. i.e. 'f' or 'd'\n"
                  "           default: " << default_opts.prec << "\n" <<
                  "    --type <int>\n"
-                 "           type of transform. 1 or 2\n"
+                 "           type of transform. 1, 2 or 3\n"
+                 "           for type 3 the N's are the number of frequency targets, not modes,\n"
+                 "           and --dim is required\n"
                  "           default: " << default_opts.type << "\n" <<
                  "    --n_runs <int>\n"
                  "           number of runs to average performance over\n"
@@ -338,6 +378,15 @@ int main(int argc, char *argv[]) {
                  "    --ntransf <int>\n"
                  "           number of transforms to do simultaneously\n"
                  "           default: " << default_opts.ntransf << "\n" <<
+                 "    --dim <int>\n"
+                 "           dimension of the transform. 0 infers it from N1/N2/N3\n"
+                 "           default: " << default_opts.dim << "\n" <<
+                 "    --X <float>\n"
+                 "           type 3 only: sources are drawn from [-X, X]\n"
+                 "           default: " << default_opts.X << "\n" <<
+                 "    --S <float>\n"
+                 "           type 3 only: frequency targets are drawn from [-S, S]\n"
+                 "           default: " << default_opts.S << "\n" <<
                  "    --tol <float>\n"
                  "           NUFFT tolerance. Scientific notation accepted (i.e. 1.2E-7)\n"
                  "           default: " << default_opts.tol << "\n" <<
@@ -346,8 +395,10 @@ int main(int argc, char *argv[]) {
                  "               1: nupts driven\n"
                  "               2: sub-problem\n"
                  "               3: output-driven subproblem (experimental)\n"
+                 "               0: let the plan choose. Type 3 wants this: forcing\n"
+                 "                  method 1 on it costs 7x\n"
                  "           Note that not all methods are compatible with all dim/type combinations\n"
-                 "           default: " << default_opts.method << "\n" <<
+                 "           default: 1, or 0 for type 3\n" <<
                  "    --kerevalmeth <int>\n"
                  "           kernel evaluation method\n"
                  "               0: Exponential of square root\n"

--- a/perftest/cuda/cuperftest.cu
+++ b/perftest/cuda/cuperftest.cu
@@ -64,6 +64,7 @@ struct test_options_t {
   int kerevalmethod;
   int method;
   int sort;
+  int maxbatchsize;
   double tol;
   int debug;
 
@@ -86,6 +87,7 @@ struct test_options_t {
           {"tol", required_argument, 0, 0},
           {"method", required_argument, 0, 0},
           {"kerevalmethod", required_argument, 0, 0},
+          {"maxbatchsize", required_argument, 0, 0},
           {"sort", required_argument, 0, 0},
           {"debug", required_argument, 0, 0},
           {0, 0, 0, 0},
@@ -115,6 +117,7 @@ struct test_options_t {
     ntransf       = std::stoi(get_or(options_map, "ntransf", "1"));
     method        = std::stoi(get_or(options_map, "method", "1"));
     kerevalmethod = std::stoi(get_or(options_map, "kerevalmethod", "1"));
+    maxbatchsize  = std::stoi(get_or(options_map, "maxbatchsize", "0"));
     sort          = std::stoi(get_or(options_map, "sort", "1"));
     tol           = std::stof(get_or(options_map, "tol", "1E-5"));
     debug = std::stof(get_or(options_map, "debug", "0"));
@@ -131,6 +134,7 @@ struct test_options_t {
                 << "# ntransf = " << opts.ntransf << "\n"
                 << "# method = " << opts.method << "\n"
                 << "# kerevalmethod = " << opts.kerevalmethod << "\n"
+                << "# maxbatchsize = " << opts.maxbatchsize << "\n"
                 << "# sort = " << opts.sort << "\n"
                 << "# tol = " << opts.tol << "\n"
                 << "# debug = " << opts.debug << "\n";
@@ -306,6 +310,7 @@ template<typename T> void run_test(test_options_t &test_opts) {
   opts.gpu_method      = test_opts.method;
   opts.gpu_sort        = test_opts.sort;
   opts.gpu_kerevalmeth = test_opts.kerevalmethod;
+  opts.gpu_maxbatchsize = test_opts.maxbatchsize;
   set_debug(opts, test_opts.debug, 0);
 
   // The public API takes the mode counts as int64.

--- a/src/cuda/execute.cu
+++ b/src/cuda/execute.cu
@@ -121,18 +121,15 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
 
   int nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
-  // We don't need this buffer if we are just spreading; so we set
-  // its size to 0 in that case.
-  gpu_array<cuda_complex<T>> fwp(opts.gpu_spreadinterponly ? 0 : nf * batchsize, alloc);
-  auto *fw = dethrust(fwp);
+  // Uninitialized: spread memsets fw below. Size 0 when spreading only, which spreads
+  // straight into f.
+  const bool spread_only = opts.gpu_spreadinterponly;
+  gpu_scratch<cuda_complex<T>> fwp(spread_only ? 0 : nf * batchsize, alloc);
   for (int i = 0; i * batchsize < ntransf; i++) {
-    int blksize   = std::min(ntransf - i * batchsize, batchsize);
+    int blksize = std::min(ntransf - i * batchsize, batchsize);
     const auto *c = d_c + i * batchsize * M;
-    auto *fk      = d_fk + i * batchsize * nmodes; // so deconvolve will write into
-                                                   // user output f
-    if (opts.gpu_spreadinterponly)
-      fw = fk;                                     // spread directly into the appropriate
-                                                   // section of the user output f
+    auto *fk = d_fk + i * batchsize * nmodes; // deconvolve writes user output f
+    auto *fw = spread_only ? fk : fwp.data();
 
     checkCudaErrors(
         cudaMemsetAsync(fw, 0, blksize * nf * sizeof(cuda_complex<T>), stream));
@@ -140,7 +137,7 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
     // Step 1: Spread
     spreadSorted(c, fw, blksize);
 
-    if (opts.gpu_spreadinterponly) continue; // skip steps 2 and 3
+    if (spread_only) continue; // skip steps 2 and 3
 
     // Step 2: FFT
     cufftResult cufft_status = cufft_ex(fftplan.get(), fw, fw, iflag);
@@ -176,17 +173,19 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
 
   int nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
-  // We don't need this buffer if we are just interpolating; so we set
-  // its size to 0 in that case.
-  gpu_array<cuda_complex<T>> fwp(opts.gpu_spreadinterponly ? 0 : nf * batchsize, alloc);
-  auto *fw = dethrust(fwp);
+  // Uninitialized: deconvolve overwrites fw below. Size 0 when interpolating only, which
+  // reads f directly.
+  const bool interp_only = opts.gpu_spreadinterponly;
+  gpu_scratch<cuda_complex<T>> fwp(interp_only ? 0 : nf * batchsize, alloc);
+  // cufft_ex transforms all `batchsize` grids even when blksize < batchsize; the extra
+  // ones hold stale data and are discarded.
   for (int i = 0; i * batchsize < ntransf_for_this_run; i++) {
     int blksize = std::min(ntransf_for_this_run - i * batchsize, batchsize);
-    auto *c     = d_c + i * batchsize * M;
-    auto *fk    = d_fk + i * batchsize * nmodes;
+    auto *c = d_c + i * batchsize * M;
+    auto *fk = d_fk + i * batchsize * nmodes;
+    auto *fw = interp_only ? fk : fwp.data();
 
-    // Skip steps 1 and 2 if interponly
-    if (!opts.gpu_spreadinterponly) {
+    if (!interp_only) {
       // Step 1: amplify Fourier coeffs fk and copy into upsampled array fw
       deconvolve(fw, fk, blksize);
 
@@ -195,8 +194,7 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
       cufftResult cufft_status = cufft_ex(fftplan.get(), fw, fw, iflag);
       if (cufft_status != CUFFT_SUCCESS)
         throw cufinufft::cufft_exception(cufft_status, "cufft_ex_type2");
-    } else
-      fw = fk; // interpolate directly from user input f
+    }
 
     // Step 3: Interpolate
     interpSorted(c, fw, blksize);
@@ -223,7 +221,7 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
   gpu_array<cuda_complex<T>> fwp(nf * batchsize, alloc);
   auto *fw = dethrust(fwp);
   for (int i = 0; i * batchsize < ntransf; i++) {
-    int blksize                = std::min(ntransf - i * batchsize, batchsize);
+    int blksize = std::min(ntransf - i * batchsize, batchsize);
     cuda_complex<T> *d_cstart  = d_c + i * batchsize * M;
     cuda_complex<T> *d_fkstart = d_fk + i * batchsize * N;
     // setting input for spreader

--- a/src/cuda/execute.cu
+++ b/src/cuda/execute.cu
@@ -123,19 +123,15 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
 
   std::int64_t nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
-  // We don't need this buffer if we are just spreading; so we set
-  // its size to 0 in that case.
-  gpu_array<cuda_complex<T>> fwp(
-      opts.gpu_spreadinterponly ? 0 : std::size_t(nf) * batchsize, alloc);
-  auto *fw = dethrust(fwp);
+  // Uninitialized: spread memsets fw below. Size 0 when spreading only, which spreads
+  // straight into f.
+  const bool spread_only = opts.gpu_spreadinterponly;
+  gpu_scratch<cuda_complex<T>> fwp(spread_only ? 0 : std::size_t(nf) * batchsize, alloc);
   for (std::int64_t i = 0; i * batchsize < ntransf; i++) {
     int blksize = int(std::min<std::int64_t>(ntransf - i * batchsize, batchsize));
     const auto *c = d_c + i * batchsize * M;
-    auto *fk      = d_fk + i * batchsize * nmodes; // so deconvolve will write into
-                                                   // user output f
-    if (opts.gpu_spreadinterponly)
-      fw = fk;                                     // spread directly into the appropriate
-                                                   // section of the user output f
+    auto *fk = d_fk + i * batchsize * nmodes; // deconvolve writes user output f
+    auto *fw = spread_only ? fk : fwp.data();
 
     checkCudaErrors(cudaMemsetAsync(
         fw, 0, std::size_t(blksize) * nf * sizeof(cuda_complex<T>), stream));
@@ -143,7 +139,7 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
     // Step 1: Spread
     spreadSorted(c, fw, blksize);
 
-    if (opts.gpu_spreadinterponly) continue; // skip steps 2 and 3
+    if (spread_only) continue; // skip steps 2 and 3
 
     // Step 2: FFT
     cufftResult cufft_status = cufft_ex(fftplan.get(), fw, fw, iflag);
@@ -179,11 +175,10 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
 
   std::int64_t nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
-  // We don't need this buffer if we are just interpolating; so we set
-  // its size to 0 in that case.
-  gpu_array<cuda_complex<T>> fwp(
-      opts.gpu_spreadinterponly ? 0 : std::size_t(nf) * batchsize, alloc);
-  auto *fw = dethrust(fwp);
+  // Uninitialized: deconvolve overwrites fw below. Size 0 when interpolating only, which
+  // reads f directly.
+  const bool interp_only = opts.gpu_spreadinterponly;
+  gpu_scratch<cuda_complex<T>> fwp(interp_only ? 0 : std::size_t(nf) * batchsize, alloc);
   // cufft_ex transforms all `batchsize` grids even when blksize < batchsize; the extra
   // ones hold stale data and are discarded.
   for (std::int64_t i = 0; i * batchsize < ntransf_for_this_run; i++) {
@@ -191,9 +186,9 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
         int(std::min<std::int64_t>(ntransf_for_this_run - i * batchsize, batchsize));
     auto *c = d_c + i * batchsize * M;
     auto *fk = d_fk + i * batchsize * nmodes;
+    auto *fw = interp_only ? fk : fwp.data();
 
-    // Skip steps 1 and 2 if interponly
-    if (!opts.gpu_spreadinterponly) {
+    if (!interp_only) {
       // Step 1: amplify Fourier coeffs fk and copy into upsampled array fw
       deconvolve(fw, fk, blksize);
 
@@ -202,8 +197,7 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
       cufftResult cufft_status = cufft_ex(fftplan.get(), fw, fw, iflag);
       if (cufft_status != CUFFT_SUCCESS)
         throw cufinufft::cufft_exception(cufft_status, "cufft_ex_type2");
-    } else
-      fw = fk; // interpolate directly from user input f
+    }
 
     // Step 3: Interpolate
     interpSorted(c, fw, blksize);

--- a/src/cuda/execute.cu
+++ b/src/cuda/execute.cu
@@ -151,7 +151,8 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
 
 template<typename T>
 void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d_fk,
-                                        std::optional<int> ntransf_override) const
+                                        std::optional<int> ntransf_override,
+                                        cuda_complex<T> *fw_scratch) const
 /*
     1D/2D/3D Type-2 NUFFT
 
@@ -176,14 +177,15 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
   // Uninitialized: deconvolve overwrites fw below. Size 0 when interpolating only, which
   // reads f directly.
   const bool interp_only = opts.gpu_spreadinterponly;
-  gpu_scratch<cuda_complex<T>> fwp(interp_only ? 0 : nf * batchsize, alloc);
+  gpu_scratch<cuda_complex<T>> fwp(interp_only || fw_scratch ? 0 : nf * batchsize, alloc);
+  auto *const fwbuf = fw_scratch ? fw_scratch : fwp.data();
   // cufft_ex transforms all `batchsize` grids even when blksize < batchsize; the extra
   // ones hold stale data and are discarded.
   for (int i = 0; i * batchsize < ntransf_for_this_run; i++) {
     int blksize = std::min(ntransf_for_this_run - i * batchsize, batchsize);
     auto *c = d_c + i * batchsize * M;
     auto *fk = d_fk + i * batchsize * nmodes;
-    auto *fw = interp_only ? fk : fwp.data();
+    auto *fw = interp_only ? fk : fwbuf;
 
     if (!interp_only) {
       // Step 1: amplify Fourier coeffs fk and copy into upsampled array fw
@@ -217,7 +219,10 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
 
   Marco Barbone 08/14/2024
   */
-  gpu_array<cuda_complex<T>> CpBatch(M * batchsize, alloc);
+  // Doubles as the inner type 2's fw: CpBatch is dead once the spread has read it,
+  // and deconvolve_nd overwrites the whole batchsize*nf before reading it.
+  gpu_scratch<cuda_complex<T>> CpBatch(std::size_t(std::max(M, t2_plan->nf)) * batchsize,
+                                       alloc);
   gpu_array<cuda_complex<T>> fwp(nf * batchsize, alloc);
   auto *fw = dethrust(fwp);
   for (int i = 0; i * batchsize < ntransf; i++) {
@@ -225,7 +230,7 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
     cuda_complex<T> *d_cstart  = d_c + i * batchsize * M;
     cuda_complex<T> *d_fkstart = d_fk + i * batchsize * N;
     // setting input for spreader
-    auto *c = dethrust(CpBatch);
+    auto *c = CpBatch.data();
     // setting output for spreader
     auto *fk = fw;
     // NOTE: fw might need to be set to 0
@@ -244,7 +249,7 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
     // type 2 goes from fk to c
     // saving the results directly in the user output array d_fk
     // it needs to do blksize transforms
-    t2_plan->execute_type2(d_fkstart, fw, blksize);
+    t2_plan->execute_type2(d_fkstart, fw, blksize, c);
     // Step 3: deconvolve
     // now we need to d_fk = d_fk*deconv
     for (int j = 0; j < blksize; j++) {

--- a/src/cuda/execute.cu
+++ b/src/cuda/execute.cu
@@ -2,6 +2,7 @@
 // plus the deconvolve kernel that only the execute path uses.
 // Mirrors CPU src/execute.cpp.
 
+#include <cstdint>
 #include <iostream>
 
 #include <cufinufft/contrib/helper_cuda.h>
@@ -72,7 +73,8 @@ void cufinufft_plan_t<T>::deconvolve_nd<modeord, ndim>(
     Melody Shih 11/21/21
 */
 {
-  int nmodes = 1, nftot = 1;
+  // 64-bit: MAX_NF is 1e12, so these products overflow int on large 3D grids.
+  std::int64_t nmodes = 1, nftot = 1;
   for (int idim = 0; idim < ndim; ++idim) {
     nmodes *= mstu[idim];
     nftot *= nf123[idim];
@@ -83,8 +85,8 @@ void cufinufft_plan_t<T>::deconvolve_nd<modeord, ndim>(
     checkCudaErrors(
         cudaMemsetAsync(fw, 0, batchsize * nftot * sizeof(cuda_complex<T>), stream));
 
-  for (int t = 0; t < blksize; t++)
-    deconv_nd<T, modeord, ndim><<<(nmodes + 256 - 1) / 256, 256, 0, stream>>>(
+  for (std::int64_t t = 0; t < blksize; t++)
+    deconv_nd<T, modeord, ndim><<<uint((nmodes + 256 - 1) / 256), 256, 0, stream>>>(
         mstu, nf123, fw + t * nftot, fk + t * nmodes, dethrust(fwkerhalf), fw2fk);
 }
 
@@ -119,14 +121,15 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
 {
   assert(spopts.spread_direction == 1);
 
-  int nmodes = 1;
+  std::int64_t nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
   // We don't need this buffer if we are just spreading; so we set
   // its size to 0 in that case.
-  gpu_array<cuda_complex<T>> fwp(opts.gpu_spreadinterponly ? 0 : nf * batchsize, alloc);
+  gpu_array<cuda_complex<T>> fwp(
+      opts.gpu_spreadinterponly ? 0 : std::size_t(nf) * batchsize, alloc);
   auto *fw = dethrust(fwp);
-  for (int i = 0; i * batchsize < ntransf; i++) {
-    int blksize   = std::min(ntransf - i * batchsize, batchsize);
+  for (std::int64_t i = 0; i * batchsize < ntransf; i++) {
+    int blksize = int(std::min<std::int64_t>(ntransf - i * batchsize, batchsize));
     const auto *c = d_c + i * batchsize * M;
     auto *fk      = d_fk + i * batchsize * nmodes; // so deconvolve will write into
                                                    // user output f
@@ -134,8 +137,8 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
       fw = fk;                                     // spread directly into the appropriate
                                                    // section of the user output f
 
-    checkCudaErrors(
-        cudaMemsetAsync(fw, 0, blksize * nf * sizeof(cuda_complex<T>), stream));
+    checkCudaErrors(cudaMemsetAsync(
+        fw, 0, std::size_t(blksize) * nf * sizeof(cuda_complex<T>), stream));
 
     // Step 1: Spread
     spreadSorted(c, fw, blksize);
@@ -174,16 +177,20 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
   int ntransf_for_this_run = ntransf;
   if (ntransf_override) ntransf_for_this_run = *ntransf_override;
 
-  int nmodes = 1;
+  std::int64_t nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
   // We don't need this buffer if we are just interpolating; so we set
   // its size to 0 in that case.
-  gpu_array<cuda_complex<T>> fwp(opts.gpu_spreadinterponly ? 0 : nf * batchsize, alloc);
+  gpu_array<cuda_complex<T>> fwp(
+      opts.gpu_spreadinterponly ? 0 : std::size_t(nf) * batchsize, alloc);
   auto *fw = dethrust(fwp);
-  for (int i = 0; i * batchsize < ntransf_for_this_run; i++) {
-    int blksize = std::min(ntransf_for_this_run - i * batchsize, batchsize);
-    auto *c     = d_c + i * batchsize * M;
-    auto *fk    = d_fk + i * batchsize * nmodes;
+  // cufft_ex transforms all `batchsize` grids even when blksize < batchsize; the extra
+  // ones hold stale data and are discarded.
+  for (std::int64_t i = 0; i * batchsize < ntransf_for_this_run; i++) {
+    int blksize =
+        int(std::min<std::int64_t>(ntransf_for_this_run - i * batchsize, batchsize));
+    auto *c = d_c + i * batchsize * M;
+    auto *fk = d_fk + i * batchsize * nmodes;
 
     // Skip steps 1 and 2 if interponly
     if (!opts.gpu_spreadinterponly) {
@@ -219,11 +226,11 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
 
   Marco Barbone 08/14/2024
   */
-  gpu_array<cuda_complex<T>> CpBatch(M * batchsize, alloc);
-  gpu_array<cuda_complex<T>> fwp(nf * batchsize, alloc);
+  gpu_array<cuda_complex<T>> CpBatch(std::size_t(M) * batchsize, alloc);
+  gpu_array<cuda_complex<T>> fwp(std::size_t(nf) * batchsize, alloc);
   auto *fw = dethrust(fwp);
-  for (int i = 0; i * batchsize < ntransf; i++) {
-    int blksize                = std::min(ntransf - i * batchsize, batchsize);
+  for (std::int64_t i = 0; i * batchsize < ntransf; i++) {
+    int blksize = int(std::min<std::int64_t>(ntransf - i * batchsize, batchsize));
     cuda_complex<T> *d_cstart  = d_c + i * batchsize * M;
     cuda_complex<T> *d_fkstart = d_fk + i * batchsize * N;
     // setting input for spreader
@@ -231,8 +238,8 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
     // setting output for spreader
     auto *fk = fw;
     // NOTE: fw might need to be set to 0
-    checkCudaErrors(
-        cudaMemsetAsync(fw, 0, blksize * nf * sizeof(cuda_complex<T>), stream));
+    checkCudaErrors(cudaMemsetAsync(
+        fw, 0, std::size_t(blksize) * nf * sizeof(cuda_complex<T>), stream));
     // Step 0: pre-phase the input strengths
     for (int block = 0; block < blksize; block++) {
       thrust::transform(thrust::cuda::par.on(stream), dethrust(prephase),

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -363,24 +363,29 @@ void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int ty
 }
 
 template<typename T>
-int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts,
-                     int ntransf) {
+int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf,
+                     CUFINUFFT_BIGINT nf) {
   // Cap at ntransf: a larger batch would make cuFFT transform grids that are then
   // discarded.
   if (opts.gpu_maxbatchsize) return std::min(opts.gpu_maxbatchsize, ntransf);
 
-  // Auto: a few transforms per FFT.
-  return std::min(ntransf, 8);
+  // Before nf is known, a few transforms per FFT.
+  if (nf == 0) return std::min(ntransf, 8);
+
+  // Keep nf*batchsize inside the L2 budget, up to 32 to fill the SMs at small nf. Past
+  // the budget a batch only adds FFT work the grid cannot hold.
+  const std::int64_t l2_elems = gpu.l2_complex_budget<T>();
+  return int(std::clamp<std::int64_t>(l2_elems / nf, 1, std::min(ntransf, 32)));
 }
 
 template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, int ns,
                                              int dim, cufinufft_opts *opts);
 template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
                                               int dim, cufinufft_opts *opts);
-template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &,
-                                     int);
+template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &, int,
+                                     CUFINUFFT_BIGINT);
 template int choose_batchsize<double>(const GpuCapabilities &, const cufinufft_opts &,
-                                      int);
+                                      int, CUFINUFFT_BIGINT);
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -132,7 +132,8 @@ namespace {
 // Returns (bin,np) for Method 3 based on GpuCapabilities::method3_category(),
 // dimension, and ns. Derived from sweeps over 8 GPUs (A100-40/80GB, H100-80/94GB,
 // H200, RTX 6000 Ada, RTX 4070 Mobile, RTX Blackwell), which is also where the
-// category boundaries come from:
+// category boundaries come from; sweeps and timings in
+// https://github.com/flatironinstitute/finufft/pull/807 :
 //
 //   AMPERE_LARGE: A100 (CC 8.0, 164 KB/block)
 //   HOPPER:       H100/H200 (CC 9.0, 228 KB/block)
@@ -362,24 +363,38 @@ void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int ty
 }
 
 template<typename T>
-int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts,
-                     int ntransf) {
+int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf,
+                     CUFINUFFT_BIGINT nf) {
   // Cap at ntransf: a larger batch would make cuFFT transform grids that are then
   // discarded.
   if (opts.gpu_maxbatchsize) return std::min(opts.gpu_maxbatchsize, ntransf);
 
-  // Auto: a few transforms per FFT.
-  return std::min(ntransf, 8);
+  // Before nf is known, a few transforms per FFT.
+  if (nf == 0) return std::min(ntransf, 8);
+
+  // Keep nf*batchsize inside the L2 budget, up to 32 to fill the SMs at small nf. Past
+  // the budget a batch only adds FFT work the grid cannot hold. Multi-GPU timings:
+  // https://github.com/flatironinstitute/finufft/pull/873
+  const std::int64_t l2_elems = gpu.l2_complex_budget<T>();
+  const int cap = int(std::clamp<std::int64_t>(l2_elems / nf, 1, std::min(ntransf, 32)));
+
+  // Spread out the batches evenly: the cuFFT plan is fixed at batchsize, and cufft_ex has
+  // no per-call count, so the last batch always transforms batchsize grids even when only
+  // blksize of them hold data. ntransf=9 with cap 8 would do 2x8 grid FFTs for 9
+  // transforms; balancing gives 2x5 instead. Never above cap, so the L2 bound still
+  // holds.
+  const int nbatch = 1 + (ntransf - 1) / cap;
+  return 1 + (ntransf - 1) / nbatch;
 }
 
 template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, int ns,
                                              int dim, cufinufft_opts *opts);
 template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
                                               int dim, cufinufft_opts *opts);
-template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &,
-                                     int);
+template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &, int,
+                                     CUFINUFFT_BIGINT);
 template int choose_batchsize<double>(const GpuCapabilities &, const cufinufft_opts &,
-                                      int);
+                                      int, CUFINUFFT_BIGINT);
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -364,13 +364,15 @@ void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int ty
 
 template<typename T>
 int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf,
-                     CUFINUFFT_BIGINT nf) {
+                     std::int64_t nf) {
   // Cap at ntransf: a larger batch would make cuFFT transform grids that are then
   // discarded.
   if (opts.gpu_maxbatchsize) return std::min(opts.gpu_maxbatchsize, ntransf);
 
-  // Before nf is known, a few transforms per FFT.
-  if (nf == 0) return std::min(ntransf, 8);
+  // No FFT to amortize a batch against, so it would only widen the working set. For a
+  // type 3's outer plan it would also evict the L2 that the inner type-2's FFT needs.
+  // Timings: https://github.com/flatironinstitute/finufft/pull/873
+  if (opts.gpu_spreadinterponly) return 1;
 
   // Keep nf*batchsize inside the L2 budget, up to 32 to fill the SMs at small nf. Past
   // the budget a batch only adds FFT work the grid cannot hold. Multi-GPU timings:
@@ -392,9 +394,9 @@ template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, 
 template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
                                               int dim, cufinufft_opts *opts);
 template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &, int,
-                                     CUFINUFFT_BIGINT);
+                                     std::int64_t);
 template int choose_batchsize<double>(const GpuCapabilities &, const cufinufft_opts &,
-                                      int, CUFINUFFT_BIGINT);
+                                      int, std::int64_t);
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -17,6 +17,76 @@
 #include <cufinufft/spreadinterp.hpp>
 #include <cufinufft/utils.hpp>
 
+// GpuCapabilities members declared in types.hpp. Defined here so the Method-3
+// taxonomy and the debug printing stay with the heuristics they serve.
+Method3Category GpuCapabilities::method3_category() const {
+  // CC 8.0 = Ampere large (A100, A30)
+  if (cc_major == 8 && cc_minor == 0) return Method3Category::AMPERE_LARGE;
+
+  // CC 9.0 = Hopper (H100, H200)
+  if (cc_major == 9 && cc_minor == 0) return Method3Category::HOPPER;
+
+  // CC 8.9 = Ada Lovelace; SM count distinguishes desktop (RTX 6000 Ada, 142 SMs)
+  // from mobile (RTX 4070, 36-46 SMs).
+  if (cc_major == 8 && cc_minor == 9)
+    return (multiprocessor_count >= 80) ? Method3Category::ADA_DESKTOP
+                                        : Method3Category::ADA_MOBILE;
+
+  // CC 12.0 = Blackwell workstation (RTX 6000/5000 Blackwell): same table as Ada
+  // desktop (both are ~100KB/block parts).
+  if (cc_major == 12 && cc_minor == 0) return Method3Category::ADA_DESKTOP;
+
+  // CC 10.0 = Blackwell datacenter (B200) - treat as Hopper-like
+  if (cc_major == 10 && cc_minor == 0) return Method3Category::HOPPER;
+
+  return Method3Category::UNKNOWN;
+}
+
+const char *GpuCapabilities::method3_category_name() const {
+  switch (method3_category()) {
+  case Method3Category::AMPERE_LARGE:
+    return "Ampere-Large";
+  case Method3Category::HOPPER:
+    return "Hopper";
+  case Method3Category::ADA_DESKTOP:
+    return "Small-SMEM-Desktop";
+  case Method3Category::ADA_MOBILE:
+    return "Small-SMEM-Mobile";
+  case Method3Category::UNKNOWN:
+    return "Unknown";
+  }
+  return "Unknown";
+}
+
+void GpuCapabilities::print_classification(int debug_level) const {
+  if (debug_level < 2) return;
+
+  // Only for the name; every other field comes from cudaDeviceGetAttribute.
+  cudaDeviceProp prop{};
+  cudaGetDeviceProperties(&prop, device_id);
+  printf("[cufinufft] GPU Classification:\n");
+  printf("  Name: %s\n", prop.name);
+  printf("  Compute Capability: %d.%d\n", cc_major, cc_minor);
+  printf("  Multiprocessor Count: %d SMs\n", multiprocessor_count);
+  printf("  Shared Memory:\n");
+  printf("    Per-block (opt-in): %.1f KB\n", max_smem_per_block_optin / 1024.0);
+  printf("    Per-SM: %.1f KB\n", max_smem_per_sm / 1024.0);
+  printf("  Occupancy:\n");
+  printf("    Max warps/SM: %d\n", max_warps_per_sm());
+  printf("    Max threads/SM: %d\n", max_threads_per_sm);
+  printf("  L2: %.1f MB, memory bus: %d bits\n", l2_cache_size / 1048576.0,
+         global_mem_bus_width);
+
+  if (debug_level >= 3) {
+    printf("  Binsize Categories:\n");
+    printf("    Method 2/3: Hopper-like (>=200 KB/block, >=64 warps): %s\n",
+           is_hopper_like() ? "YES" : "NO");
+    printf("    Method 2/3: Small SMEM (<=110 KB/block): %s\n",
+           is_small_smem() ? "YES" : "NO");
+    printf("    Method 3: Category: %s\n", method3_category_name());
+  }
+}
+
 namespace cufinufft {
 namespace common {
 using std::max;
@@ -58,167 +128,20 @@ template<typename T> int find_bin_size(std::size_t mem_size, int dim, int ns) {
 
 namespace {
 // ============================================================================
-// GPU Classification for Binsize Selection
-// ============================================================================
-//
-// Categorizes GPUs based on runtime-queryable device attributes
-// to select optimal bin sizes for Methods 2 & 3.
-//
-// Background: Benchmark sweeps across 8 GPUs (A100-40GB, A100-80GB, H100-80GB,
-// H100-94GB, H200, RTX 6000 Ada, RTX 4070 Mobile, RTX Blackwell) revealed:
-//
-// METHOD 2: Requires 2-4 GPU groups depending on dimension
-// METHOD 3: Requires 4-5 GPU groups (highly architecture-sensitive)
-//
-//   Group 1 (Ampere Large):    A100 (CC 8.0, 164 KB/block)
-//   Group 2 (Hopper):          H100/H200 (CC 9.0, 228 KB/block)
-//   Group 3 (Small-SMEM Desk): Ada/Blackwell workstation-class parts
-//                              (~100 KB/block, high SM count)
-//   Group 4 (Small-SMEM Mob):  Mobile parts with low SM count (need very large np)
-//
-// Key insight: Method 3 couples shared memory footprint with work granularity
-// in ways that make different GPU architectures prefer vastly different configs.
-// ============================================================================
-
-// Method 3 GPU categories for granular heuristic selection
-enum class Method3Category {
-  AMPERE_LARGE, // A100: CC 8.0, prefers low shmem, small np
-  HOPPER,       // H100/H200: CC 9.0, can use larger np
-  ADA_DESKTOP,  // Small-SMEM desktop/workstation: Ada/Blackwell, high SM count
-  ADA_MOBILE,   // Small-SMEM mobile: low SM count
-  UNKNOWN       // Fallback
-};
-
-struct GpuCharacteristics {
-  int cc_major, cc_minor;
-  int max_smem_per_block_optin; // bytes
-  int max_smem_per_sm;          // bytes
-  int max_threads_per_sm;
-  int max_warps_per_sm;         // derived: max_threads_per_sm / 32
-  int multiprocessor_count;     // SM count
-  std::string gpu_name;
-
-  static GpuCharacteristics query(int device_id) {
-    GpuCharacteristics gpu{};
-
-    // Query compute capability
-    cudaDeviceGetAttribute(&gpu.cc_major, cudaDevAttrComputeCapabilityMajor, device_id);
-    cudaDeviceGetAttribute(&gpu.cc_minor, cudaDevAttrComputeCapabilityMinor, device_id);
-
-    // Query shared memory limits (primary classification signals)
-    cudaDeviceGetAttribute(&gpu.max_smem_per_block_optin,
-                           cudaDevAttrMaxSharedMemoryPerBlockOptin, device_id);
-    cudaDeviceGetAttribute(&gpu.max_smem_per_sm,
-                           cudaDevAttrMaxSharedMemoryPerMultiprocessor, device_id);
-
-    // Query occupancy limiters
-    cudaDeviceGetAttribute(&gpu.max_threads_per_sm,
-                           cudaDevAttrMaxThreadsPerMultiProcessor, device_id);
-    gpu.max_warps_per_sm = gpu.max_threads_per_sm / 32;
-
-    // Query SM count (for Ada desktop vs mobile classification)
-    cudaDeviceGetAttribute(&gpu.multiprocessor_count, cudaDevAttrMultiProcessorCount,
-                           device_id);
-
-    // Get GPU name
-    cudaDeviceProp prop{};
-    cudaGetDeviceProperties(&prop, device_id);
-    gpu.gpu_name = std::string(prop.name);
-
-    return gpu;
-  }
-
-  // Check if this GPU is "Hopper-like" for Method 2/3 binsize selection.
-  // "Hopper-like" = large shared memory (≥200 KB/block) AND high occupancy (≥64 warps/SM)
-  // Matches: H100 (9.0), H200 (9.0), Blackwell datacenter (10.0)
-  bool is_hopper_like() const {
-    return (max_smem_per_block_optin >= 200 * 1024) && (max_warps_per_sm >= 64);
-  }
-
-  // Check if this GPU has "small SMEM" constraints (≤110 KB/block).
-  // Matches: Ada (8.9), Ampere 8.6, Blackwell workstation (12.0)
-  bool is_small_smem() const { return (max_smem_per_block_optin <= 110 * 1024); }
-
-  // Classify GPU for Method 3 heuristics (5-category system)
-  Method3Category get_method3_category() const {
-    // CC 8.0 = Ampere large (A100, A30)
-    if (cc_major == 8 && cc_minor == 0) {
-      return Method3Category::AMPERE_LARGE;
-    }
-
-    // CC 9.0 = Hopper (H100, H200)
-    if (cc_major == 9 && cc_minor == 0) {
-      return Method3Category::HOPPER;
-    }
-
-    // CC 8.9 = Ada Lovelace (need SM count to distinguish desktop vs mobile)
-    // Desktop (RTX 6000 Ada): 142 SMs
-    // Mobile (RTX 4070): typically 36-46 SMs
-    // Threshold: 80 SMs
-    if (cc_major == 8 && cc_minor == 9) {
-      return (multiprocessor_count >= 80) ? Method3Category::ADA_DESKTOP
-                                          : Method3Category::ADA_MOBILE;
-    }
-
-    // CC 12.0 = Blackwell workstation (RTX 6000/5000 Blackwell)
-    // Reuse the same binsize table as Ada desktop (both are ~100KB/block parts).
-    if (cc_major == 12 && cc_minor == 0) return Method3Category::ADA_DESKTOP;
-
-    // CC 10.0 = Blackwell datacenter (B200) - treat as Hopper-like
-    if (cc_major == 10 && cc_minor == 0) {
-      return Method3Category::HOPPER;
-    }
-
-    // Unknown / future architectures: fallback to simple classification
-    return Method3Category::UNKNOWN;
-  }
-
-  const char *method3_category_name() const {
-    switch (get_method3_category()) {
-    case Method3Category::AMPERE_LARGE:
-      return "Ampere-Large";
-    case Method3Category::HOPPER:
-      return "Hopper";
-    case Method3Category::ADA_DESKTOP:
-      return "Small-SMEM-Desktop";
-    case Method3Category::ADA_MOBILE:
-      return "Small-SMEM-Mobile";
-    case Method3Category::UNKNOWN:
-      return "Unknown";
-    }
-    return "Unknown";
-  }
-
-  void print_classification(int debug_level) const {
-    if (debug_level < 2) return;
-
-    printf("[cufinufft] GPU Classification:\n");
-    printf("  Name: %s\n", gpu_name.c_str());
-    printf("  Compute Capability: %d.%d\n", cc_major, cc_minor);
-    printf("  Multiprocessor Count: %d SMs\n", multiprocessor_count);
-    printf("  Shared Memory:\n");
-    printf("    Per-block (opt-in): %.1f KB\n", max_smem_per_block_optin / 1024.0);
-    printf("    Per-SM: %.1f KB\n", max_smem_per_sm / 1024.0);
-    printf("  Occupancy:\n");
-    printf("    Max warps/SM: %d\n", max_warps_per_sm);
-    printf("    Max threads/SM: %d\n", max_threads_per_sm);
-
-    if (debug_level >= 3) {
-      printf("  Binsize Categories:\n");
-      printf("    Method 2/3: Hopper-like (≥200 KB/block, ≥64 warps): %s\n",
-             is_hopper_like() ? "YES" : "NO");
-      printf("    Method 2/3: Small SMEM (≤110 KB/block): %s\n",
-             is_small_smem() ? "YES" : "NO");
-      printf("    Method 3: Category: %s\n", method3_category_name());
-    }
-  }
-};
-
-// ============================================================================
 // Method 3 Heuristic (Benchmark-Validated Tables)
 // ============================================================================
-// Returns (bin,np) for Method 3 based on GPU category, dimension, and ns.
-// Tables derived from multi-GPU sweeps; achieves ~90% of optimal throughput.
+// Returns (bin,np) for Method 3 based on GpuCapabilities::method3_category(),
+// dimension, and ns. Derived from sweeps over 8 GPUs (A100-40/80GB, H100-80/94GB,
+// H200, RTX 6000 Ada, RTX 4070 Mobile, RTX Blackwell), which is also where the
+// category boundaries come from:
+//
+//   AMPERE_LARGE: A100 (CC 8.0, 164 KB/block)
+//   HOPPER:       H100/H200 (CC 9.0, 228 KB/block)
+//   ADA_DESKTOP:  Ada/Blackwell workstation parts (~100 KB/block, high SM count)
+//   ADA_MOBILE:   mobile parts, low SM count (need very large np)
+//
+// Achieves ~90% of optimal throughput. Method 2 needs only the coarser 2-4 groups
+// that is_hopper_like()/is_small_smem() give.
 // ============================================================================
 struct Method3Config {
   int bin;
@@ -323,14 +246,9 @@ Method3Config get_method3_config(Method3Category category, int dim, int ns,
 } // anonymous namespace
 
 template<typename T>
-void cufinufft_setup_binsize([[maybe_unused]] int type, int ns, int dim,
-                             cufinufft_opts *opts) {
-  const int device_id = opts->gpu_device_id;
-  int shmem_limit{};
-  cudaDeviceGetAttribute(&shmem_limit, cudaDevAttrMaxSharedMemoryPerBlockOptin,
-                         device_id);
-
-  const auto gpu         = GpuCharacteristics::query(device_id);
+void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int type,
+                             int ns, int dim, cufinufft_opts *opts) {
+  const int shmem_limit = gpu.max_smem_per_block_optin;
   const int shmem_per_pt = static_cast<int>(shared_memory_per_point<T>(dim, ns));
 
   gpu.print_classification(opts->debug);
@@ -414,7 +332,7 @@ void cufinufft_setup_binsize([[maybe_unused]] int type, int ns, int dim,
       validate_fit(opts->gpu_np);
       debug_print(3, opts->gpu_np, user_np ? "(user)" : "(user bin)");
     } else {
-      auto cfg = get_method3_config<T>(gpu.get_method3_category(), dim, ns, shmem_limit,
+      auto cfg = get_method3_config<T>(gpu.method3_category(), dim, ns, shmem_limit,
                                        shmem_per_pt);
       set_bins(cfg.bin);
       opts->gpu_np = cfg.np;
@@ -444,10 +362,11 @@ void cufinufft_setup_binsize([[maybe_unused]] int type, int ns, int dim,
         ", ns=" + std::to_string(ns) + ")");
 }
 
-template void cufinufft_setup_binsize<float>(int type, int ns, int dim,
-                                             cufinufft_opts *opts);
-template void cufinufft_setup_binsize<double>(int type, int ns, int dim,
-                                              cufinufft_opts *opts);
+template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, int ns,
+                                             int dim, cufinufft_opts *opts);
+template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
+                                              int dim, cufinufft_opts *opts);
+
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -17,6 +17,75 @@
 #include <cufinufft/spreadinterp.hpp>
 #include <cufinufft/utils.hpp>
 
+// GpuCapabilities members declared in types.hpp. Defined here so the Method-3
+// taxonomy and the debug printing stay with the heuristics they serve.
+Method3Category GpuCapabilities::method3_category() const {
+  // CC 8.0 = Ampere large (A100, A30)
+  if (cc_major == 8 && cc_minor == 0) return Method3Category::AMPERE_LARGE;
+
+  // CC 9.0 = Hopper (H100, H200)
+  if (cc_major == 9 && cc_minor == 0) return Method3Category::HOPPER;
+
+  // CC 8.9 = Ada Lovelace; SM count distinguishes desktop (RTX 6000 Ada, 142 SMs)
+  // from mobile (RTX 4070, 36-46 SMs).
+  if (cc_major == 8 && cc_minor == 9)
+    return (multiprocessor_count >= 80) ? Method3Category::ADA_DESKTOP
+                                        : Method3Category::ADA_MOBILE;
+
+  // CC 12.0 = Blackwell workstation (RTX 6000/5000 Blackwell): same table as Ada
+  // desktop (both are ~100KB/block parts).
+  if (cc_major == 12 && cc_minor == 0) return Method3Category::ADA_DESKTOP;
+
+  // CC 10.0 = Blackwell datacenter (B200) - treat as Hopper-like
+  if (cc_major == 10 && cc_minor == 0) return Method3Category::HOPPER;
+
+  return Method3Category::UNKNOWN;
+}
+
+const char *GpuCapabilities::method3_category_name() const {
+  switch (method3_category()) {
+  case Method3Category::AMPERE_LARGE:
+    return "Ampere-Large";
+  case Method3Category::HOPPER:
+    return "Hopper";
+  case Method3Category::ADA_DESKTOP:
+    return "Small-SMEM-Desktop";
+  case Method3Category::ADA_MOBILE:
+    return "Small-SMEM-Mobile";
+  case Method3Category::UNKNOWN:
+    return "Unknown";
+  }
+  return "Unknown";
+}
+
+void GpuCapabilities::print_classification(int debug_level) const {
+  if (debug_level < 2) return;
+
+  // Only for the name; every other field comes from cudaDeviceGetAttribute.
+  cudaDeviceProp prop{};
+  cudaGetDeviceProperties(&prop, device_id);
+  printf("[cufinufft] GPU Classification:\n");
+  printf("  Name: %s\n", prop.name);
+  printf("  Compute Capability: %d.%d\n", cc_major, cc_minor);
+  printf("  Multiprocessor Count: %d SMs\n", multiprocessor_count);
+  printf("  Shared Memory:\n");
+  printf("    Per-block (opt-in): %.1f KB\n", max_smem_per_block_optin / 1024.0);
+  printf("    Per-SM: %.1f KB\n", max_smem_per_sm / 1024.0);
+  printf("  Occupancy:\n");
+  printf("    Max warps/SM: %d\n", max_warps_per_sm());
+  printf("    Max threads/SM: %d\n", max_threads_per_sm);
+  printf("  L2: %.1f MB\n", l2_cache_size / 1048576.0);
+
+  if (debug_level >= 3) {
+    printf("  Binsize Categories:\n");
+    printf("    Method 2/3: Hopper-like (>=200 KB/block, >=64 warps): %s\n",
+           is_hopper_like() ? "YES" : "NO");
+    printf("    Method 2/3: Small SMEM (<=110 KB/block): %s\n",
+           is_small_smem() ? "YES" : "NO");
+    printf("    Method 3: Category: %s\n", method3_category_name());
+  }
+}
+
 namespace cufinufft {
 namespace common {
 using std::max;
@@ -58,167 +127,20 @@ template<typename T> int find_bin_size(std::size_t mem_size, int dim, int ns) {
 
 namespace {
 // ============================================================================
-// GPU Classification for Binsize Selection
-// ============================================================================
-//
-// Categorizes GPUs based on runtime-queryable device attributes
-// to select optimal bin sizes for Methods 2 & 3.
-//
-// Background: Benchmark sweeps across 8 GPUs (A100-40GB, A100-80GB, H100-80GB,
-// H100-94GB, H200, RTX 6000 Ada, RTX 4070 Mobile, RTX Blackwell) revealed:
-//
-// METHOD 2: Requires 2-4 GPU groups depending on dimension
-// METHOD 3: Requires 4-5 GPU groups (highly architecture-sensitive)
-//
-//   Group 1 (Ampere Large):    A100 (CC 8.0, 164 KB/block)
-//   Group 2 (Hopper):          H100/H200 (CC 9.0, 228 KB/block)
-//   Group 3 (Small-SMEM Desk): Ada/Blackwell workstation-class parts
-//                              (~100 KB/block, high SM count)
-//   Group 4 (Small-SMEM Mob):  Mobile parts with low SM count (need very large np)
-//
-// Key insight: Method 3 couples shared memory footprint with work granularity
-// in ways that make different GPU architectures prefer vastly different configs.
-// ============================================================================
-
-// Method 3 GPU categories for granular heuristic selection
-enum class Method3Category {
-  AMPERE_LARGE, // A100: CC 8.0, prefers low shmem, small np
-  HOPPER,       // H100/H200: CC 9.0, can use larger np
-  ADA_DESKTOP,  // Small-SMEM desktop/workstation: Ada/Blackwell, high SM count
-  ADA_MOBILE,   // Small-SMEM mobile: low SM count
-  UNKNOWN       // Fallback
-};
-
-struct GpuCharacteristics {
-  int cc_major, cc_minor;
-  int max_smem_per_block_optin; // bytes
-  int max_smem_per_sm;          // bytes
-  int max_threads_per_sm;
-  int max_warps_per_sm;         // derived: max_threads_per_sm / 32
-  int multiprocessor_count;     // SM count
-  std::string gpu_name;
-
-  static GpuCharacteristics query(int device_id) {
-    GpuCharacteristics gpu{};
-
-    // Query compute capability
-    cudaDeviceGetAttribute(&gpu.cc_major, cudaDevAttrComputeCapabilityMajor, device_id);
-    cudaDeviceGetAttribute(&gpu.cc_minor, cudaDevAttrComputeCapabilityMinor, device_id);
-
-    // Query shared memory limits (primary classification signals)
-    cudaDeviceGetAttribute(&gpu.max_smem_per_block_optin,
-                           cudaDevAttrMaxSharedMemoryPerBlockOptin, device_id);
-    cudaDeviceGetAttribute(&gpu.max_smem_per_sm,
-                           cudaDevAttrMaxSharedMemoryPerMultiprocessor, device_id);
-
-    // Query occupancy limiters
-    cudaDeviceGetAttribute(&gpu.max_threads_per_sm,
-                           cudaDevAttrMaxThreadsPerMultiProcessor, device_id);
-    gpu.max_warps_per_sm = gpu.max_threads_per_sm / 32;
-
-    // Query SM count (for Ada desktop vs mobile classification)
-    cudaDeviceGetAttribute(&gpu.multiprocessor_count, cudaDevAttrMultiProcessorCount,
-                           device_id);
-
-    // Get GPU name
-    cudaDeviceProp prop{};
-    cudaGetDeviceProperties(&prop, device_id);
-    gpu.gpu_name = std::string(prop.name);
-
-    return gpu;
-  }
-
-  // Check if this GPU is "Hopper-like" for Method 2/3 binsize selection.
-  // "Hopper-like" = large shared memory (≥200 KB/block) AND high occupancy (≥64 warps/SM)
-  // Matches: H100 (9.0), H200 (9.0), Blackwell datacenter (10.0)
-  bool is_hopper_like() const {
-    return (max_smem_per_block_optin >= 200 * 1024) && (max_warps_per_sm >= 64);
-  }
-
-  // Check if this GPU has "small SMEM" constraints (≤110 KB/block).
-  // Matches: Ada (8.9), Ampere 8.6, Blackwell workstation (12.0)
-  bool is_small_smem() const { return (max_smem_per_block_optin <= 110 * 1024); }
-
-  // Classify GPU for Method 3 heuristics (5-category system)
-  Method3Category get_method3_category() const {
-    // CC 8.0 = Ampere large (A100, A30)
-    if (cc_major == 8 && cc_minor == 0) {
-      return Method3Category::AMPERE_LARGE;
-    }
-
-    // CC 9.0 = Hopper (H100, H200)
-    if (cc_major == 9 && cc_minor == 0) {
-      return Method3Category::HOPPER;
-    }
-
-    // CC 8.9 = Ada Lovelace (need SM count to distinguish desktop vs mobile)
-    // Desktop (RTX 6000 Ada): 142 SMs
-    // Mobile (RTX 4070): typically 36-46 SMs
-    // Threshold: 80 SMs
-    if (cc_major == 8 && cc_minor == 9) {
-      return (multiprocessor_count >= 80) ? Method3Category::ADA_DESKTOP
-                                          : Method3Category::ADA_MOBILE;
-    }
-
-    // CC 12.0 = Blackwell workstation (RTX 6000/5000 Blackwell)
-    // Reuse the same binsize table as Ada desktop (both are ~100KB/block parts).
-    if (cc_major == 12 && cc_minor == 0) return Method3Category::ADA_DESKTOP;
-
-    // CC 10.0 = Blackwell datacenter (B200) - treat as Hopper-like
-    if (cc_major == 10 && cc_minor == 0) {
-      return Method3Category::HOPPER;
-    }
-
-    // Unknown / future architectures: fallback to simple classification
-    return Method3Category::UNKNOWN;
-  }
-
-  const char *method3_category_name() const {
-    switch (get_method3_category()) {
-    case Method3Category::AMPERE_LARGE:
-      return "Ampere-Large";
-    case Method3Category::HOPPER:
-      return "Hopper";
-    case Method3Category::ADA_DESKTOP:
-      return "Small-SMEM-Desktop";
-    case Method3Category::ADA_MOBILE:
-      return "Small-SMEM-Mobile";
-    case Method3Category::UNKNOWN:
-      return "Unknown";
-    }
-    return "Unknown";
-  }
-
-  void print_classification(int debug_level) const {
-    if (debug_level < 2) return;
-
-    printf("[cufinufft] GPU Classification:\n");
-    printf("  Name: %s\n", gpu_name.c_str());
-    printf("  Compute Capability: %d.%d\n", cc_major, cc_minor);
-    printf("  Multiprocessor Count: %d SMs\n", multiprocessor_count);
-    printf("  Shared Memory:\n");
-    printf("    Per-block (opt-in): %.1f KB\n", max_smem_per_block_optin / 1024.0);
-    printf("    Per-SM: %.1f KB\n", max_smem_per_sm / 1024.0);
-    printf("  Occupancy:\n");
-    printf("    Max warps/SM: %d\n", max_warps_per_sm);
-    printf("    Max threads/SM: %d\n", max_threads_per_sm);
-
-    if (debug_level >= 3) {
-      printf("  Binsize Categories:\n");
-      printf("    Method 2/3: Hopper-like (≥200 KB/block, ≥64 warps): %s\n",
-             is_hopper_like() ? "YES" : "NO");
-      printf("    Method 2/3: Small SMEM (≤110 KB/block): %s\n",
-             is_small_smem() ? "YES" : "NO");
-      printf("    Method 3: Category: %s\n", method3_category_name());
-    }
-  }
-};
-
-// ============================================================================
 // Method 3 Heuristic (Benchmark-Validated Tables)
 // ============================================================================
-// Returns (bin,np) for Method 3 based on GPU category, dimension, and ns.
-// Tables derived from multi-GPU sweeps; achieves ~90% of optimal throughput.
+// Returns (bin,np) for Method 3 based on GpuCapabilities::method3_category(),
+// dimension, and ns. Derived from sweeps over 8 GPUs (A100-40/80GB, H100-80/94GB,
+// H200, RTX 6000 Ada, RTX 4070 Mobile, RTX Blackwell), which is also where the
+// category boundaries come from:
+//
+//   AMPERE_LARGE: A100 (CC 8.0, 164 KB/block)
+//   HOPPER:       H100/H200 (CC 9.0, 228 KB/block)
+//   ADA_DESKTOP:  Ada/Blackwell workstation parts (~100 KB/block, high SM count)
+//   ADA_MOBILE:   mobile parts, low SM count (need very large np)
+//
+// Achieves ~90% of optimal throughput. Method 2 needs only the coarser 2-4 groups
+// that is_hopper_like()/is_small_smem() give.
 // ============================================================================
 struct Method3Config {
   int bin;
@@ -323,14 +245,9 @@ Method3Config get_method3_config(Method3Category category, int dim, int ns,
 } // anonymous namespace
 
 template<typename T>
-void cufinufft_setup_binsize([[maybe_unused]] int type, int ns, int dim,
-                             cufinufft_opts *opts) {
-  const int device_id = opts->gpu_device_id;
-  int shmem_limit{};
-  cudaDeviceGetAttribute(&shmem_limit, cudaDevAttrMaxSharedMemoryPerBlockOptin,
-                         device_id);
-
-  const auto gpu         = GpuCharacteristics::query(device_id);
+void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int type,
+                             int ns, int dim, cufinufft_opts *opts) {
+  const int shmem_limit = gpu.max_smem_per_block_optin;
   const int shmem_per_pt = static_cast<int>(shared_memory_per_point<T>(dim, ns));
 
   gpu.print_classification(opts->debug);
@@ -414,7 +331,7 @@ void cufinufft_setup_binsize([[maybe_unused]] int type, int ns, int dim,
       validate_fit(opts->gpu_np);
       debug_print(3, opts->gpu_np, user_np ? "(user)" : "(user bin)");
     } else {
-      auto cfg = get_method3_config<T>(gpu.get_method3_category(), dim, ns, shmem_limit,
+      auto cfg = get_method3_config<T>(gpu.method3_category(), dim, ns, shmem_limit,
                                        shmem_per_pt);
       set_bins(cfg.bin);
       opts->gpu_np = cfg.np;
@@ -444,10 +361,11 @@ void cufinufft_setup_binsize([[maybe_unused]] int type, int ns, int dim,
         ", ns=" + std::to_string(ns) + ")");
 }
 
-template void cufinufft_setup_binsize<float>(int type, int ns, int dim,
-                                             cufinufft_opts *opts);
-template void cufinufft_setup_binsize<double>(int type, int ns, int dim,
-                                              cufinufft_opts *opts);
+template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, int ns,
+                                             int dim, cufinufft_opts *opts);
+template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
+                                              int dim, cufinufft_opts *opts);
+
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -361,11 +361,25 @@ void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int ty
         ", ns=" + std::to_string(ns) + ")");
 }
 
+template<typename T>
+int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts,
+                     int ntransf) {
+  // Cap at ntransf: a larger batch would make cuFFT transform grids that are then
+  // discarded.
+  if (opts.gpu_maxbatchsize) return std::min(opts.gpu_maxbatchsize, ntransf);
+
+  // Auto: a few transforms per FFT.
+  return std::min(ntransf, 8);
+}
+
 template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, int ns,
                                              int dim, cufinufft_opts *opts);
 template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
                                               int dim, cufinufft_opts *opts);
-
+template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &,
+                                     int);
+template int choose_batchsize<double>(const GpuCapabilities &, const cufinufft_opts &,
+                                      int);
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -364,13 +364,16 @@ void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int ty
 
 template<typename T>
 int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts, int ntransf,
-                     CUFINUFFT_BIGINT nf) {
+                     std::int64_t nf) {
   // Cap at ntransf: a larger batch would make cuFFT transform grids that are then
   // discarded.
   if (opts.gpu_maxbatchsize) return std::min(opts.gpu_maxbatchsize, ntransf);
 
-  // Before nf is known, a few transforms per FFT.
-  if (nf == 0) return std::min(ntransf, 8);
+  // No FFT to amortize a batch against, so it would only widen the working set. For a
+  // type 3's outer plan that footprint (M + nf per transform) evicts the L2 the inner
+  // type-2's FFT needs: 1 is within 1.05x of the per-shape optimum over 7 Ada shapes,
+  // where min(ntransf, 8) is 1.25x off.
+  if (opts.gpu_spreadinterponly) return 1;
 
   // Keep nf*batchsize inside the L2 budget, up to 32 to fill the SMs at small nf. Past
   // the budget a batch only adds FFT work the grid cannot hold.
@@ -383,9 +386,9 @@ template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, 
 template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
                                               int dim, cufinufft_opts *opts);
 template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &, int,
-                                     CUFINUFFT_BIGINT);
+                                     std::int64_t);
 template int choose_batchsize<double>(const GpuCapabilities &, const cufinufft_opts &,
-                                      int, CUFINUFFT_BIGINT);
+                                      int, std::int64_t);
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -362,11 +362,25 @@ void cufinufft_setup_binsize(const GpuCapabilities &gpu, [[maybe_unused]] int ty
         ", ns=" + std::to_string(ns) + ")");
 }
 
+template<typename T>
+int choose_batchsize(const GpuCapabilities &gpu, const cufinufft_opts &opts,
+                     int ntransf) {
+  // Cap at ntransf: a larger batch would make cuFFT transform grids that are then
+  // discarded.
+  if (opts.gpu_maxbatchsize) return std::min(opts.gpu_maxbatchsize, ntransf);
+
+  // Auto: a few transforms per FFT.
+  return std::min(ntransf, 8);
+}
+
 template void cufinufft_setup_binsize<float>(const GpuCapabilities &, int type, int ns,
                                              int dim, cufinufft_opts *opts);
 template void cufinufft_setup_binsize<double>(const GpuCapabilities &, int type, int ns,
                                               int dim, cufinufft_opts *opts);
-
+template int choose_batchsize<float>(const GpuCapabilities &, const cufinufft_opts &,
+                                     int);
+template int choose_batchsize<double>(const GpuCapabilities &, const cufinufft_opts &,
+                                      int);
 } // namespace common
 } // namespace cufinufft
 

--- a/src/cuda/interp_nupts_driven_inst.cu
+++ b/src/cuda/interp_nupts_driven_inst.cu
@@ -70,8 +70,7 @@ __global__ FINUFFT_FLATTEN void interp_nupts_driven(
 template<typename T, int ndim, int ns>
 void interp_nupts_driven_launch(const cufinufft_plan_t<T> &d_plan, cuda_complex<T> *c,
                                 const cuda_complex<T> *fw, int blksize) {
-  const dim3 threadsPerBlock{
-      optimal_interp_block_threads(d_plan.opts.gpu_device_id, d_plan.M), 1u, 1u};
+  const dim3 threadsPerBlock{d_plan.gpu.interp_block_threads(d_plan.M), 1u, 1u};
   const dim3 blocks{(d_plan.M + threadsPerBlock.x - 1) / threadsPerBlock.x, 1, 1};
 
   const auto launch = [&](auto kernel) {

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -252,6 +252,12 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
             ntransf);
     throw finufft::exception(FINUFFT_ERR_NTRANS_NOTVALID);
   }
+  if (opts.gpu_maxbatchsize < 0) {
+    fprintf(stderr, "[%s] Invalid gpu_maxbatchsize (%d): should be 0 (auto) or > 0.\n",
+            __func__, opts.gpu_maxbatchsize);
+    throw finufft::exception(FINUFFT_ERR_INVALID_ARGUMENT);
+  }
+
   if (!warned_pools && !gpu.memory_pools_supported && opts.gpu_stream != nullptr) {
     fprintf(stderr,
             "[cufinufft] Warning: cudaMallocAsync not supported on this device. Use of "
@@ -260,9 +266,8 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
   }
 
   // set nf1, nf2, nf3 to 1 for type 3, type 1, type 2 will overwrite this
-  nf123                 = {1, 1, 1};
-  opts.gpu_maxbatchsize = std::max(opts.gpu_maxbatchsize, 1);
-  opts.gpu_np           = opts.gpu_method == 3 ? opts.gpu_np : 0;
+  nf123 = {1, 1, 1};
+  opts.gpu_np = opts.gpu_method == 3 ? opts.gpu_np : 0;
 
   if (type != 3) {
     mstu = {nmodes[0], nmodes[1], nmodes[2]};
@@ -273,10 +278,7 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     opts.gpu_spreadinterponly = 1;
   }
 
-  batchsize = opts.gpu_maxbatchsize;
-  // TODO: check if this is the right heuristic
-  if (batchsize == 0)                 // implies: use a heuristic.
-    batchsize = std::min(ntransf, 8); // heuristic from test codes
+  batchsize = choose_batchsize<T>(gpu, opts, ntransf);
 
   stream = (cudaStream_t)opts.gpu_stream;
 

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -247,6 +247,12 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
             ntransf);
     throw finufft::exception(FINUFFT_ERR_NTRANS_NOTVALID);
   }
+  if (opts.gpu_maxbatchsize < 0) {
+    fprintf(stderr, "[%s] Invalid gpu_maxbatchsize (%d): should be 0 (auto) or > 0.\n",
+            __func__, opts.gpu_maxbatchsize);
+    throw finufft::exception(FINUFFT_ERR_INVALID_ARGUMENT);
+  }
+
   if (!warned_pools && !gpu.memory_pools_supported && opts.gpu_stream != nullptr) {
     fprintf(stderr,
             "[cufinufft] Warning: cudaMallocAsync not supported on this device. Use of "
@@ -255,9 +261,8 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
   }
 
   // set nf1, nf2, nf3 to 1 for type 3, type 1, type 2 will overwrite this
-  nf123                 = {1, 1, 1};
-  opts.gpu_maxbatchsize = std::max(opts.gpu_maxbatchsize, 1);
-  opts.gpu_np           = opts.gpu_method == 3 ? opts.gpu_np : 0;
+  nf123 = {1, 1, 1};
+  opts.gpu_np = opts.gpu_method == 3 ? opts.gpu_np : 0;
 
   if (type != 3) {
     mstu = {nmodes[0], nmodes[1], nmodes[2]};
@@ -268,10 +273,7 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     opts.gpu_spreadinterponly = 1;
   }
 
-  batchsize = opts.gpu_maxbatchsize;
-  // TODO: check if this is the right heuristic
-  if (batchsize == 0)                 // implies: use a heuristic.
-    batchsize = std::min(ntransf, 8); // heuristic from test codes
+  batchsize = choose_batchsize<T>(gpu, opts, ntransf);
 
   stream = (cudaStream_t)opts.gpu_stream;
 

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -273,7 +273,8 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     opts.gpu_spreadinterponly = 1;
   }
 
-  batchsize = choose_batchsize<T>(gpu, opts, ntransf);
+  // Provisional: re-chosen below once nf is known.
+  batchsize = choose_batchsize<T>(gpu, opts, ntransf, 0);
 
   stream = (cudaStream_t)opts.gpu_stream;
 
@@ -354,6 +355,10 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     // We don't need any cuFFT plans or kernel values if we are only spreading /
     // interpolating
     if (!opts.gpu_spreadinterponly) {
+      batchsize = choose_batchsize<T>(gpu, opts, ntransf, nf); // now nf-aware (#846)
+      if (opts.debug)
+        printf("[cufinufft] batchsize=%d (nf=%d ntransf=%d maxbatchsize=%d)\n", batchsize,
+               nf, ntransf, opts.gpu_maxbatchsize);
       int n[3];
       int ntot = 1;
       for (int idim = 0; idim < dim; ++idim) {

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -2,6 +2,7 @@
 // Mirrors CPU src/makeplan.cpp. Also hosts the cufft_plan RAII destructor,
 // which is tied to plan setup.
 
+#include <cstdint>
 #include <iostream>
 
 #include <cufinufft/contrib/helper_cuda.h>
@@ -348,7 +349,15 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
         printf("[cufinufft] (nf1,nf2,nf3) = (%d, %d, %d)\n", nf123[0], nf123[1],
                nf123[2]);
     }
-    nf = nf123[0] * nf123[1] * nf123[2];
+    // Widen first: nf123 are CUFINUFFT_BIGINT (int), so a 3D grid past MAX_NF would
+    // overflow instead of being rejected.
+    const auto nf_wide = std::int64_t(nf123[0]) * nf123[1] * nf123[2];
+    if (nf_wide > MAX_NF) {
+      fprintf(stderr, "[%s] nf=%lld exceeds MAX_NF, not attempting malloc!\n", __func__,
+              (long long)nf_wide);
+      throw finufft::exception(FINUFFT_ERR_MAXNALLOC);
+    }
+    nf = CUFINUFFT_BIGINT(nf_wide);
 
     allocate_subprob_state();
 

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -274,9 +274,6 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     opts.gpu_spreadinterponly = 1;
   }
 
-  // Provisional: re-chosen below once nf is known.
-  batchsize = choose_batchsize<T>(gpu, opts, ntransf, 0);
-
   stream = (cudaStream_t)opts.gpu_stream;
 
   // simple check to use upsampfac=1.25 if tol is big
@@ -359,15 +356,18 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     }
     nf = CUFINUFFT_BIGINT(nf_wide);
 
+    // The choice is L2-aware, so it waits for nf; type 3 stays 0 here and is resolved in
+    // setpts, which owns the allocation it bounds (#846).
+    batchsize = choose_batchsize<T>(gpu, opts, ntransf, nf);
+    if (opts.debug)
+      printf("[cufinufft] batchsize=%d (nf=%d ntransf=%d maxbatchsize=%d)\n", batchsize,
+             nf, ntransf, opts.gpu_maxbatchsize);
+
     allocate_subprob_state();
 
     // We don't need any cuFFT plans or kernel values if we are only spreading /
     // interpolating
     if (!opts.gpu_spreadinterponly) {
-      batchsize = choose_batchsize<T>(gpu, opts, ntransf, nf); // now nf-aware (#846)
-      if (opts.debug)
-        printf("[cufinufft] batchsize=%d (nf=%d ntransf=%d maxbatchsize=%d)\n", batchsize,
-               nf, ntransf, opts.gpu_maxbatchsize);
       int n[3];
       int ntot = 1;
       for (int idim = 0; idim < dim; ++idim) {

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -278,7 +278,8 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     opts.gpu_spreadinterponly = 1;
   }
 
-  batchsize = choose_batchsize<T>(gpu, opts, ntransf);
+  // Provisional: re-chosen below once nf is known.
+  batchsize = choose_batchsize<T>(gpu, opts, ntransf, 0);
 
   stream = (cudaStream_t)opts.gpu_stream;
 
@@ -359,6 +360,10 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     // We don't need any cuFFT plans or kernel values if we are only spreading /
     // interpolating
     if (!opts.gpu_spreadinterponly) {
+      batchsize = choose_batchsize<T>(gpu, opts, ntransf, nf); // now nf-aware (#846)
+      if (opts.debug)
+        printf("[cufinufft] batchsize=%d (nf=%d ntransf=%d maxbatchsize=%d)\n", batchsize,
+               nf, ntransf, opts.gpu_maxbatchsize);
       int n[3];
       int ntot = 1;
       for (int idim = 0; idim < dim; ++idim) {

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -278,9 +278,6 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     opts.gpu_spreadinterponly = 1;
   }
 
-  // Provisional: re-chosen below once nf is known.
-  batchsize = choose_batchsize<T>(gpu, opts, ntransf, 0);
-
   stream = (cudaStream_t)opts.gpu_stream;
 
   // simple check to use upsampfac=1.25 if tol is big
@@ -355,15 +352,18 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     }
     nf = nf123[0] * nf123[1] * nf123[2];
 
+    // The choice is L2-aware, so it waits for nf; type 3 stays 0 here and is resolved in
+    // setpts, which owns the allocation it bounds (#846).
+    batchsize = choose_batchsize<T>(gpu, opts, ntransf, nf);
+    if (opts.debug)
+      printf("[cufinufft] batchsize=%d (nf=%d ntransf=%d maxbatchsize=%d)\n", batchsize,
+             nf, ntransf, opts.gpu_maxbatchsize);
+
     allocate_subprob_state();
 
     // We don't need any cuFFT plans or kernel values if we are only spreading /
     // interpolating
     if (!opts.gpu_spreadinterponly) {
-      batchsize = choose_batchsize<T>(gpu, opts, ntransf, nf); // now nf-aware (#846)
-      if (opts.debug)
-        printf("[cufinufft] batchsize=%d (nf=%d ntransf=%d maxbatchsize=%d)\n", batchsize,
-               nf, ntransf, opts.gpu_maxbatchsize);
       int n[3];
       int ntot = 1;
       for (int idim = 0; idim < dim; ++idim) {

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -1,6 +1,6 @@
 // "makeplan" stage: cufinufft_plan_t<T> ctor and the helpers it calls.
-// Mirrors CPU src/makeplan.cpp. Also hosts the cufft_plan RAII destructor
-// and the have_pool_support warning helper, which are tied to plan setup.
+// Mirrors CPU src/makeplan.cpp. Also hosts the cufft_plan RAII destructor,
+// which is tied to plan setup.
 
 #include <iostream>
 
@@ -25,20 +25,8 @@ cufft_plan::~cufft_plan() {
   }
 }
 
-static bool have_pool_support(const cufinufft_opts &opts) {
-  DeviceSwitcher switcher(opts.gpu_device_id);
-  int supports_pools = 0;
-  cudaDeviceGetAttribute(&supports_pools, cudaDevAttrMemoryPoolsSupported,
-                         opts.gpu_device_id);
-  static bool warned = false;
-  if (!warned && !supports_pools && opts.gpu_stream != nullptr) {
-    fprintf(stderr,
-            "[cufinufft] Warning: cudaMallocAsync not supported on this device. Use of "
-            "CUDA streams may not perform optimally.\n");
-    warned = true;
-  }
-  return supports_pools;
-}
+// File scope, not a static local in the ctor: that would warn once per T.
+static bool warned_pools = false;
 
 template<typename T>
 void cufinufft_plan_t<T>::setup_spreadinterp()
@@ -225,8 +213,8 @@ template void cufinufft_plan_t<double>::allocate_nupts();
 template<typename T>
 cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, int iflag_,
                                       int ntransf_, T tol_, const cufinufft_opts &opts_)
-    : opts(opts_), supports_pools(have_pool_support(opts_)), tol(tol_), type(type_),
-      dim(dim_), ntransf(ntransf_), iflag(iflag_ >= 0 ? 1 : -1) {
+    : opts(opts_), gpu(GpuCapabilities::query(opts_.gpu_device_id)), tol(tol_),
+      type(type_), dim(dim_), ntransf(ntransf_), iflag(iflag_ >= 0 ? 1 : -1) {
   /*
       "plan" stage (in single or double precision).
           See ../docs/cppdoc.md for main user-facing documentation.
@@ -258,6 +246,12 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     fprintf(stderr, "[%s] Invalid ntransf (%d): should be at least 1.\n", __func__,
             ntransf);
     throw finufft::exception(FINUFFT_ERR_NTRANS_NOTVALID);
+  }
+  if (!warned_pools && !gpu.memory_pools_supported && opts.gpu_stream != nullptr) {
+    fprintf(stderr,
+            "[cufinufft] Warning: cudaMallocAsync not supported on this device. Use of "
+            "CUDA streams may not perform optimally.\n");
+    warned_pools = true;
   }
 
   // set nf1, nf2, nf3 to 1 for type 3, type 1, type 2 will overwrite this
@@ -310,12 +304,12 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
       opts.gpu_method = (type == 1 || type == 3) ? 2 : 1;
     }
     try {
-      cufinufft_setup_binsize<T>(type, spopts.nspread, dim, &opts);
+      cufinufft_setup_binsize<T>(gpu, type, spopts.nspread, dim, &opts);
     } catch (const std::runtime_error &e) {
       if (auto_method) {
         // Auto-selection of SM failed, fall back to GM and try again.
         opts.gpu_method = 1;
-        cufinufft_setup_binsize<T>(type, spopts.nspread, dim, &opts);
+        cufinufft_setup_binsize<T>(gpu, type, spopts.nspread, dim, &opts);
       } else {
         // User-specified method failed, or the fallback GM method failed.
         fprintf(stderr, "%s, method %d\n", e.what(), opts.gpu_method);

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -1,6 +1,6 @@
 // "makeplan" stage: cufinufft_plan_t<T> ctor and the helpers it calls.
-// Mirrors CPU src/makeplan.cpp. Also hosts the cufft_plan RAII destructor
-// and the have_pool_support warning helper, which are tied to plan setup.
+// Mirrors CPU src/makeplan.cpp. Also hosts the cufft_plan RAII destructor,
+// which is tied to plan setup.
 
 #include <iostream>
 
@@ -25,20 +25,10 @@ cufft_plan::~cufft_plan() {
   }
 }
 
-static bool have_pool_support(const cufinufft_opts &opts) {
-  DeviceSwitcher switcher(opts.gpu_device_id);
-  int supports_pools = 0;
-  cudaDeviceGetAttribute(&supports_pools, cudaDevAttrMemoryPoolsSupported,
-                         opts.gpu_device_id);
-  static bool warned = false;
-  if (!warned && !supports_pools && opts.gpu_stream != nullptr) {
-    fprintf(stderr,
-            "[cufinufft] Warning: cudaMallocAsync not supported on this device. Use of "
-            "CUDA streams may not perform optimally.\n");
-    warned = true;
-  }
-  return supports_pools;
-}
+// Emit the no-memory-pool warning below at most once per process. Shared by both
+// precisions on purpose: a static local in the (templated) constructor would give
+// float and double a flag each, and warn twice.
+static bool warned_pools = false;
 
 template<typename T>
 void cufinufft_plan_t<T>::setup_spreadinterp()
@@ -223,8 +213,8 @@ template void cufinufft_plan_t<double>::allocate_nupts();
 template<typename T>
 cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, int iflag_,
                                       int ntransf_, T tol_, const cufinufft_opts &opts_)
-    : opts(opts_), supports_pools(have_pool_support(opts_)), tol(tol_), type(type_),
-      dim(dim_), ntransf(ntransf_), iflag(iflag_ >= 0 ? 1 : -1) {
+    : opts(opts_), gpu(GpuCapabilities::query(opts_.gpu_device_id)), tol(tol_),
+      type(type_), dim(dim_), ntransf(ntransf_), iflag(iflag_ >= 0 ? 1 : -1) {
   /*
       "plan" stage (in single or double precision).
           See ../docs/cppdoc.md for main user-facing documentation.
@@ -261,6 +251,12 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
     fprintf(stderr, "[%s] Invalid ntransf (%d): should be at least 1.\n", __func__,
             ntransf);
     throw finufft::exception(FINUFFT_ERR_NTRANS_NOTVALID);
+  }
+  if (!warned_pools && !gpu.memory_pools_supported && opts.gpu_stream != nullptr) {
+    fprintf(stderr,
+            "[cufinufft] Warning: cudaMallocAsync not supported on this device. Use of "
+            "CUDA streams may not perform optimally.\n");
+    warned_pools = true;
   }
 
   // set nf1, nf2, nf3 to 1 for type 3, type 1, type 2 will overwrite this
@@ -313,12 +309,12 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
       opts.gpu_method = (type == 1 || type == 3) ? 2 : 1;
     }
     try {
-      cufinufft_setup_binsize<T>(type, spopts.nspread, dim, &opts);
+      cufinufft_setup_binsize<T>(gpu, type, spopts.nspread, dim, &opts);
     } catch (const std::runtime_error &e) {
       if (auto_method) {
         // Auto-selection of SM failed, fall back to GM and try again.
         opts.gpu_method = 1;
-        cufinufft_setup_binsize<T>(type, spopts.nspread, dim, &opts);
+        cufinufft_setup_binsize<T>(gpu, type, spopts.nspread, dim, &opts);
       } else {
         // User-specified method failed, or the fallback GM method failed.
         fprintf(stderr, "%s, method %d\n", e.what(), opts.gpu_method);

--- a/src/cuda/setpts.cu
+++ b/src/cuda/setpts.cu
@@ -10,6 +10,7 @@
 
 #include <cufinufft.h>
 #include <cufinufft/fft.hpp>
+#include <cufinufft/heuristics.hpp>
 
 #include <cufinufft/spreadinterp.hpp>
 #include <cufinufft/types.hpp>
@@ -149,6 +150,9 @@ void cufinufft_plan_t<T>::setpts(int nj, const T *d_kx, const T *d_ky, const T *
   // Guard the fwBatch allocation, nf * batchsize. Widen first: CUFINUFFT_BIGINT is int
   // and MAX_NF is INT32_MAX, so the product would overflow before tripping the guard.
   const auto nf_wide = std::int64_t(nf123[0]) * nf123[1] * nf123[2];
+  // Only known here: nf123 comes from the type-3 params computed above. The outer plan is
+  // spread-only, so this resolves to 1 unless the user set gpu_maxbatchsize.
+  batchsize = cufinufft::common::choose_batchsize<T>(gpu, opts, ntransf, nf_wide);
   if (nf_wide * batchsize > MAX_NF) {
     fprintf(stderr,
             "[%s t3] fwBatch would be bigger than MAX_NF, not attempting malloc!\n",
@@ -299,7 +303,9 @@ void cufinufft_plan_t<T>::setpts(int nj, const T *d_kx, const T *d_ky, const T *
     cufinufft_opts t2opts       = opts;
     t2opts.gpu_spreadinterponly = 0;
     t2opts.gpu_method           = 0;
-
+    // The inner type 2 resolves its own batchsize: its fine grid is upsampled again from
+    // t2modes, and its ntransf is our batchsize, so it can only shrink from there.
+    t2opts.gpu_maxbatchsize = 0;
     // Release the old inner plan before allocating the new one to
     // avoid holding both in memory at the same time, which could be wasteful.
     t2_plan.reset();

--- a/src/cuda/setpts.cu
+++ b/src/cuda/setpts.cu
@@ -1,6 +1,8 @@
 // "setpts" stage: cufinufft_plan_t<T>::setpts and the type-1/2 helper.
 // Mirrors CPU src/setpts.cpp.
 
+#include <algorithm>
+#include <cstdint>
 #include <iostream>
 
 #include <cufinufft/contrib/helper_cuda.h>
@@ -8,6 +10,7 @@
 
 #include <cufinufft.h>
 #include <cufinufft/fft.hpp>
+
 #include <cufinufft/spreadinterp.hpp>
 #include <cufinufft/types.hpp>
 #include <cufinufft/utils.hpp>
@@ -142,15 +145,17 @@ void cufinufft_plan_t<T>::setpts(int nj, const T *d_kx, const T *d_ky, const T *
              type3_params.gam[2], nf123[2], type3_params.h[2]);
     }
   }
-  nf = nf123[0] * nf123[1] * nf123[2];
-
   // FIXME: MAX_NF might be too small...
-  if (nf * opts.gpu_maxbatchsize > MAX_NF) {
+  // Guard the fwBatch allocation, nf * batchsize. Widen first: CUFINUFFT_BIGINT is int
+  // and MAX_NF is INT32_MAX, so the product would overflow before tripping the guard.
+  const auto nf_wide = std::int64_t(nf123[0]) * nf123[1] * nf123[2];
+  if (nf_wide * batchsize > MAX_NF) {
     fprintf(stderr,
             "[%s t3] fwBatch would be bigger than MAX_NF, not attempting malloc!\n",
             __func__);
     throw finufft::exception(FINUFFT_ERR_MAXNALLOC);
   }
+  nf = CUFINUFFT_BIGINT(nf_wide);
 
   for (int idim = 0; idim < dim; ++idim) {
     kxyzp[idim].resize(M);
@@ -294,6 +299,7 @@ void cufinufft_plan_t<T>::setpts(int nj, const T *d_kx, const T *d_ky, const T *
     cufinufft_opts t2opts       = opts;
     t2opts.gpu_spreadinterponly = 0;
     t2opts.gpu_method           = 0;
+
     // Release the old inner plan before allocating the new one to
     // avoid holding both in memory at the same time, which could be wasteful.
     t2_plan.reset();

--- a/src/cuda/setpts.cu
+++ b/src/cuda/setpts.cu
@@ -8,6 +8,8 @@
 
 #include <cufinufft.h>
 #include <cufinufft/fft.hpp>
+#include <cufinufft/heuristics.hpp>
+
 #include <cufinufft/spreadinterp.hpp>
 #include <cufinufft/types.hpp>
 #include <cufinufft/utils.hpp>
@@ -151,7 +153,10 @@ void cufinufft_plan_t<T>::setpts(int nj, const T *d_kx, const T *d_ky, const T *
   nf = nf123[0] * nf123[1] * nf123[2];
 
   // FIXME: MAX_NF might be too small...
-  if (nf * opts.gpu_maxbatchsize > MAX_NF) {
+  // Only known here: nf123 comes from the type-3 params computed above. The outer plan is
+  // spread-only, so this resolves to 1 unless the user set gpu_maxbatchsize.
+  batchsize = cufinufft::common::choose_batchsize<T>(gpu, opts, ntransf, nf);
+  if (nf * batchsize > MAX_NF) {
     fprintf(stderr,
             "[%s t3] fwBatch would be bigger than MAX_NF, not attempting malloc!\n",
             __func__);
@@ -300,6 +305,10 @@ void cufinufft_plan_t<T>::setpts(int nj, const T *d_kx, const T *d_ky, const T *
     cufinufft_opts t2opts       = opts;
     t2opts.gpu_spreadinterponly = 0;
     t2opts.gpu_method           = 0;
+    // The outer plan owns the batch decision; the inner type 2 must process each batch
+    // in one go rather than subdividing it again (it would need an fw buffer per
+    // sub-batch, and the outer spread already materialized the whole batch).
+    t2opts.gpu_maxbatchsize = batchsize;
     // Release the old inner plan before allocating the new one to
     // avoid holding both in memory at the same time, which could be wasteful.
     t2_plan.reset();

--- a/test/cuda/CMakeLists.txt
+++ b/test/cuda/CMakeLists.txt
@@ -224,6 +224,7 @@ add_test(NAME cufinufft_makeplan COMMAND test_makeplan)
 add_test(NAME cufinufft_error_handling COMMAND cufinufft_error_handling)
 add_test(NAME cufinufft_math_test COMMAND cufinufft_math_test)
 add_test(NAME cufinufft_simple_test COMMAND cufinufft_simple_test)
+add_test(NAME cufinufft_t3_batch COMMAND cufinufft_t3_batch_test)
 add_test(NAME cufinufft_multigpu COMMAND cufinufft_multigpu_test)
 # Returns 77 when only one device is visible: the cross-device path cannot run.
 set_tests_properties(cufinufft_multigpu PROPERTIES SKIP_RETURN_CODE 77)

--- a/test/cuda/cufinufft_error_handling.cu
+++ b/test/cuda/cufinufft_error_handling.cu
@@ -43,8 +43,16 @@ int main() {
   rc                    = check_rc("nmodes invalid", rc, FINUFFT_ERR_NDATA_NOTVALID, 5);
   if (rc) return rc;
 
-  // Upsamp too small -> expect FINUFFT_ERR_UPSAMPFAC_TOO_SMALL
+  // Negative gpu_maxbatchsize -> expect FINUFFT_ERR_INVALID_ARGUMENT.
+  // 0 means auto and > 0 is a request; negative has no meaning.
   cufinufft_opts opts;
+  cufinufft_default_opts(&opts);
+  opts.gpu_maxbatchsize = -1;
+  rc = cufinufftf_makeplan(1, 2, N, 1, 4, 1e-5f, &fplan, &opts);
+  rc = check_rc("gpu_maxbatchsize negative", rc, FINUFFT_ERR_INVALID_ARGUMENT, 9);
+  if (rc) return rc;
+
+  // Upsamp too small -> expect FINUFFT_ERR_UPSAMPFAC_TOO_SMALL
   cufinufft_default_opts(&opts);
   opts.upsampfac       = 0.9;
   opts.gpu_kerevalmeth = 0;

--- a/test/cuda/cufinufft_error_handling.cu
+++ b/test/cuda/cufinufft_error_handling.cu
@@ -43,8 +43,16 @@ int main(void) {
   rc                    = check_rc("nmodes invalid", rc, FINUFFT_ERR_NDATA_NOTVALID, 5);
   if (rc) return rc;
 
-  // Upsamp too small -> expect FINUFFT_ERR_UPSAMPFAC_TOO_SMALL
+  // Negative gpu_maxbatchsize -> expect FINUFFT_ERR_INVALID_ARGUMENT.
+  // 0 means auto and > 0 is a request; negative has no meaning.
   cufinufft_opts opts;
+  cufinufft_default_opts(&opts);
+  opts.gpu_maxbatchsize = -1;
+  rc = cufinufftf_makeplan(1, 2, N, 1, 4, 1e-5f, &fplan, &opts);
+  rc = check_rc("gpu_maxbatchsize negative", rc, FINUFFT_ERR_INVALID_ARGUMENT, 9);
+  if (rc) return rc;
+
+  // Upsamp too small -> expect FINUFFT_ERR_UPSAMPFAC_TOO_SMALL
   cufinufft_default_opts(&opts);
   opts.upsampfac       = 0.9;
   opts.gpu_kerevalmeth = 0;

--- a/test/cuda/cufinufft_t3_batch_test.cu
+++ b/test/cuda/cufinufft_t3_batch_test.cu
@@ -1,0 +1,134 @@
+// Type 3 must give the same answer whatever batchsize it runs at, including the
+// buffers its batch loop shares (CpBatch doubles as the inner type 2's fw).
+
+#include <cmath>
+#include <complex>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+#include <cufinufft.h>
+#include <cufinufft/contrib/helper_cuda.h>
+#include <finufft_common/common.h>
+
+#include <thrust/complex.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+template<typename T>
+std::vector<std::complex<T>> run(
+    int maxbatchsize, int dim, int M, int nk, int ntransf,
+    const thrust::host_vector<T> &x, const thrust::host_vector<T> &y,
+    const thrust::host_vector<T> &s, const thrust::host_vector<T> &t,
+    const thrust::host_vector<thrust::complex<T>> &c) {
+  thrust::device_vector<T> d_x(x), d_y(y), d_s(s), d_t(t);
+  thrust::device_vector<thrust::complex<T>> d_c(c), d_fk(size_t(nk) * ntransf);
+
+  cufinufft_opts opts;
+  cufinufft_default_opts(&opts);
+  opts.gpu_maxbatchsize = maxbatchsize;
+
+  const T tol = std::is_same_v<T, float> ? 1e-5 : 1e-12;
+  const int64_t nmodes[3] = {8, 8, 1}; // unused by type 3, but makeplan takes it
+  typename std::conditional_t<std::is_same_v<T, float>, cufinufftf_plan, cufinufft_plan>
+      plan;
+  int ier;
+  if constexpr (std::is_same_v<T, float>) {
+    ier = cufinufftf_makeplan(3, dim, nmodes, 1, ntransf, tol, &plan, &opts);
+    if (ier) return {};
+    ier = cufinufftf_setpts(plan, M, d_x.data().get(), d_y.data().get(), nullptr, nk,
+                            d_s.data().get(), d_t.data().get(), nullptr);
+    if (!ier)
+      ier = cufinufftf_execute(plan, (cuFloatComplex *)d_c.data().get(),
+                               (cuFloatComplex *)d_fk.data().get());
+    cufinufftf_destroy(plan);
+  } else {
+    ier = cufinufft_makeplan(3, dim, nmodes, 1, ntransf, tol, &plan, &opts);
+    if (ier) return {};
+    ier = cufinufft_setpts(plan, M, d_x.data().get(), d_y.data().get(), nullptr, nk,
+                           d_s.data().get(), d_t.data().get(), nullptr);
+    if (!ier)
+      ier = cufinufft_execute(plan, (cuDoubleComplex *)d_c.data().get(),
+                              (cuDoubleComplex *)d_fk.data().get());
+    cufinufft_destroy(plan);
+  }
+  if (ier) return {};
+
+  thrust::host_vector<thrust::complex<T>> h_fk(d_fk);
+  std::vector<std::complex<T>> out(h_fk.size());
+  for (size_t i = 0; i < h_fk.size(); ++i) out[i] = {h_fk[i].real(), h_fk[i].imag()};
+  return out;
+}
+
+template<typename T> int run_prec(const char *label) {
+  const int dim = 2, M = 2000, nk = 500, ntransf = 7;
+  std::default_random_engine eng(42);
+  std::uniform_real_distribution<T> uni(-1, 1);
+
+  thrust::host_vector<T> x(M), y(M), s(nk), t(nk);
+  thrust::host_vector<thrust::complex<T>> c(size_t(M) * ntransf);
+  for (int j = 0; j < M; ++j) {
+    x[j] = T(finufft::common::PI) * uni(eng);
+    y[j] = T(finufft::common::PI) * uni(eng);
+  }
+  for (int k = 0; k < nk; ++k) {
+    s[k] = T(12) * uni(eng);
+    t[k] = T(12) * uni(eng);
+  }
+  // Distinct data per transform, so a batch-indexing slip cannot cancel out.
+  for (size_t i = 0; i < c.size(); ++i) {
+    const T re = uni(eng), im = uni(eng);
+    c[i] = thrust::complex<T>(re, im);
+  }
+
+  // batchsize 1 is the reference: one transform per batch, nothing shared across a
+  // batch boundary.
+  const auto ref = run<T>(1, dim, M, nk, ntransf, x, y, s, t, c);
+  if (ref.empty()) {
+    std::cerr << label << ": reference run failed\n";
+    return 1;
+  }
+  T refnorm = 0;
+  for (const auto &v : ref) refnorm = std::max(refnorm, std::abs(v));
+
+  const auto diff = [&](const std::vector<std::complex<T>> &a) {
+    T e = 0;
+    for (size_t i = 0; i < ref.size(); ++i) e = std::max(e, std::abs(a[i] - ref[i]));
+    return e / refnorm;
+  };
+
+  // The spreader accumulates with atomics, so even a repeat of the reference differs.
+  // That noise floor, not a fixed constant, is what a batchsize may move the answer by.
+  const T ctrl = diff(run<T>(1, dim, M, nk, ntransf, x, y, s, t, c));
+  // Floor scales with the precision: a deterministic control must not demand bit
+  // equality of a batch that only reassociates the sum.
+  const T checktol = std::max(T(8) * ctrl, T(100) * std::numeric_limits<T>::epsilon());
+  std::cout << label << ": bs=1 repeat (control) " << ctrl << ", tol " << checktol
+            << "\n";
+
+  int fails = 0;
+  for (int bs : {0, 2, 3, 4, 7, 8}) { // 0 = auto, 8 > ntransf (must clamp)
+    const auto got = run<T>(bs, dim, M, nk, ntransf, x, y, s, t, c);
+    if (got.size() != ref.size()) {
+      std::cerr << label << " maxbatchsize=" << bs << ": run failed\n";
+      ++fails;
+      continue;
+    }
+    const T err = diff(got);
+    std::cout << label << " maxbatchsize=" << bs << ": rel err vs bs=1 " << err << "\n";
+    if (!(err <= checktol)) {
+      std::cerr << label << " maxbatchsize=" << bs << ": FAILED (tol " << checktol
+                << ")\n";
+      ++fails;
+    }
+  }
+  return fails;
+}
+
+int main() {
+  int fails = run_prec<float>("float") + run_prec<double>("double");
+  std::cout << (fails ? "FAILED\n" : "PASSED\n");
+  return fails != 0;
+}


### PR DESCRIPTION
Two compounding regressions made many-transform 2D type-2 ~6x slower than
cuFINUFFT <= 2.4.x, and single transforms ~2x slower:

RC#1 (utils.hpp): optimal_block_threads() called cudaGetDeviceProperties()
  to read only prop.major. That fills the entire cudaDeviceProp struct and
  costs ~54us/call on Ada (~96us on A100), once per interp launch. Replaced
  with cudaDeviceGetAttribute(cudaDevAttrComputeCapabilityMajor) (~0.02us,
  identical result on every GPU).

RC#2 (makeplan.cu): opts.gpu_maxbatchsize was clamped to >=1 before the
  `if (batchsize == 0)` auto heuristic ran, making the heuristic dead code
  and pinning batchsize to 1 (no FFT batching; interp launch + RC#1 query
  fired per transform). Capture the "auto" intent before clamping.
  setpts.cu: guard the actual fwBatch allocation (nf * batchsize), which can
  exceed the clamped opts.gpu_maxbatchsize once the heuristic batches.

Measured on RTX 6000 Ada (sm_89, CUDA 12.5), 2D type-2 179^2 M=16020 single:
  ntransf=1:   89.5 -> 39.8 us/call         (2.2x)
  ntransf=512: 63.7 -> ~10  us/transform    (~6x)
ctest 287/287 pass.

Investigation and root-cause analysis by Libin Lu.
