### PR TITLE
docs: recommend mip for installing the MATLAB interface

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -37,6 +37,8 @@ to document your installation problem.
 
 Python-only users can simply install via ``pip install finufft`` which downloads a generic binary from PyPI. If you prefer a local Python package build, see :ref:`below<install-python>`.
 
+MATLAB-only users can similarly skip building from source by installing a precompiled MEX interface via `mip <https://mip.sh>`_, a package manager for MATLAB: ``mip install finufft`` then ``mip load finufft``. See the :ref:`MATLAB docs <matlab>` for details.
+
 .. note::
     Here are some overall notes about Windows. On Windows, MSVC works fine. However, the LLVM toolchain included in Visual Studio does not seem to have OpenMP, but it is still possible to build single-threaded FINUFFT.
     The official windows LLVM distribution builds FINUFFT with no issues, but debug builds using sanitizers break.

--- a/docs/matlab.rst
+++ b/docs/matlab.rst
@@ -3,9 +3,22 @@
 MATLAB/Octave interfaces
 ========================
 
+The simplest way to install this interface is with `mip <https://mip.sh>`_,
+a package manager for MATLAB:
+
+.. code-block:: matlab
+
+   mip install finufft
+   mip load finufft
+
+This downloads a prebuilt MEX binary for Linux, macOS, or Windows, so no
+compiler is needed. See `mip.sh/docs <https://mip.sh/docs>`_ for details.
+
 .. note::
 
-   See the :ref:`installation page <install>` for how to build these interfaces.
+   mip is MATLAB-only. Octave users, or anyone who wants to customize the
+   build, should build from source instead — see the
+   :ref:`installation page <install>`.
 
 
 Quick-start examples


### PR DESCRIPTION
Add a pointer to mip (https://mip.sh) alongside the existing pip callout, so MATLAB users can install a prebuilt MEX interface without compiling from source.