### PR TITLE
perf: analytic PSWF self-FT for type-3 deconv; drop non-prolate kernels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,14 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 v2.6.0-dev
 
+* The spread/interp kernel is now PSWF (prolate) only: opts.spread_kerformula
+  takes 0 (default) or 7,8,9 (PSWF shape-parameter choices); the legacy ES (1,2),
+  Kaiser-Bessel (3,4) and cosh-type (5,6) formulas are removed and now return
+  FINUFFT_ERR_KERFORMULA_NOTVALID. Since the order-0 PSWF is an eigenfunction of
+  the finite Fourier transform, type 3 gets its kernel FT as a rescaled copy of
+  the kernel, replacing the per-target cosine quadrature in setpts. Users of
+  spreadinterp_only now always see the PSWF kernel (consulted in discussion
+  #881). (Barbone, Barnett #879)
 * Fixed the cuFINUFFT build against a CPM-fetched CCCL: it was added as an
   include-SYSTEM package, and nvcc searches its own include directory before
   every `-isystem` path, so `cuda/std/*` resolved to the CUDA toolkit's older

--- a/devel/check_pswf_selfft.cpp
+++ b/devel/check_pswf_selfft.cpp
@@ -1,0 +1,121 @@
+/* Checks the analytic PSWF self-FT used by type-3 deconv (kernel.h:
+   pswf_selfft_params) against brute-force integration of the same piecewise
+   polynomial, over the reachable (kerformula, upsampfac, nspread) space.
+
+   phihat(xi) = prefac * phi(grid_scale*xi), phi the Horner approximant of the
+   kernel in grid units. Three things can break, and each gets its own check:
+
+   1) prefac == int phi dx: pure arithmetic on the panel coeffs (parity, stride,
+      degree indexing), so it must hold to machine precision.
+   2) the identity at xi != 0: exact for the true PSWF, so the error here is the
+      approximant's, not the formula's. Compared against the kernel's own error
+      scale tolfac*exp(-(ns-1)*pi*sqrt(1-1/sigma)).
+   3) support: the identity needs |xi| <= 2*beta/nspread, while deconv evaluates
+      up to |xi| = pi/upsampfac. Outside the support phi is 0, which would make
+      deconv infinite, so the margin must stay positive.
+
+   Not in CI; run by hand after touching the kernel shape formulas or the Horner
+   coefficient layout, from the repo root:
+
+   g++ -O2 -std=c++17 -Iinclude devel/check_pswf_selfft.cpp src/common/kernel.cpp \
+       src/common/pswf.cpp src/common/utils.cpp -o /tmp/check_pswf_selfft
+
+   Currently PASSES with min margin 0.473, max prefac_err 3.3e-15, and ft_err at
+   worst 0.37 of the kernel error scale. Barbone.
+*/
+#include <cmath>
+#include <cstdio>
+#include <finufft_common/kernel.h>
+#include <finufft_common/utils.h>
+#include <vector>
+
+using namespace finufft::kernel;
+using finufft::common::gaussquad;
+using finufft::common::PI;
+
+// Panel coeffs exactly as precompute_horner_coeffs lays them out, but with
+// stride = ns (no SIMD padding, which pswf_selfft_params takes as an argument).
+static std::vector<double> fit_panels(const finufft_spread_opts &so, int nc) {
+  const int ns = so.nspread;
+  auto ker = kernel_definition_lambda(so);
+  std::vector<double> c(size_t(nc) * ns);
+  for (int j = 0; j < ns; ++j) {
+    const double shift = 2 * j + 1 - ns;
+    auto panel = poly_fit<double>([&](double x) { return ker((x + shift) / ns); }, nc);
+    for (int k = 0; k < nc; ++k) c[size_t(k) * ns + j] = panel[k];
+  }
+  return c;
+}
+
+// phi(x), x in grid units, from the panel coeffs (mirrors evaluate_kernel_runtime)
+static double eval_phi(const std::vector<double> &c, int ns, int nc, double x) {
+  const double ns2 = ns / 2.0;
+  for (int i = 0; i < ns; ++i)
+    if (x > -ns2 + i && x <= -ns2 + i + 1) {
+      const double z = 2 * (x - i) + (ns - 1);
+      double r = 0;
+      for (int k = 0; k < nc; ++k) r = r * z + c[size_t(k) * ns + i];
+      return r;
+    }
+  return 0;
+}
+
+// int_{-ns/2}^{ns/2} phi(x) cos(xi.x) dx by per-panel Gauss (exact at xi=0; the
+// rule must be per-panel, a global one would straddle the panel kinks)
+static double phihat_quad(const std::vector<double> &c, int ns, int nc, double xi) {
+  constexpr int NQ = 32;
+  double z[NQ], w[NQ];
+  gaussquad(NQ, z, w);
+  double sum = 0;
+  for (int i = 0; i < ns; ++i) {
+    const double xc = -ns / 2.0 + i + 0.5;
+    for (int n = 0; n < NQ; ++n) {
+      const double x = xc + 0.5 * z[n];
+      sum += 0.5 * w[n] * eval_phi(c, ns, nc, x) * std::cos(xi * x);
+    }
+  }
+  return sum;
+}
+
+int main() {
+  int fails = 0;
+  printf("%3s %3s %5s %8s %10s %10s %10s %10s\n", "kf", "ns", "sigma", "margin",
+         "prefac_err", "ft_err", "ker_err", "ratio");
+  for (int kf : {7, 8, 9})
+    for (double sigma : {1.1, 1.25, 1.5, 2.0, 3.0})
+      for (int ns = 2; ns <= 16; ++ns) {
+        finufft_spread_opts so{};
+        so.nspread = ns, so.upsampfac = sigma, so.kerformula = kf;
+        set_kernel_shape_given_ns(so, 0);
+        const int nc = max_nc_given_ns(ns);
+        const auto c = fit_panels(so, nc);
+        const auto [grid_scale, prefac] =
+            pswf_selfft_params(ns, so.beta, c.data(), nc, ns);
+
+        // (1) prefac == phihat(0)
+        const double p_err = std::abs(prefac - phihat_quad(c, ns, nc, 0)) / prefac;
+        // (3) support margin: phi(grid_scale*xi) is 0 beyond grid_scale*xi = ns/2,
+        // ie beyond |xi| = 2*beta/nspread; deconv evaluates up to |xi| = pi/sigma
+        const double ximax = PI / sigma, margin = (ns / 2.0) / grid_scale - ximax;
+        // (2) identity away from 0, relative to phihat(0) (deconv divides by phihat,
+        // so the absolute error at large xi is what pollutes the result)
+        double ft_err = 0;
+        for (int m = 1; m <= 32; ++m) {
+          const double xi = ximax * m / 32.0;
+          ft_err =
+              std::max(ft_err, std::abs(prefac * eval_phi(c, ns, nc, xi * grid_scale) -
+                                        phihat_quad(c, ns, nc, xi)) /
+                                   prefac);
+        }
+        // kernel error scale, floored at double roundoff (ft_err cannot beat it)
+        const double ker_err = std::max(
+            kernel_tolfac(1, 3) * std::exp(-(ns - 1) * PI * std::sqrt(1 - 1 / sigma)),
+            1e-14);
+        printf("%3d %3d %5.2f %8.3f %10.2e %10.2e %10.2e %10.2f%s\n", kf, ns, sigma,
+               margin, p_err, ft_err, ker_err, ft_err / ker_err,
+               (p_err > 1e-13 || margin <= 0 || ft_err > 10 * ker_err) ? "  FAIL" : "");
+        fails += (p_err > 1e-13) + (margin <= 0) + (ft_err > 10 * ker_err);
+      }
+  printf("%s (%d failure(s))\n", fails ? "FAILED" : "PASSED", fails);
+  return fails != 0;
+}

--- a/docs/opts.rst
+++ b/docs/opts.rst
@@ -200,7 +200,7 @@ Here ``0`` makes an automatic choice. If you are unhappy with this, then for sma
 
 **spread_max_sp_size**: if positive, overrides the maximum subproblem (chunking) size for multithreaded spreading (type 1 transforms). Otherwise the default in the spreader is used, set in ``src/spreadinterp.cpp:setup_spreader()``, which we believe is a decent heuristic for Intel i7 and xeon machines.
 
-**spread_kerformula**: ``0`` uses default spreading (gridding) kernel with default shape choice, whereas positive integers select among various kernels and shape parameter choices. In particular ``1`` returns to the "legacy ES" choices used from the first 2017 code to v2.4.1 (2025). Only developers should mess with this parameter; users should leave it at default.
+**spread_kerformula**: ``0`` uses the default spreading (gridding) kernel with default shape choice; ``7``, ``8`` and ``9`` select among shape parameter choices for it. As of v2.6.0 the prolate spheroidal wavefunction (PSWF) is the only kernel: the legacy ES, Kaiser--Bessel and cosh-type formulas (``1``--``6``, available up to v2.5.0) have been removed and now return an error. Only developers should mess with this parameter; users should leave it at default.
 
 **spread_kerevalmeth**: [DEPRECATED] Kernel evaluation method in spreader/interpolator; retained only for API compatibility and documentation. The library now always uses the Horner piecewise-polynomial evaluation internally (the historical ``=1`` choice). Setting this field has no effect.
 

--- a/include/finufft/plan.hpp
+++ b/include/finufft/plan.hpp
@@ -233,18 +233,18 @@ private:
   std::vector<int> gridsize_for_fft() const;
   void do_fft(TC *fwBatch, int ntrans_actual, bool adjoint) const;
 
-  // Precomputed quadrature-based 1D kernel FT evaluator (used by type-3 setpts).
-  // Nested class: has access to plan's private members via implicit friendship.
+  // Analytic PSWF self-FT 1D kernel FT evaluator, one Horner eval per target
+  // (used by type-3 setpts). See finufft::kernel::pswf_selfft_params for the
+  // identity. Nested class: accesses plan's private members via friendship.
   class Kernel_onedim_FT {
-    std::vector<TF> z, f;
+    const FINUFFT_PLAN_T *plan_ptr = nullptr;
+    TF grid_scale = 0;
+    TF prefac = 0;
 
   public:
     Kernel_onedim_FT(const FINUFFT_PLAN_T &plan);
     FINUFFT_ALWAYS_INLINE TF operator()(TF k) const {
-      TF x = 0;
-      for (size_t n = 0; n < z.size(); ++n)
-        x += f[n] * 2 * std::cos(k * z[n]); // pos & neg freq pair
-      return x;
+      return prefac * plan_ptr->evaluate_kernel_runtime(k * grid_scale);
     }
   };
 

--- a/include/finufft/spreadinterp.hpp
+++ b/include/finufft/spreadinterp.hpp
@@ -94,40 +94,27 @@ TF FINUFFT_PLAN_T<TF>::evaluate_kernel_runtime(TF x) const
 }
 
 /*
-  Approximates exact 1D Fourier transform of spreadinterp's real symmetric
-  kernel, directly via q-node quadrature on Euler-Fourier formula, exploiting
-  narrowness of kernel. Evaluates at set of arbitrary freqs k in [-pi, pi),
-  for a kernel with x measured in grid-spacings. (See onedim_fseries_kernel
-  for FT definition.) Note: old (pre-2025) name was: onedim_nuft_kernel().
+  1D Fourier transform of spreadinterp's real symmetric kernel, evaluated at a
+  set of arbitrary freqs k in [-pi, pi), for a kernel with x measured in
+  grid-spacings. (See onedim_fseries_kernel for FT definition.) Uses the
+  analytic PSWF self-FT (one Horner eval per freq; see pswf_selfft_params), the
+  prolate being an eigenfunction of the finite FT. Old name: onedim_nuft_kernel.
 
-  operator()(k) evaluates the Fourier transform of the kernel at a single
-  frequency k, using the z and f arrays from creation time.
+  operator()(k) returns the kernel FT phihat at a single frequency k.
     Input: k - frequency, dual to the kernel's natural argument, ie exp(i.k.z)
     Output: phihat - real Fourier transform evaluated at freq k
 
-  Barnett 2/8/17. openmp since cos slow 2/9/17.
-  11/25/25, replaced kernel_definition by evaluate_kernel_runtime, so that
-  the FT of the piecewise poly approximant (not "exact" kernel) is computed.
-  Converted to nested class of FINUFFT_PLAN_T, Barbone 2/24/26.
-  Previous constructor args (spopts, horner_coeffs_ptr, nc) are now read from
-  the plan reference.
+  Barnett 2/8/17. Converted to nested class, Barbone 2/24/26.
+  Analytic PSWF self-FT replacing per-point cosine quadrature, Barbone 7/23/26.
 */
 template<typename TF>
-FINUFFT_PLAN_T<TF>::Kernel_onedim_FT::Kernel_onedim_FT(const FINUFFT_PLAN_T &plan) {
-  // Creator: uses slow kernel evals to initialize z and f arrays.
-  using finufft::common::gaussquad;
-  TF J2 = plan.m.spopts.nspread / 2.0; // J/2, half-width of ker z-support
-  // # quadr nodes in z (from 0 to J/2; reflections will be added)...
-  int q = (int)(2 + 2.0 * J2); // > pi/2 ratio.  cannot exceed MAX_NQUAD
-  if (plan.m.spopts.debug) printf("q (# ker FT quadr pts) = %d\n", q);
-  std::vector<double> Z(2 * q), W(2 * q);
-  gaussquad(2 * q, Z.data(), W.data()); // only half the nodes used, for (0,1)
-  z.resize(q);
-  f.resize(q);
-  for (int n = 0; n < q; ++n) {
-    z[n] = TF(Z[n] * J2); // quadr nodes for [0,J/2] with weights J2 * w
-    f[n] = J2 * TF(W[n]) * plan.evaluate_kernel_runtime(z[n]);
-  }
+FINUFFT_PLAN_T<TF>::Kernel_onedim_FT::Kernel_onedim_FT(const FINUFFT_PLAN_T &plan)
+    : plan_ptr(&plan) {
+  const auto [gs, pf] = finufft::kernel::pswf_selfft_params(
+      plan.m.spopts.nspread, plan.m.spopts.beta, plan.m.horner_coeffs.data(), plan.m.nc,
+      int(plan.m.padded_ns));
+  grid_scale = TF(gs);
+  prefac = TF(pf);
 }
 
 template<typename TF>

--- a/include/finufft/spreadinterp.hpp
+++ b/include/finufft/spreadinterp.hpp
@@ -94,40 +94,26 @@ TF FINUFFT_PLAN_T<TF>::evaluate_kernel_runtime(TF x) const
 }
 
 /*
-  Approximates exact 1D Fourier transform of spreadinterp's real symmetric
-  kernel, directly via q-node quadrature on Euler-Fourier formula, exploiting
-  narrowness of kernel. Evaluates at set of arbitrary freqs k in [-pi, pi),
-  for a kernel with x measured in grid-spacings. (See onedim_fseries_kernel
-  for FT definition.) Note: old (pre-2025) name was: onedim_nuft_kernel().
+  1D Fourier transform of spreadinterp's real symmetric kernel, evaluated at a
+  set of arbitrary freqs k in [-pi, pi), for a kernel with x measured in
+  grid-spacings. (See onedim_fseries_kernel for FT definition.) Uses the
+  analytic PSWF self-FT (one Horner eval per freq; see pswf_selfft_params), the
+  prolate being an eigenfunction of the finite FT. Old name: onedim_nuft_kernel.
 
-  operator()(k) evaluates the Fourier transform of the kernel at a single
-  frequency k, using the z and f arrays from creation time.
+  operator()(k) returns the kernel FT phihat at a single frequency k.
     Input: k - frequency, dual to the kernel's natural argument, ie exp(i.k.z)
     Output: phihat - real Fourier transform evaluated at freq k
 
-  Barnett 2/8/17. openmp since cos slow 2/9/17.
-  11/25/25, replaced kernel_definition by evaluate_kernel_runtime, so that
-  the FT of the piecewise poly approximant (not "exact" kernel) is computed.
-  Converted to nested class of FINUFFT_PLAN_T, Barbone 2/24/26.
-  Previous constructor args (spopts, horner_coeffs_ptr, nc) are now read from
-  the plan reference.
+  Barnett 2/8/17. Converted to nested class, Barbone 2/24/26.
+  Analytic PSWF self-FT replacing per-point cosine quadrature, Barbone 7/23/26.
 */
 template<typename TF>
-FINUFFT_PLAN_T<TF>::Kernel_onedim_FT::Kernel_onedim_FT(const FINUFFT_PLAN_T &plan) {
-  // Creator: uses slow kernel evals to initialize z and f arrays.
-  using finufft::common::gaussquad;
-  TF J2 = plan.m.spopts.nspread / 2.0; // J/2, half-width of ker z-support
-  // # quadr nodes in z (from 0 to J/2; reflections will be added)...
-  int q = (int)(2 + 2.0 * J2); // > pi/2 ratio.  cannot exceed MAX_NQUAD
-  if (plan.m.spopts.debug) printf("q (# ker FT quadr pts) = %d\n", q);
-  std::vector<double> Z(2 * q), W(2 * q);
-  gaussquad(2 * q, Z.data(), W.data()); // only half the nodes used, for (0,1)
-  z.resize(q);
-  f.resize(q);
-  for (int n = 0; n < q; ++n) {
-    z[n] = TF(Z[n] * J2); // quadr nodes for [0,J/2] with weights J2 * w
-    f[n] = J2 * TF(W[n]) * plan.evaluate_kernel_runtime(z[n]);
-  }
+FINUFFT_PLAN_T<TF>::Kernel_onedim_FT::Kernel_onedim_FT(const FINUFFT_PLAN_T &plan)
+    : plan_ptr(&plan) {
+  const auto [gs, pf] =
+      finufft::kernel::pswf_selfft_params(plan.m.spopts.nspread, plan.m.spopts.beta);
+  grid_scale = TF(gs);
+  prefac = TF(pf);
 }
 
 template<typename TF>

--- a/include/finufft_common/kernel.h
+++ b/include/finufft_common/kernel.h
@@ -96,6 +96,15 @@ template<class TF> inline int clamp_kernel_ns(int ns, double upsampfac) {
 
 void set_kernel_shape_given_ns(finufft_spread_opts &opts, int debug);
 
+// Analytic PSWF self-FT parameters. The order-0 PSWF is an eigenfunction of the
+// finite Fourier transform, so the kernel's continuous FT is a rescaled copy of the
+// kernel itself: phihat(xi) = prefac * phi(grid_scale*xi), with phi the Horner
+// approximant (evaluate_kernel_runtime, grid-unit arg), grid_scale = J2^2/beta,
+// prefac = J2*mu0, J2 = nspread/2, mu0 = int_{-1}^{1} PSWF0(beta,t) dt. Returns
+// (grid_scale, prefac). Used by the type-3 per-target evaluator (Kernel_onedim_FT);
+// type-1/2 fseries keeps quadrature. GPU-reusable. Defined in src/common/kernel.cpp.
+std::tuple<double, double> pswf_selfft_params(int nspread, double beta);
+
 // min and max number of poly coeffs allowed (compiled) for a given spread width ns.
 // Since for low upsampfacs, ns=16 can need only nc~12, allow such low nc here.
 // Note: spreadinterp.cpp compilation time grows with the gap between these bounds...

--- a/include/finufft_common/kernel.h
+++ b/include/finufft_common/kernel.h
@@ -96,6 +96,32 @@ template<class TF> inline int clamp_kernel_ns(int ns, double upsampfac) {
 
 void set_kernel_shape_given_ns(finufft_spread_opts &opts, int debug);
 
+// Analytic PSWF self-FT parameters. The order-0 PSWF is an eigenfunction of the
+// finite Fourier transform, so the kernel's continuous FT is a rescaled copy of the
+// kernel itself: phihat(xi) = prefac * phi(grid_scale*xi), with phi the Horner
+// approximant (evaluate_kernel_runtime, grid-unit arg), grid_scale = J2^2/beta,
+// J2 = nspread/2, and prefac = phihat(0) = int phi dx (as phi(0)=1). That integral
+// is closed-form from the panel coeffs: on panel i, phi = sum_j coeffs[j*stride+i]
+// z^(nc-1-j), z in [-1,1], dz = 2dx, so odd powers cancel and the whole setup is
+// ~ns.nc/2 flops, no quadrature. Integrating the approximant rather than the exact
+// PSWF makes phihat the FT of the function actually spread. Valid only inside the
+// kernel support, |xi| <= 1/grid_scale = 2.beta/nspread; type-3 deconv evaluates at
+// |xi| <= pi/upsampfac (= h.gam.S, setpts), and over every reachable (tol, dim,
+// precision, upsampfac >= 1.1) the margin 2.beta/nspread - pi/upsampfac is >= 0.47
+// for kerformula 7-9. Returns (grid_scale, prefac). Used by the type-3 per-target
+// evaluator (Kernel_onedim_FT); type-1/2 fseries keeps quadrature. GPU-reusable.
+// Barbone 7/23/26.
+template<class TF>
+inline std::tuple<double, double> pswf_selfft_params(
+    int nspread, double beta, const TF *coeffs, int nc, int stride) {
+  double prefac = 0;
+  for (int i = 0; i < nspread; ++i)
+    for (int j = nc - 1; j >= 0; j -= 2) // even powers of z only
+      prefac += double(coeffs[j * stride + i]) / (nc - j);
+  const double J2 = nspread / 2.0; // half-width of kernel z-support
+  return {J2 * J2 / beta, prefac};
+}
+
 // min and max number of poly coeffs allowed (compiled) for a given spread width ns.
 // Since for low upsampfacs, ns=16 can need only nc~12, allow such low nc here.
 // Note: spreadinterp.cpp compilation time grows with the gap between these bounds...

--- a/matlab/test/wsweepkerrcomp.m
+++ b/matlab/test/wsweepkerrcomp.m
@@ -23,8 +23,8 @@ sigma = 1.25;
 tolsperdecade = 10;
 tolstep = 10 ^ (-1 / tolsperdecade); % multiplicative step in tol, < 1
 % following names must match src/finufft_common/kernel.h:
-kfnam = {"ES legacy", "ES Beatty", "KB Beatty", "cont-KB Beatty", "cosh-type Bea", "cont cosh Bea", "PSWF Beatty", "PSWF beta-shift", "PSWF Marco"};
-kfs = [1 8];       % kernel formulae to test
+kfnam = {"", "", "", "", "", "", "PSWF Beatty", "PSWF beta-shift", "PSWF Marco"};
+kfs = [7 8 9];     % kernel formulae to test (1-6 removed in v2.6.0)
 
 o.upsampfac = sigma;
 %o.debug = 1;

--- a/perftest/perftest.cpp
+++ b/perftest/perftest.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <getopt.h>
 
@@ -117,42 +118,31 @@ struct Timer {
 
   void stop() { stop_.emplace_back(std::chrono::steady_clock::now()); }
 
+  // fractional ms: an integer-ms cast rounds every sub-ms event (small type-3
+  // setpts, small execute) down to zero.
+  float dt(size_t i) const {
+    return std::chrono::duration<float, std::milli>(stop_[i] - start_[i]).count();
+  }
+
   float mean() { return this->tot() / start_.size(); }
 
   float min() {
     float min_dt = std::numeric_limits<float>::max();
-    for (size_t i = 0; i < start_.size(); ++i) {
-      auto dt = float(
-          std::chrono::duration_cast<std::chrono::milliseconds>(stop_[i] - start_[i])
-              .count());
-      if (dt < min_dt) {
-        min_dt = dt;
-      }
-    }
+    for (size_t i = 0; i < start_.size(); ++i) min_dt = std::min(min_dt, dt(i));
     return min_dt;
   }
 
   float std() {
     float avg  = this->mean();
     double var = 0.0;
-    for (size_t i = 0; i < start_.size(); ++i) {
-      auto dt = float(
-          std::chrono::duration_cast<std::chrono::milliseconds>(stop_[i] - start_[i])
-              .count());
-      var += (dt - avg) * (dt - avg);
-    }
+    for (size_t i = 0; i < start_.size(); ++i) var += (dt(i) - avg) * (dt(i) - avg);
     var /= float(start_.size());
     return std::sqrt(var);
   }
 
   float tot() {
     float dt_tot = 0.0;
-    for (size_t i = 0; i < start_.size(); ++i) {
-      auto dt = float(
-          std::chrono::duration_cast<std::chrono::milliseconds>(stop_[i] - start_[i])
-              .count());
-      dt_tot += dt;
-    }
+    for (size_t i = 0; i < start_.size(); ++i) dt_tot += dt(i);
     return dt_tot;
   }
 

--- a/perftest/spreadtestnd.cpp
+++ b/perftest/spreadtestnd.cpp
@@ -35,7 +35,7 @@ static void usage() {
     "\ttol=requested accuracy\n"
     "\tsort=0 (no), 1 (yes), 2 (auto; default)\n"
     "\tspread_debug=0,1,...\n"
-    "\tspread_kerformula=0,1,... spread kernel type (>0 only for devs)\n"
+    "\tspread_kerformula=0 (default), 7,8,9 PSWF beta choice (only for devs)\n"
     "\tupsampfac>1.0: sigma upsampling factor (typ range 1.2 to 2.5)\n"
     "\nexample: ./spreadtestnd 3 8e6 8e6 1e-6 2 0 0 1.5\n");
 }

--- a/python/test/wsweepkerrcomp.py
+++ b/python/test/wsweepkerrcomp.py
@@ -6,6 +6,7 @@ This script uses erralltypedim.py for the core error computations and calls the
 FINUFFT Python bindings to measure kernel support via spreadinterponly for each
 kernel formula, producing a figure saved under results/.
 """
+
 from __future__ import annotations
 
 import math
@@ -30,11 +31,19 @@ def main() -> None:
     import argparse
 
     p = argparse.ArgumentParser(description="Kernel-width sweep")
-    p.add_argument("--sigma", type=float, default=2.00, help="upsampling factor (sigma)")
-    p.add_argument("--dim", type=int, default=1, choices=[1, 2, 3], help="dimension to test")
-    p.add_argument("--M", type=int, default=1000, help="number of nonuniform points (M)")
+    p.add_argument(
+        "--sigma", type=float, default=2.00, help="upsampling factor (sigma)"
+    )
+    p.add_argument(
+        "--dim", type=int, default=1, choices=[1, 2, 3], help="dimension to test"
+    )
+    p.add_argument(
+        "--M", type=int, default=1000, help="number of nonuniform points (M)"
+    )
     p.add_argument("--Ntot", type=int, default=300, help="total number of modes (Ntot)")
-    p.add_argument("--ntr", type=int, default=10, help="# transforms to average per tol (ntr)")
+    p.add_argument(
+        "--ntr", type=int, default=10, help="# transforms to average per tol (ntr)"
+    )
     args = p.parse_args()
 
     prec = "double"
@@ -47,8 +56,9 @@ def main() -> None:
     sigma = float(args.sigma)
     tolsperdecade = 8
     tolstep = 10 ** (-1 / tolsperdecade)
-    kfnam = ["ES legacy", "ES Beatty", "KB Beatty", "cont-KB Beatty", "cosh-type", "smoothed cont-KB"]
-    kfs = list(range(1, len(kfnam) + 1))
+    # kerformula 1-6 (ES/KB/cosh) were removed in v2.6.0; PSWF betas only
+    kfnam = {7: "PSWF Beatty", 8: "PSWF beta-shift", 9: "PSWF Marco"}
+    kfs = sorted(kfnam)
 
     o = {"upsampfac": sigma, "showwarn": False, "allow_eps_too_small": 1}
     dims = [False, False, False]
@@ -148,7 +158,7 @@ def main() -> None:
                 elinewidth=0.6,
                 capsize=2,
             )
-            legs.append(f"kf={kfs[i]}: {kfnam[i]}")
+            legs.append(f"kf={kfs[i]}: {kfnam[kfs[i]]}")
         ax.set_yscale("log")
         ax.set_xlim(2, wmax)
         if np.isfinite(min_err) and np.isfinite(max_err):
@@ -157,16 +167,12 @@ def main() -> None:
         ax.set_ylabel("mean rel err")
         if legs:
             ax.legend(legs)
-        ax.set_title(
-            f"{dim}D type {y + 1} {prec}, N_tot={Ntot}, σ={sigma}", pad=6
-        )
+        ax.set_title(f"{dim}D type {y + 1} {prec}, N_tot={Ntot}, σ={sigma}", pad=6)
         ax.tick_params(axis="both", which="both", width=0.5, length=4)
         ax.set_facecolor("white")
 
     plt.tight_layout()
-    outfile = os.path.join(
-        results_dir, f"wsweepkerrcomp_{dim}D_{prec}_sig{sigma}.png"
-    )
+    outfile = os.path.join(results_dir, f"wsweepkerrcomp_{dim}D_{prec}_sig{sigma}.png")
     fig.savefig(outfile)
     print(f"Saved {outfile}")
 

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -5,7 +5,6 @@
 #include <finufft_common/safe_call.h>
 #include <finufft_common/spread_opts.h>
 #include <finufft_errors.h>
-#include <limits>
 
 // this module uses finufft_spread_opts but does not know about FINUFFT_PLAN class
 // nor finufft_opts. This allows it to be used by CPU & GPU.
@@ -42,42 +41,7 @@ std::function<double(double)> kernel_definition_lambda(
   double beta = spopts.beta; // get shape param
   int kf      = spopts.kerformula;
 
-  if (kf == 1 || kf == 2) {
-    // ES ("exponential of semicircle" or "exp sqrt"), see [FIN] reference.
-    // Used in FINUFFT 2017-2025 (up to v2.4.1). max is 1, as of v2.3.0.
-    const double expbeta = std::exp(beta);
-    return [beta, expbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return std::exp(beta * std::sqrt(1.0 - z * z)) / expbeta;
-    };
-  } else if (kf == 3) {
-    // forwards Kaiser--Bessel (KB), normalized to max of 1.
-    // std::cyl_bessel_i is from <cmath>, expects double. See src/common/utils.cpp
-    const double besselbeta = common::cyl_bessel_i(0, beta);
-    return [beta, besselbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return common::cyl_bessel_i(0, beta * std::sqrt(1.0 - z * z)) / besselbeta;
-    };
-  } else if (kf == 4) {
-    // continuous (deplinthed) KB, as in Barnett SIREV 2022, normalized to max nearly 1
-    const double besselbeta = common::cyl_bessel_i(0, beta);
-    return [beta, besselbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return (common::cyl_bessel_i(0, beta * std::sqrt(1.0 - z * z)) - 1.0) / besselbeta;
-    };
-  } else if (kf == 5) {
-    const double coshbeta = std::cosh(beta);
-    return [beta, coshbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return std::cosh(beta * std::sqrt(1.0 - z * z)) / coshbeta;
-    }; // normalized cosh-type of Rmk. 13 [FIN]
-  } else if (kf == 6) {
-    const double coshbeta = std::cosh(beta);
-    return [beta, coshbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return (std::cosh(beta * std::sqrt(1.0 - z * z)) - 1.0) / coshbeta;
-    }; // Potts-Tasche cont cosh-type
-  } else if (kf >= 7 && kf <= 9) {
+  if (kf >= 7 && kf <= 9) {
     finufft::common::PSWF0 pswf(beta);
     return [pswf](double z) {
       if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
@@ -114,23 +78,14 @@ int theoretical_kernel_ns(double tol, int dim, int type, int debug,
   // in exact arithmetic, to achieve requested tolerance tol. Possibly uses
   // other parameters in spopts (upsampfac, kerformula,...). No clipping of ns
   // to valid range done here. Input upsampfac must be >1.0.
-  int ns       = 0;
   double sigma = spopts.upsampfac;
-
-  if (spopts.kerformula == 1) // ES legacy ns choice (v2.4.1, ie 2025, and before)
-    if (sigma == 2.0)
-      ns = (int)std::ceil(std::log10(10.0 / tol));
-    else
-      ns = (int)std::ceil(
-          std::log(1.0 / tol) / (finufft::common::PI * std::sqrt(1.0 - 1.0 / sigma)));
-  else { // generic formula for PSWF-like kernels. Currently for kf=8, PSWF (beta shift)
-    // tweak tolfac and nsoff for user tol matching (& tolsweep passing) over sigma...
-    const double tolfac = kernel_tolfac(dim, type);
-    const double nsoff = 1.0; // width offset (helps balance err over sigma range)
-    ns                 = (int)std::ceil(
-        std::log(tolfac / tol) / (finufft::common::PI * std::sqrt(1.0 - 1.0 / sigma)) +
-        nsoff);
-  }
+  // generic formula for PSWF-like kernels. Currently for kf=8, PSWF (beta shift).
+  // tweak tolfac and nsoff for user tol matching (& tolsweep passing) over sigma...
+  const double tolfac = kernel_tolfac(dim, type);
+  const double nsoff = 1.0; // width offset (helps balance err over sigma range)
+  int ns = (int)std::ceil(
+      std::log(tolfac / tol) / (finufft::common::PI * std::sqrt(1.0 - 1.0 / sigma)) +
+      nsoff);
   return ns;
 }
 
@@ -145,33 +100,7 @@ void set_kernel_shape_given_ns(finufft_spread_opts &spopts, int debug) {
   // For PSWF, aligns cut-off (start of aliasing) with freq (c) param. Used below...
   const double beta_cutoff = common::PI * (double)ns * (1.0 - 1.0 / (2.0 * sigma));
 
-  // these strings must match: kernel_definition(), the above, and the below
-  const char *kernames[] = {"default",
-                            "ES (legacy beta)",        // 1
-                            "ES (Beatty beta)",        // 2
-                            "KB (Beatty beta)",        // 3
-                            "cont-KB (Beatty beta)",   // 4
-                            "cosh-type (Beatty beta)", // 5
-                            "cont cosh (Beatty beta)", // 6
-                            "PSWF (Beatty beta)",      // 7
-                            "PSWF (beta shift)",       // 8
-                            "PSWF (beta Marco)"};      // 9
-  if (kf == 1) {
-    // Exponential of Semicircle (ES), the legacy logic, from 2017, used to v2.4.1
-    double betaoverns = 2.30;
-    if (ns == 2)
-      betaoverns = 2.20;
-    else if (ns == 3)
-      betaoverns = 2.26;
-    else if (ns == 4)
-      betaoverns = 2.38;         // in hindsight this value was too large
-    spopts.beta = betaoverns * (double)ns;
-    if (sigma != 2.0) {          // low-sigma option, introduced v1.0 (2018-2025)
-      const double gamma = 0.97; // safety factor, from [FIN] paper
-      spopts.beta        = gamma * beta_cutoff;
-    }
-
-  } else if (kf >= 2 && kf <= 7) {
+  if (kf == 7) {
     /* Shape param formula (designed for K-B), from Beatty et al,
       IEEE Trans Med Imaging, 2005 24(6):799-808. doi:10.1109/TMI.2005.848376
       "Rapid gridding reconstruction with a minimal oversampling ratio".
@@ -180,10 +109,7 @@ void set_kernel_shape_given_ns(finufft_spread_opts &spopts, int debug) {
     */
     double c_Beatty = (ns == 2) ? 0.5 : 0.8; // ns=2 case gives error fac 2 better for KB
     double pis      = common::PI * common::PI;
-    spopts.beta     = std::sqrt(beta_cutoff * beta_cutoff - c_Beatty / pis);
-    // Expts show beta_cutoff with KB is 1/3-digit worse than Beatty, similar to ES.
-    // In fact, in wsweepkerrcomp.m on KB we find beta_cutoff-0.17 is indistinguishable.
-    // This is analogous to a safety factor of >0.99 around ns=10 (0.97 was too small)
+    spopts.beta = std::sqrt(beta_cutoff * beta_cutoff - c_Beatty / pis);
 
   } else if (kf == 8) {
     // Std shape param with const shift to exploit a little more tail decay,
@@ -199,9 +125,35 @@ void set_kernel_shape_given_ns(finufft_spread_opts &spopts, int debug) {
   }
 
   if (debug || spopts.debug) {
-    const char *kname = (kf >= 0 && kf <= 9) ? kernames[kf] : "unknown";
+    const char *kname = [kf] {
+      switch (kf) {
+      case 7:
+        return "PSWF (Beatty beta)";
+      case 8:
+        return "PSWF (beta shift)";
+      case 9:
+        return "PSWF (beta Marco)";
+      default:
+        return "unknown";
+      }
+    }();
     printf("[setup_spreadinterp]\tkerformula=%d: %s...\n", kf, kname);
   }
+}
+
+std::tuple<double, double> pswf_selfft_params(int nspread, double beta) {
+  // mu0 = int_{-1}^{1} PSWF0(beta,t) dt, the finite-FT eigenvalue (see kernel.h).
+  // Barbone 7/23/26.
+  finufft::common::PSWF0 pswf(beta);
+  constexpr int nquad = 80; // once per plan, need not be fast
+  double z[nquad], w[nquad];
+  finufft::common::gaussquad(nquad, z, w);
+  double mu0 = 0;
+  for (int n = 0; n < nquad; ++n) mu0 += w[n] * pswf(z[n]);
+  const double J2 = nspread / 2.0; // half-width of kernel z-support
+  const double grid_scale = J2 * J2 / beta;
+  const double prefac = J2 * mu0;
+  return {grid_scale, prefac};
 }
 
 } // namespace finufft::kernel

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -5,7 +5,6 @@
 #include <finufft_common/safe_call.h>
 #include <finufft_common/spread_opts.h>
 #include <finufft_errors.h>
-#include <limits>
 
 // this module uses finufft_spread_opts but does not know about FINUFFT_PLAN class
 // nor finufft_opts. This allows it to be used by CPU & GPU.
@@ -42,42 +41,7 @@ std::function<double(double)> kernel_definition_lambda(
   double beta = spopts.beta; // get shape param
   int kf      = spopts.kerformula;
 
-  if (kf == 1 || kf == 2) {
-    // ES ("exponential of semicircle" or "exp sqrt"), see [FIN] reference.
-    // Used in FINUFFT 2017-2025 (up to v2.4.1). max is 1, as of v2.3.0.
-    const double expbeta = std::exp(beta);
-    return [beta, expbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return std::exp(beta * std::sqrt(1.0 - z * z)) / expbeta;
-    };
-  } else if (kf == 3) {
-    // forwards Kaiser--Bessel (KB), normalized to max of 1.
-    // std::cyl_bessel_i is from <cmath>, expects double. See src/common/utils.cpp
-    const double besselbeta = common::cyl_bessel_i(0, beta);
-    return [beta, besselbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return common::cyl_bessel_i(0, beta * std::sqrt(1.0 - z * z)) / besselbeta;
-    };
-  } else if (kf == 4) {
-    // continuous (deplinthed) KB, as in Barnett SIREV 2022, normalized to max nearly 1
-    const double besselbeta = common::cyl_bessel_i(0, beta);
-    return [beta, besselbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return (common::cyl_bessel_i(0, beta * std::sqrt(1.0 - z * z)) - 1.0) / besselbeta;
-    };
-  } else if (kf == 5) {
-    const double coshbeta = std::cosh(beta);
-    return [beta, coshbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return std::cosh(beta * std::sqrt(1.0 - z * z)) / coshbeta;
-    }; // normalized cosh-type of Rmk. 13 [FIN]
-  } else if (kf == 6) {
-    const double coshbeta = std::cosh(beta);
-    return [beta, coshbeta](double z) {
-      if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
-      return (std::cosh(beta * std::sqrt(1.0 - z * z)) - 1.0) / coshbeta;
-    }; // Potts-Tasche cont cosh-type
-  } else if (kf >= 7 && kf <= 9) {
+  if (kf >= 7 && kf <= 9) {
     finufft::common::PSWF0 pswf(beta);
     return [pswf](double z) {
       if (std::abs(z) > 1.0) return 0.0; // restrict support to [-1,1]
@@ -114,23 +78,14 @@ int theoretical_kernel_ns(double tol, int dim, int type, int debug,
   // in exact arithmetic, to achieve requested tolerance tol. Possibly uses
   // other parameters in spopts (upsampfac, kerformula,...). No clipping of ns
   // to valid range done here. Input upsampfac must be >1.0.
-  int ns       = 0;
   double sigma = spopts.upsampfac;
-
-  if (spopts.kerformula == 1) // ES legacy ns choice (v2.4.1, ie 2025, and before)
-    if (sigma == 2.0)
-      ns = (int)std::ceil(std::log10(10.0 / tol));
-    else
-      ns = (int)std::ceil(
-          std::log(1.0 / tol) / (finufft::common::PI * std::sqrt(1.0 - 1.0 / sigma)));
-  else { // generic formula for PSWF-like kernels. Currently for kf=8, PSWF (beta shift)
-    // tweak tolfac and nsoff for user tol matching (& tolsweep passing) over sigma...
-    const double tolfac = kernel_tolfac(dim, type);
-    const double nsoff = 1.0; // width offset (helps balance err over sigma range)
-    ns                 = (int)std::ceil(
-        std::log(tolfac / tol) / (finufft::common::PI * std::sqrt(1.0 - 1.0 / sigma)) +
-        nsoff);
-  }
+  // generic formula for PSWF-like kernels. Currently for kf=8, PSWF (beta shift).
+  // tweak tolfac and nsoff for user tol matching (& tolsweep passing) over sigma...
+  const double tolfac = kernel_tolfac(dim, type);
+  const double nsoff = 1.0; // width offset (helps balance err over sigma range)
+  int ns = (int)std::ceil(
+      std::log(tolfac / tol) / (finufft::common::PI * std::sqrt(1.0 - 1.0 / sigma)) +
+      nsoff);
   return ns;
 }
 
@@ -145,33 +100,7 @@ void set_kernel_shape_given_ns(finufft_spread_opts &spopts, int debug) {
   // For PSWF, aligns cut-off (start of aliasing) with freq (c) param. Used below...
   const double beta_cutoff = common::PI * (double)ns * (1.0 - 1.0 / (2.0 * sigma));
 
-  // these strings must match: kernel_definition(), the above, and the below
-  const char *kernames[] = {"default",
-                            "ES (legacy beta)",        // 1
-                            "ES (Beatty beta)",        // 2
-                            "KB (Beatty beta)",        // 3
-                            "cont-KB (Beatty beta)",   // 4
-                            "cosh-type (Beatty beta)", // 5
-                            "cont cosh (Beatty beta)", // 6
-                            "PSWF (Beatty beta)",      // 7
-                            "PSWF (beta shift)",       // 8
-                            "PSWF (beta Marco)"};      // 9
-  if (kf == 1) {
-    // Exponential of Semicircle (ES), the legacy logic, from 2017, used to v2.4.1
-    double betaoverns = 2.30;
-    if (ns == 2)
-      betaoverns = 2.20;
-    else if (ns == 3)
-      betaoverns = 2.26;
-    else if (ns == 4)
-      betaoverns = 2.38;         // in hindsight this value was too large
-    spopts.beta = betaoverns * (double)ns;
-    if (sigma != 2.0) {          // low-sigma option, introduced v1.0 (2018-2025)
-      const double gamma = 0.97; // safety factor, from [FIN] paper
-      spopts.beta        = gamma * beta_cutoff;
-    }
-
-  } else if (kf >= 2 && kf <= 7) {
+  if (kf == 7) {
     /* Shape param formula (designed for K-B), from Beatty et al,
       IEEE Trans Med Imaging, 2005 24(6):799-808. doi:10.1109/TMI.2005.848376
       "Rapid gridding reconstruction with a minimal oversampling ratio".
@@ -180,10 +109,7 @@ void set_kernel_shape_given_ns(finufft_spread_opts &spopts, int debug) {
     */
     double c_Beatty = (ns == 2) ? 0.5 : 0.8; // ns=2 case gives error fac 2 better for KB
     double pis      = common::PI * common::PI;
-    spopts.beta     = std::sqrt(beta_cutoff * beta_cutoff - c_Beatty / pis);
-    // Expts show beta_cutoff with KB is 1/3-digit worse than Beatty, similar to ES.
-    // In fact, in wsweepkerrcomp.m on KB we find beta_cutoff-0.17 is indistinguishable.
-    // This is analogous to a safety factor of >0.99 around ns=10 (0.97 was too small)
+    spopts.beta = std::sqrt(beta_cutoff * beta_cutoff - c_Beatty / pis);
 
   } else if (kf == 8) {
     // Std shape param with const shift to exploit a little more tail decay,
@@ -199,7 +125,18 @@ void set_kernel_shape_given_ns(finufft_spread_opts &spopts, int debug) {
   }
 
   if (debug || spopts.debug) {
-    const char *kname = (kf >= 0 && kf <= 9) ? kernames[kf] : "unknown";
+    const char *kname = [kf] {
+      switch (kf) {
+      case 7:
+        return "PSWF (Beatty beta)";
+      case 8:
+        return "PSWF (beta shift)";
+      case 9:
+        return "PSWF (beta Marco)";
+      default:
+        return "unknown";
+      }
+    }();
     printf("[setup_spreadinterp]\tkerformula=%d: %s...\n", kf, kname);
   }
 }

--- a/test/error_handling.c
+++ b/test/error_handling.c
@@ -92,15 +92,20 @@ int main(void) {
     return 9;
   }
 
-  // Invalid kernel formula -> expect FINUFFT_ERR_KERFORMULA_NOTVALID
-  finufft_default_opts(&opts);
-  opts.upsampfac         = 2.0; // force kernel setup in makeplan
-  opts.spread_kerformula = 99;  // invalid kernel formula
-  rc                     = finufft_makeplan(1, 1, N, 1, 1, 1e-6, &plan, &opts);
-  if (rc != FINUFFT_ERR_KERFORMULA_NOTVALID) {
-    fprintf(stderr, "kerformula invalid: expected %d got %d\n",
-            FINUFFT_ERR_KERFORMULA_NOTVALID, rc);
-    return 10;
+  // Invalid kernel formula -> expect FINUFFT_ERR_KERFORMULA_NOTVALID.
+  // Only the PSWF formulas (7..9) survive; 1..6 (legacy ES/KB/cosh) and any other
+  // out-of-range value are now rejected.
+  const int bad_kerformulas[] = {3, 6, 99};
+  for (size_t i = 0; i < sizeof(bad_kerformulas) / sizeof(bad_kerformulas[0]); ++i) {
+    finufft_default_opts(&opts);
+    opts.upsampfac = 2.0; // force kernel setup in makeplan
+    opts.spread_kerformula = bad_kerformulas[i];
+    rc = finufft_makeplan(1, 1, N, 1, 1, 1e-6, &plan, &opts);
+    if (rc != FINUFFT_ERR_KERFORMULA_NOTVALID) {
+      fprintf(stderr, "kerformula=%d invalid: expected %d got %d\n", bad_kerformulas[i],
+              FINUFFT_ERR_KERFORMULA_NOTVALID, rc);
+      return 10;
+    }
   }
 
   printf("error_handling: PASS\n");

--- a/test/error_handling.c
+++ b/test/error_handling.c
@@ -92,15 +92,21 @@ int main(void) {
     return 9;
   }
 
-  // Invalid kernel formula -> expect FINUFFT_ERR_KERFORMULA_NOTVALID
-  finufft_default_opts(&opts);
-  opts.upsampfac         = 2.0; // force kernel setup in makeplan
-  opts.spread_kerformula = 99;  // invalid kernel formula
-  rc                     = finufft_makeplan(1, 1, N, 1, 1, 1e-6, &plan, &opts);
-  if (rc != FINUFFT_ERR_KERFORMULA_NOTVALID) {
-    fprintf(stderr, "kerformula invalid: expected %d got %d\n",
-            FINUFFT_ERR_KERFORMULA_NOTVALID, rc);
-    return 10;
+  // Invalid kernel formula -> expect FINUFFT_ERR_KERFORMULA_NOTVALID.
+  // Only the PSWF formulas (7..9) survive; 1..6 (legacy ES/KB/cosh) and any other
+  // out-of-range value are now rejected.
+  // 1 is the legacy ES value documented up to v2.5.0, so users will try it.
+  const int bad_kerformulas[] = {1, 3, 6, 99};
+  for (size_t i = 0; i < sizeof(bad_kerformulas) / sizeof(bad_kerformulas[0]); ++i) {
+    finufft_default_opts(&opts);
+    opts.upsampfac = 2.0; // force kernel setup in makeplan
+    opts.spread_kerformula = bad_kerformulas[i];
+    rc = finufft_makeplan(1, 1, N, 1, 1, 1e-6, &plan, &opts);
+    if (rc != FINUFFT_ERR_KERFORMULA_NOTVALID) {
+      fprintf(stderr, "kerformula=%d invalid: expected %d got %d\n", bad_kerformulas[i],
+              FINUFFT_ERR_KERFORMULA_NOTVALID, rc);
+      return 10;
+    }
   }
 
   printf("error_handling: PASS\n");


### PR DESCRIPTION
The order-0 PSWF is an eigenfunction of the finite Fourier transform, so the spread kernel's continuous FT is a rescaled copy of the kernel itself:
  phihat(k) = J2*mu0 * phi(k * J2^2/beta)
with phi the Horner approximant (evaluate_kernel_runtime), J2 = nspread/2, mu0 = int_{-1}^{1} PSWF0(beta,t) dt.