### PR TITLE
SIMD complex hadd 

### DIFF
--- a/.github/workflows/cmake_ci.yml
+++ b/.github/workflows/cmake_ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           # Pin pip to 25.2 to match the pip-tools compatibility seen in CI
           python3 -m pip install --upgrade "pip==25.2"
-          python3 -m pip install pip-tools
+          python3 -m pip install pip-tools typing_extensions
           python3 -m pip --version
           pip-compile --all-build-deps python/finufft/pyproject.toml -o requirements.txt
           echo pytest >> requirements.txt

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,10 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 v2.6.0-dev
 
+* Sanitizer CI builds now compile at `-O1 -fno-omit-frame-pointer` (working around an
+  xsimd 14.3.0 constexpr immediate-argument folding bug at `-O0`), instrument the
+  single-precision `finufft_f32` object library, and mark xsimd/ducc0 includes as
+  `SYSTEM` to drop third-party warnings. (Barbone)
 * Added C-level simple API to cuFINUFFT
   (`cufinufft{,f}{1,2,3}d{1,2,3}[many]`) mirroring the CPU `finufft1d1`-style
   wrappers. 36 new entry points that allocate a plan, set points, execute, and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ include(toolchain) # finds cmake/toolchain.cmake
 # Versions for dependencies
 set(CPM_DOWNLOAD_VERSION "0.42.0" CACHE STRING "Version of CPM.cmake to use")
 set(FFTW_VERSION "3.3.10" CACHE STRING "Version of FFTW to use")
-set(XSIMD_VERSION "6842624" CACHE STRING "Version of xsimd to use") # this commit fixes gcc-10 for now
+set(XSIMD_VERSION "14.3.0" CACHE STRING "Version of xsimd to use")
 set(POET_VERSION "v0.0.0" CACHE STRING "Version of POET to use")
 set(DUCC0_VERSION "ducc0_0_39_1" CACHE STRING "Version of ducc0 to use")
 set(CUDA11_CCCL_VERSION "2.8.5" CACHE STRING "Version of FINUFFT-cccl for cuda 11 to use")

--- a/cmake/setupDUCC.cmake
+++ b/cmake/setupDUCC.cmake
@@ -23,7 +23,7 @@ if(ducc0_ADDED)
     # consumers of an installed (static) finufft never do (the public API is plain
     # C). Wrapping in BUILD_INTERFACE keeps the absolute source path out of the
     # exported interface so ducc0 can be part of finufftTargets and stay relocatable.
-    target_include_directories(ducc0 PUBLIC $<BUILD_INTERFACE:${ducc0_SOURCE_DIR}/src/>)
+    target_include_directories(ducc0 SYSTEM PUBLIC $<BUILD_INTERFACE:${ducc0_SOURCE_DIR}/src/>)
     target_compile_options(ducc0 PRIVATE $<$<CONFIG:Release,RelWithDebInfo>:${FINUFFT_ARCH_FLAGS}>)
     target_compile_options(ducc0 PRIVATE $<$<CONFIG:Release>:${FINUFFT_CXX_FLAGS_RELEASE}>)
     target_compile_options(ducc0 PRIVATE $<$<CONFIG:RelWithDebInfo>:${FINUFFT_CXX_FLAGS_RELWITHDEBINFO}>)

--- a/cmake/setupXSIMD.cmake
+++ b/cmake/setupXSIMD.cmake
@@ -7,6 +7,8 @@ CPMAddPackage(
     ${XSIMD_VERSION}
     EXCLUDE_FROM_ALL
     YES
+    SYSTEM
+    YES
     GIT_SHALLOW
     NO
     OPTIONS

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -90,6 +90,9 @@ if(FINUFFT_BUILD_FORTRAN)
 endif()
 
 # ---- Sanitizers ---------------------------------------------------------------
+# TODO: drop the -O1 below (revert to Debug -O0) once xsimd > 14.3.0 ships the fix
+# for the constexpr immediate-argument folding (xsimd_avx_128.hpp "last argument
+# must be an 8-bit immediate" at -O0). -O1 is only here to work around that.
 set(FINUFFT_SANITIZER_FLAGS)
 string(TOUPPER "${FINUFFT_USE_SANITIZERS}" FINUFFT_USE_SANITIZERS_MODE)
 if(FINUFFT_USE_SANITIZERS_MODE STREQUAL "OFF")
@@ -98,11 +101,13 @@ elseif(FINUFFT_USE_SANITIZERS_MODE STREQUAL "ON" OR FINUFFT_USE_SANITIZERS_MODE 
         -fsanitize=address
         -fsanitize=undefined
         -fsanitize=bounds-strict
+        -O1
+        -fno-omit-frame-pointer
         /fsanitize=address
         /RTC1
     )
 elseif(FINUFFT_USE_SANITIZERS_MODE STREQUAL "TSAN")
-    set(FINUFFT_SANITIZER_FLAGS -fsanitize=thread)
+    set(FINUFFT_SANITIZER_FLAGS -fsanitize=thread -O1 -fno-omit-frame-pointer)
 else()
     message(
         FATAL_ERROR

--- a/include/finufft/interp.hpp
+++ b/include/finufft/interp.hpp
@@ -109,29 +109,15 @@ void interp_line(T *FINUFFT_RESTRICT target, const T *du, const T *ker, BIGINT i
         res_low            = xsimd::fma(ker0low, du_pt, res_low);
       }
 
-      // This does a horizontal sum using a loop instead of relying on SIMD instructions
-      // this is faster than the code below but less elegant.
-      // lambdas here to limit the scope of temporary variables and have the compiler
+      // lambda here to limit the scope of temporary variables and have the compiler
       // optimize the code better
       return res_low + res_hi;
     }();
-    const auto res_array = xsimd_to_array(res);
-    for (uint8_t i{0}; i < simd_size; i += 2) {
-      out[0] += res_array[i];
-      out[1] += res_array[i + 1];
-    }
-    // this is where the code differs from spread_kernel, the interpolator does an extra
-    // reduction step to SIMD elements down to 2 elements
-    // This is known as horizontal sum in SIMD terminology
-
-    // This does a horizontal sum using vector instruction,
-    // is slower than summing and looping
-    // clang-format off
-    // const auto res_real = xsimd::shuffle(res_low, res_hi, select_even_mask<arch_t>);
-    // const auto res_imag = xsimd::shuffle(res_low, res_hi, select_odd_mask<arch_t>);
-    // out[0]              = xsimd::reduce_add(res_real);
-    // out[1]              = xsimd::reduce_add(res_imag);
-    // clang-format on
+    // interpolator does an extra horizontal-sum step reducing the SIMD
+    // accumulator down to a single {re, im} pair (see complex_hadd).
+    const auto c = complex_hadd(res);
+    out[0] += c[0];
+    out[1] += c[1];
   }
   target[0] = out[0];
   target[1] = out[1];
@@ -273,11 +259,9 @@ void interp_square(T *FINUFFT_RESTRICT target, const T *du, const T *ker1,
       }
       return res_low + res_hi;
     }();
-    const auto res_array = xsimd_to_array(res);
-    for (uint8_t i{0}; i < simd_size; i += 2) {
-      out[0] += res_array[i];
-      out[1] += res_array[i + 1];
-    }
+    const auto c = complex_hadd(res);
+    out[0] += c[0];
+    out[1] += c[1];
   } else {
     // wraps somewhere: use ptr list
     // this is slower than above, but occurs much less often, with fractional
@@ -443,11 +427,9 @@ void interp_cube(T *FINUFFT_RESTRICT target, const T *du, const T *ker1,
       }
       return res_low + res_hi;
     }();
-    const auto res_array = xsimd_to_array(res);
-    for (uint8_t i{0}; i < simd_size; i += 2) {
-      out[0] += res_array[i];
-      out[1] += res_array[i + 1];
-    }
+    const auto c = complex_hadd(res);
+    out[0] += c[0];
+    out[1] += c[1];
   } else {
     return interp_cube_wrapped<T, ns, simd_type>(target, du, ker1, ker2, ker3, i1, i2, i3,
                                                  N1, N2, N3);
@@ -475,8 +457,7 @@ FINUFFT_NEVER_INLINE int FINUFFT_PLAN_T<TF>::interpSorted_kernel(
   using namespace finufft::spreadinterp;
   using finufft::utils::CNTime;
   using KBL                                      = KernelBufferLayout<TF, NS>;
-  using simd_type                                = typename KBL::simd_type;
-  using arch_t                                   = typename KBL::arch_t;
+  using simd_type = typename KBL::simd_type;
   static constexpr auto alignment                = KBL::alignment;
   static constexpr auto simd_size                = KBL::simd_size;
   static constexpr auto ns2          = NS * TF(0.5);

--- a/include/finufft/simd.hpp
+++ b/include/finufft/simd.hpp
@@ -270,6 +270,29 @@ template<typename T> FINUFFT_ALWAYS_INLINE auto xsimd_to_array(const T &vec) noe
   return array;
 }
 
+// Horizontal sum of an interleaved {re,im,re,im,...} accumulator down to one
+// {re, im} pair. Folds the register in halves via memory, halving lane count
+// each step, until a scalar tail sum. Cheaper than the lane-by-lane loop.
+template<typename simd_type>
+FINUFFT_ALWAYS_INLINE std::array<typename simd_type::value_type, 2> complex_hadd(
+    const simd_type &res) noexcept {
+  using T = typename simd_type::value_type;
+  using half_t = xsimd::make_sized_batch_t<T, simd_type::size / 2>;
+  alignas(simd_type::arch_type::alignment()) std::array<T, simd_type::size> buf;
+  res.store_aligned(buf.data());
+  if constexpr (simd_type::size > 2 && !std::is_void_v<half_t>) {
+    return complex_hadd(half_t::load_aligned(buf.data()) +
+                        half_t::load_aligned(buf.data() + simd_type::size / 2));
+  } else {
+    std::array<T, 2> out{0, 0};
+    for (std::size_t i{0}; i < simd_type::size; i += 2) {
+      out[0] += buf[i];
+      out[1] += buf[i + 1];
+    }
+    return out;
+  }
+}
+
 // Forward declarations (defined in src/utils.cpp):
 FINUFFT_NEVER_INLINE void print_subgrid_info(
     int ndims, BIGINT offset1, BIGINT offset2, BIGINT offset3, UBIGINT padded_size1,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(finufft_f32 OBJECT ${FINUFFT_PRECISION_SOURCES})
 target_compile_definitions(finufft_f32 PRIVATE FINUFFT_SINGLE)
 finufft_apply_compile_settings(finufft_f32)
 enable_static_analysis(finufft_f32)
+enable_asan(finufft_f32)
 
 # Main library: double-precision precision sources + common sources + f32 objects
 set(FINUFFT_SOURCES ${FINUFFT_PRECISION_SOURCES} ${FINUFFT_COMMON_SOURCES})


### PR DESCRIPTION
Move off the gcc-10 workaround pin (6842624) to the 14.3.0 release tag
from xtensor-stack. Tweaks complex horizontal add for interp. Perf neutral to slight improvement on some architectures