### PR TITLE
ci: modernize GitHub Actions and Python wheel builds

### DIFF
--- a/.github/workflows/C++.yml
+++ b/.github/workflows/C++.yml
@@ -22,7 +22,7 @@ jobs:
     container: quay.io/pypa/manylinux_2_28_x86_64:latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install fftw
       run: |
@@ -38,7 +38,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install omp and fftw
       run: |
@@ -55,7 +55,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install gcc and fftw
       run: |
@@ -73,7 +73,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: 'Setup MSYS2'
       uses: msys2/setup-msys2@v2
       with:

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -33,11 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v7
         with:
           ref: master
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: python3 -m pip install --quiet pyyaml

--- a/.github/workflows/build_cufinufft_wheels.yml
+++ b/.github/workflows/build_cufinufft_wheels.yml
@@ -29,11 +29,11 @@ jobs:
           - [ ubuntu-22.04, manylinux_x86_64 ]
           - [ windows-2022, win_amd64 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Setup CUDA
         if: ${{ matrix.buildplat[0] == 'windows-2022' }}
-        uses: Jimver/cuda-toolkit@v0.2.24
+        uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: '12.4.0'
           method: 'network'
@@ -44,7 +44,7 @@ jobs:
           use-local-cache: 'false'
           use-github-cache: 'false' #it is not working at the moment https://github.com/Jimver/cuda-toolkit/issues/390
       - name: Build ${{ matrix.buildplat[1] }} wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v4.1
         with:
           package-dir: 'python/cufinufft'
         env:
@@ -52,18 +52,20 @@ jobs:
           CIBW_TEST_COMMAND: "echo 'Wheel installed'"
           CIBW_BUILD_FRONTEND: "pip; args: --no-deps"
           CIBW_BEFORE_ALL_LINUX: |
+            # manylinux_2_28 = AlmaLinux 8: rhel8 repo, toolkit only (no GPU driver).
+            # gcc-toolset-13 because the image defaults to gcc 14, which CUDA 12.4 nvcc rejects.
             if command -v yum &> /dev/null; then
-              yum install -y epel-release
-              yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-              yum install -y cuda-12-4
+              yum install -y yum-utils gcc-toolset-13
+              yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+              yum install -y cuda-toolkit-12-4
             else
               echo "Unsupported package manager. Exiting."
               exit 1
             fi
-          CIBW_ENVIRONMENT_LINUX: PATH=$PATH:/usr/local/cuda/bin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
+          CIBW_ENVIRONMENT_LINUX: PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH:/usr/local/cuda/bin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64 CUDAHOSTCXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
           CIBW_ARCHS_LINUX: x86_64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cufinufft-wheels-${{ matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_finufft_wheels.yml
+++ b/.github/workflows/build_finufft_wheels.yml
@@ -24,16 +24,18 @@ jobs:
     name: Build finufft wheels on ${{ matrix.buildplat[1] }}
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
-#      fail-fast: false
+      fail-fast: false
       matrix:
         buildplat:
           - [ ubuntu-22.04, manylinux_x86_64 ]
           - [ ubuntu-22.04, musllinux_x86_64 ]
-#          - [ macos-13, macosx_x86_64 ]
+          - [ ubuntu-22.04-arm, manylinux_aarch64 ]
+          - [ ubuntu-22.04-arm, musllinux_aarch64 ]
+          - [ macos-15-intel, macosx_x86_64 ]
           - [ macos-14, macosx_arm64 ]
           - [ windows-2022, win_amd64 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install dependencies
         if: ${{ runner.os == 'Windows' }}
         run: |
@@ -45,11 +47,12 @@ jobs:
           # (another one at c:\mingw64 is, however), so we add it to the path.
           echo "c:\msys64\mingw64\bin;" >> $env:GITHUB_PATH
       - name: Build ${{ matrix.buildplat[1] }} wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v4.1
         with:
           package-dir: 'python/finufft'
         env:
-          CIBW_ARCHS_LINUX: x86_64
+          # Arch comes from the runner (x86_64 on ubuntu-22.04, aarch64 on
+          # ubuntu-22.04-arm); CIBW_BUILD already scopes the platform tag.
           CIBW_BEFORE_ALL_MACOS: |
             brew install llvm libomp
           CIBW_ENVIRONMENT_MACOS: >
@@ -57,9 +60,9 @@ jobs:
             CXX=$(brew --prefix llvm)/bin/clang++
             CFLAGS="-I$(brew --prefix libomp)/include"
             LDFLAGS="-L$(brew --prefix libomp)/lib"
-            MACOSX_DEPLOYMENT_TARGET=${{ matrix.buildplat[0] == 'macos-14' && '14' || '13' }}
+            MACOSX_DEPLOYMENT_TARGET=14
           CIBW_BUILD: '*-${{ matrix.buildplat[1] }}'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: finufft-wheels-${{ matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/cmake_ci.yml
+++ b/.github/workflows/cmake_ci.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           cache: 'pip'
           python-version: '3.10'
@@ -24,7 +24,7 @@ jobs:
           sed -i -E 's/(==|>=|<=|>|<|~=|!=).*//' requirements.txt
           cat requirements.txt
       - name: Upload requirements.txt
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: requirements
           path: requirements.txt
@@ -36,13 +36,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: create cache directory
         shell: bash
         run: mkdir -p "cpm"
       - name: Check if cache exists
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           key: cpm-cache-00-${{ runner.os == 'windows' && 'windows-' || '' }}${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           enableCrossOsArchive: true
@@ -66,7 +66,7 @@ jobs:
           cmake -S . -B build -DFINUFFT_USE_DUCC0=ON -DCPM_SOURCE_CACHE="cpm"
       - name: Cache dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           key: cpm-cache-00-${{ runner.os == 'windows' && 'windows-' || '' }}${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           enableCrossOsArchive: true
@@ -142,22 +142,22 @@ jobs:
         with:
           tool-cache: false
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           key: cpm-cache-00-${{ runner.os == 'windows' && 'windows-' || '' }}${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           enableCrossOsArchive: true
           path: cpm
 
       - name: Download requirements.txt
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: requirements
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Setup Cpp
         uses: aminya/setup-cpp@v1
@@ -190,7 +190,7 @@ jobs:
           sudo apt install -y libfftw3-dev
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -280,9 +280,9 @@ jobs:
         linking: [Static, Shared]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           key: cpm-cache-00-${{ runner.os == 'windows' && 'windows-' || '' }}${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           enableCrossOsArchive: true
@@ -337,6 +337,6 @@ jobs:
     needs: [cmake-ci, consume-test]
     steps:
       - name: Artifact cleanup
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: requirements

--- a/.github/workflows/cmake_sanitizers.yml
+++ b/.github/workflows/cmake_sanitizers.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: create cache directory
         shell: bash
         run: mkdir -p "cpm"
       - name: Check if cache exists
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           key: cpm-cache-00-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           enableCrossOsArchive: true
@@ -32,7 +32,7 @@ jobs:
           cmake -S . -B ./build -DFINUFFT_USE_DUCC0=ON -DCPM_SOURCE_CACHE="cpm"
       - name: Cache dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           key: cpm-cache-00-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           enableCrossOsArchive: true
@@ -76,17 +76,17 @@ jobs:
         with:
           tool-cache: false
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           key: cpm-cache-00-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           enableCrossOsArchive: true
           path: cpm
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Setup Cpp
         uses: aminya/setup-cpp@v1

--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         # Single, simple Fortran toolchain everywhere (gfortran).
         # This action also sets FC, and typically CC/CXX to compatible compilers.
       - name: Setup Fortran

--- a/.github/workflows/make-mex.yml
+++ b/.github/workflows/make-mex.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: R2024b
           cache: true
@@ -65,11 +65,11 @@ jobs:
           sed -i '/  LIBSFFT/a \ \ LIBSFFT := `g++ --print-file-name libfftw3.a` `g++ --print-file-name libfftw3f.a` `g++ --print-file-name libfftw3_omp.a` `g++ --print-file-name libfftw3f_omp.a` -lm -lgomp' makefile
           make matlab
       - name: Run Matlab test
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: addpath(genpath('matlab')), fullmathtest, tolsweeptest
       - name: Upload mex files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.os}}-R2024b-finufft-mex
           path: ${{runner.workspace}}/finufft/matlab/finufft.mex*

--- a/.github/workflows/mex.yml
+++ b/.github/workflows/mex.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup C++ toolchain
-        uses: aminya/setup-cpp@v1.7.1
+        uses: aminya/setup-cpp@v1
         with:
           cmake: true
           ninja: true
@@ -62,7 +62,7 @@ jobs:
       # Install CUDA on non-macOS runners
       - name: Install CUDA Toolkit (non-macOS)
         if: runner.os != 'macOS'
-        uses: Jimver/cuda-toolkit@v0.2.24
+        uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: '12.4.0'
           method: 'network'
@@ -74,13 +74,13 @@ jobs:
           use-github-cache: 'false' #it is not working at the moment https://github.com/Jimver/cuda-toolkit/issues/390
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: R2023b
           products: Parallel_Computing_Toolbox
           cache: false
       - name: Detect mexext via MATLAB
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: |
             me = mexext;                       % e.g., mexa64|mexw64|mexmaci64|mexmaca64
@@ -135,7 +135,7 @@ jobs:
           fi
 
       - name: Run matlab math & tol-sweep tests
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: |
             addpath(genpath('matlab'));
@@ -147,7 +147,7 @@ jobs:
         shell: bash
         run: cmake --build build --target package
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: finufft-matlab-mex-${{ matrix.os }}
           path: |

--- a/.github/workflows/octave.yml
+++ b/.github/workflows/octave.yml
@@ -25,7 +25,7 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup C++ toolchain
         uses: aminya/setup-cpp@v1

--- a/.github/workflows/perftest-pr-cleanup.yml
+++ b/.github/workflows/perftest-pr-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout perftest-images branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v7
         with:
           ref: perftest-images
           # Don't fail if the branch doesn't exist yet.

--- a/.github/workflows/perftest-pr-head-comment.yml
+++ b/.github/workflows/perftest-pr-head-comment.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master (for git push to images branch)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v7
         with:
           ref: master
           path: repo
 
       - name: Download perftest artifact from triggering run
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v8
         with:
           name: perftest-pr-head
           path: artifact
@@ -92,14 +92,14 @@ jobs:
 
       - name: Find existing managed comment
         id: find-comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ steps.meta.outputs.pr_number }}
           comment-author: github-actions[bot]
           body-includes: "<!-- pr-managed-comment -->"
 
       - name: Create or update managed PR comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ steps.meta.outputs.pr_number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/perftest-pr-head.yml
+++ b/.github/workflows/perftest-pr-head.yml
@@ -25,19 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest master
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v7
         with:
           ref: master
           path: master
 
       - name: Checkout PR head
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-head
 
       - name: Setup Cpp
-        uses: aminya/setup-cpp@1f17f92d6a52bfcb1a25348e2c526c2e5cbb1134 # v1.8.0
+        uses: aminya/setup-cpp@v1
         with:
           cmake: true
           ninja: true
@@ -91,7 +91,7 @@ jobs:
           PY
 
       - name: Upload perftest artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         with:
           name: perftest-pr-head
           path: |

--- a/.github/workflows/perftest.yml
+++ b/.github/workflows/perftest.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest perftest
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Cpp
-        uses: aminya/setup-cpp@1f17f92d6a52bfcb1a25348e2c526c2e5cbb1134 # v1.8.0
+        uses: aminya/setup-cpp@v1
         with:
           cmake: true
           ninja: true
@@ -67,7 +67,7 @@ jobs:
           done
 
       - name: Install plotting dependency
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: python3 -m pip install --quiet matplotlib pandas Jinja2 py-cpuinfo
@@ -84,7 +84,7 @@ jobs:
             --page-template docs/performance_backend.rst.j2 \
             --output outputs
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@v7
         with:
           name: perftest-result-${{ matrix.target.name }}
           path: ./outputs/
@@ -93,8 +93,8 @@ jobs:
     needs: perftest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: perftest-result-*
           path: ./outputs/

--- a/.github/workflows/powerpc.yml
+++ b/.github/workflows/powerpc.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Apt setup (cross toolchains, qemu, ninja)
         run: |

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,7 +13,7 @@ jobs:
         backend: [fftw, ducc]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate platform-table generator parses workflows
         run: |

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Cpp
         uses: aminya/setup-cpp@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25...3.31)
+cmake_minimum_required(VERSION 3.25...4.0)
 cmake_policy(VERSION 3.25)
 project(FINUFFT VERSION 2.6.0 LANGUAGES C CXX)
 
@@ -66,7 +66,7 @@ include(toolchain) # finds cmake/toolchain.cmake
 
 # Versions for dependencies
 set(CPM_DOWNLOAD_VERSION "0.42.0" CACHE STRING "Version of CPM.cmake to use")
-set(FFTW_VERSION "3.3.11" CACHE STRING "Version of FFTW to use")
+set(FFTW_VERSION "3.3.10" CACHE STRING "Version of FFTW to use")
 set(XSIMD_VERSION "6842624" CACHE STRING "Version of xsimd to use") # this commit fixes gcc-10 for now
 set(DUCC0_VERSION "ducc0_0_39_1" CACHE STRING "Version of ducc0 to use")
 set(CUDA11_CCCL_VERSION "2.8.5" CACHE STRING "Version of FINUFFT-cccl for cuda 11 to use")

--- a/cmake/setupFFTW.cmake
+++ b/cmake/setupFFTW.cmake
@@ -28,7 +28,7 @@ if(FINUFFT_FFTW_LIBRARIES STREQUAL DEFAULT OR FINUFFT_FFTW_LIBRARIES STREQUAL DO
             URL
             "http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
             URL_HASH
-            "MD5=40ec8d0447d03b8f01f8c90aa77bd16f"
+            "MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c"
             OPTIONS
             "ENABLE_SSE2 ON"
             "ENABLE_AVX ON"
@@ -46,7 +46,7 @@ if(FINUFFT_FFTW_LIBRARIES STREQUAL DEFAULT OR FINUFFT_FFTW_LIBRARIES STREQUAL DO
             URL
             "http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
             URL_HASH
-            "MD5=40ec8d0447d03b8f01f8c90aa77bd16f"
+            "MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c"
             OPTIONS
             "ENABLE_SSE2 ON"
             "ENABLE_AVX ON"

--- a/python/cufinufft/pyproject.toml
+++ b/python/cufinufft/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core >= 0.4.3",
-    "cmake (>= 3.19, < 4)",
+    "cmake >= 3.25",
     "ninja >= 1.9.0",
 ]
 build-backend = "scikit_build_core.build"
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 name = "cufinufft"
 description = "Non-uniform fast Fourier transforms on the GPU"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = ["numpy", "packaging"]
 authors = [
     {name = "Yu-shuan Melody Shih"},
@@ -80,12 +80,17 @@ input = "cufinufft/__init__.py"
 [tool.cibuildwheel]
 # Necessary to see build output from the actual compilation
 build-verbosity = 1
-skip = "cp36-* cp37-* cp-38* pp* *-manylinux_i686 *_ppc64le *_s390x *_universal2"
+# Python floor (>=3.10) comes from requires-python; here we only drop
+# PyPy and unsupported architectures.
+skip = "pp* *-manylinux_i686 *_ppc64le *_s390x *_universal2"
 config-settings = {"cmake.define.CMAKE_CUDA_ARCHITECTURES" = "all", "cmake.define.CIBUILDWHEEL" = "ON"}
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
+# Use manylinux_2_28 (AlmaLinux 8, glibc 2.28) rather than the EOL
+# manylinux2014 (CentOS 7, glibc 2.17). Matches cibuildwheel's current
+# default and numpy/scipy; wheels require glibc >= 2.28.
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 repair-wheel-command = "auditwheel -v repair --exclude libcudart.so.12 --exclude libcufft.so.11 -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows]

--- a/python/finufft/pyproject.toml
+++ b/python/finufft/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core >= 0.4.3",
-    "cmake (>= 3.19, < 4)",
+    "cmake >= 3.25",
     "ninja >= 1.9.0",
 ]
 
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "finufft"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = ["numpy >= 1.12.0", "packaging"]
 authors = [
     {name = "Jeremy Magland"},
@@ -78,7 +78,9 @@ input = "finufft/__init__.py"
 [tool.cibuildwheel]
 # Necessary to see build output from the actual compilation
 build-verbosity = 1
-skip = "cp36-* cp37-* cp-38* pp* *-manylinux_i686 *_ppc64le *_s390x *_universal2"
+# Python floor (>=3.10) comes from requires-python; here we only drop
+# PyPy and unsupported architectures.
+skip = "pp* *-manylinux_i686 *_ppc64le *_s390x *_universal2"
 test-requires = ["pytest", "pytest-mock"]
 test-command = "pytest {project}/python/finufft/test"
 
@@ -89,9 +91,14 @@ config-settings = {"cmake.define.FINUFFT_ARCH_FLAGS" = "-march=x86-64", "cmake.d
 # TODO: CIBW crashes when we try to make config-settings above into a table. Why?
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
-musllinux-x86_64-image = "musllinux_1_1"
+# Use manylinux_2_28 (AlmaLinux 8, glibc 2.28) rather than the older
+# manylinux2014 (CentOS 7, glibc 2.17), which is EOL and ships a frozen,
+# ancient GCC. This matches cibuildwheel's current default and what
+# numpy/scipy build against. Wheels therefore require glibc >= 2.28
+# (RHEL 8 / Ubuntu 18.10+), the same floor as numpy/scipy.
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+musllinux-x86_64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"
@@ -99,12 +106,10 @@ before-build = "pip install delvewheel"
 # install delvewheel and run it.
 repair-wheel-command = "delvewheel repair -v --analyze-existing -w {dest_dir} {wheel}"
 
+# Override for ARM builds (macOS arm64 and Linux/musl aarch64): the
+# default config-settings pass -march=x86-64, which is invalid on ARM, so
+# clear FINUFFT_ARCH_FLAGS there. Note "*aarch64*" does not match the
+# "*arm64*" glob, so both patterns are required.
 [[tool.cibuildwheel.overrides]]
-select = "cp310-*"
-manylinux-x86_64-image = "manylinux_2_28"
-musllinux-x86_64-image = "musllinux_1_2"
-
-# Override for ARM64 builds
-[[tool.cibuildwheel.overrides]]
-select = "*arm64*"
+select = "*arm64* *aarch64*"
 config-settings = { "cmake.define.FINUFFT_ARCH_FLAGS" = "", "cmake.define.CMAKE_VERBOSE_MAKEFILE" = "ON" }


### PR DESCRIPTION
- Float all GitHub Actions to their latest major versions (node24 runtimes).
- Bump cibuildwheel to v4.1; build linux wheels on manylinux_2_28 and musllinux_1_2 (EOL manylinux2014 dropped), matching numpy/scipy.
- Add native aarch64 (manylinux + musllinux) and Intel macOS wheels.
- Require Python >=3.10; allow CMake 4 (range 3.25...4.0).
- Downgrade bundled FFTW to 3.3.10 (3.3.11 breaks the AVX2 COMPILE_FLAGS).
- macOS: set MACOSX_DEPLOYMENT_TARGET=14 (brew libomp floor, delocate).
- cufinufft linux: install cuda-toolkit-12-4 from the rhel8 repo and pin the CUDA host compiler to gcc-13 (nvcc rejects the image's gcc-14).