### PR TITLE
chore: update pinned dependencies; CUDA 13 CCCL and editable-install fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,14 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 v2.6.0-dev
 
+* Fixed the cuFINUFFT build against a CPM-fetched CCCL: it was added as an
+  include-SYSTEM package, and nvcc searches its own include directory before
+  every `-isystem` path, so `cuda/std/*` resolved to the CUDA toolkit's older
+  libcudacxx while thrust/cub came from the fetched tree. CUDA 11 failed to build
+  outright, and on CUDA 12 toolkits that ship thrust/cub the pinned CCCL version
+  was silently not the one compiled against. Fetching it non-SYSTEM exposed
+  missing `<cuda/std/tuple>`, `<cuda/std/array>` and `<iostream>` includes.
+  (Barbone)
 * Sanitizer CI builds now compile at `-O1 -fno-omit-frame-pointer` (working around an
   xsimd 14.3.0 constexpr immediate-argument folding bug at `-O0`), instrument the
   single-precision `finufft_f32` object library, and mark xsimd/ducc0 includes as

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,10 @@ include(toolchain) # finds cmake/toolchain.cmake
 set(CPM_DOWNLOAD_VERSION "0.43.1" CACHE STRING "Version of CPM.cmake to use")
 set(FFTW_VERSION "3.3.10" CACHE STRING "Version of FFTW to use")
 set(XSIMD_VERSION "14.3.0" CACHE STRING "Version of xsimd to use")
-set(POET_VERSION "v0.0.0" CACHE STRING "Version of POET to use")
-set(DUCC0_VERSION "ducc0_0_39_1" CACHE STRING "Version of ducc0 to use")
+set(POET_VERSION "v0.0.1" CACHE STRING "Version of POET to use")
+set(DUCC0_VERSION "ducc0_0_41_1" CACHE STRING "Version of ducc0 to use")
 set(CUDA11_CCCL_VERSION "2.8.5" CACHE STRING "Version of FINUFFT-cccl for cuda 11 to use")
-set(CUDA12_CCCL_VERSION "3.0.2" CACHE STRING "Version of FINUFFT-cccl for cuda 12 to use")
+set(CUDA12_CCCL_VERSION "3.4.2" CACHE STRING "Version of FINUFFT-cccl for cuda 12 to use")
 
 mark_as_advanced(
     CPM_DOWNLOAD_VERSION

--- a/cmake/setupCCCL.cmake
+++ b/cmake/setupCCCL.cmake
@@ -13,14 +13,25 @@ if(CUDA_VERSION_MAJOR LESS 12)
         YES
     )
 else()
-    CPMAddPackage(
+    # Any CCCL 3.x already on the machine will do, so take the one the CUDA
+    # toolkit ships (13.x does; its config lives in <libdir>/cmake/cccl, which
+    # plain prefix search does not reach) and only fetch when there is none.
+    # Preferring it is not just to save a download: the toolkit's
+    # <toolkit>/include/cccl lands ahead of any CPM include dir, so a fetched
+    # CCCL would have the toolkit's thrust/cub compiled against its libcudacxx
+    # - two incompatible trees, which fails to build.
+    cpmfindpackage(
         NAME
         CCCL
+        VERSION
+        3
         GIT_REPOSITORY
         https://github.com/NVIDIA/cccl.git
         GIT_TAG
         v${CUDA12_CCCL_VERSION}
         SYSTEM
         YES
+        FIND_PACKAGE_ARGUMENTS
+        "CONFIG PATHS ${CUDAToolkit_LIBRARY_DIR}/cmake ${CUDAToolkit_LIBRARY_ROOT}/lib64/cmake"
     )
 endif()

--- a/cmake/setupCCCL.cmake
+++ b/cmake/setupCCCL.cmake
@@ -2,6 +2,10 @@ string(REPLACE "." ";" CUDA_VERSION_LIST ${CMAKE_CUDA_COMPILER_VERSION})
 list(GET CUDA_VERSION_LIST 0 CUDA_VERSION_MAJOR)
 message(STATUS "CUDA ${CUDA_VERSION_MAJOR} detected")
 if(CUDA_VERSION_MAJOR LESS 12)
+    # CUDA 11 ships libcudacxx 1.x, too old for us (no structured bindings on
+    # cuda::std::tuple). SYSTEM NO is required, not cosmetic: nvcc puts its own
+    # include dir ahead of every -isystem path but after -I, so a SYSTEM package
+    # would give cuda/std/* from the toolkit and thrust/cub from here.
     CPMAddPackage(
         NAME
         CCCL
@@ -10,16 +14,14 @@ if(CUDA_VERSION_MAJOR LESS 12)
         GIT_TAG
         v${CUDA11_CCCL_VERSION}
         SYSTEM
-        YES
+        NO
     )
 else()
-    # Any CCCL 3.x already on the machine will do, so take the one the CUDA
-    # toolkit ships (13.x does; its config lives in <libdir>/cmake/cccl, which
-    # plain prefix search does not reach) and only fetch when there is none.
-    # Preferring it is not just to save a download: the toolkit's
-    # <toolkit>/include/cccl lands ahead of any CPM include dir, so a fetched
-    # CCCL would have the toolkit's thrust/cub compiled against its libcudacxx
-    # - two incompatible trees, which fails to build.
+    # Prefer the CCCL the toolkit ships (13.x does; its config lives in
+    # <libdir>/cmake/cccl, which plain prefix search does not reach) - its
+    # <toolkit>/include/cccl wins over any CPM include dir anyway, so fetching
+    # over it just mixes two trees. 12.x ships thrust/cub but no config, so it
+    # fetches, and non-SYSTEM for the same reason as the CUDA 11 branch.
     cpmfindpackage(
         NAME
         CCCL
@@ -30,7 +32,7 @@ else()
         GIT_TAG
         v${CUDA12_CCCL_VERSION}
         SYSTEM
-        YES
+        NO
         FIND_PACKAGE_ARGUMENTS
         "CONFIG PATHS ${CUDAToolkit_LIBRARY_DIR}/cmake ${CUDAToolkit_LIBRARY_ROOT}/lib64/cmake"
     )

--- a/include/cufinufft/cufinufft_plan_t.hpp
+++ b/include/cufinufft/cufinufft_plan_t.hpp
@@ -6,6 +6,7 @@
 #include <cufinufft/contrib/helper_cuda.h>
 #include <cufinufft/types.hpp>
 #include <cufinufft_opts.h>
+#include <iostream>
 #include <finufft_common/safe_call.h>
 #include <finufft_common/spread_opts.h>
 #include <finufft_errors.h>

--- a/include/cufinufft/spreadinterp.hpp
+++ b/include/cufinufft/spreadinterp.hpp
@@ -3,6 +3,8 @@
 
 #include <cmath>
 #include <cuda.h>
+#include <cuda/std/array>
+#include <cuda/std/tuple>
 #include <thrust/sequence.h>
 
 #include <cufinufft/contrib/helper_cuda.h>

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,25 +1,9 @@
 if(FINUFFT_USE_CPU)
     install(TARGETS finufft LIBRARY DESTINATION finufft RUNTIME DESTINATION finufft)
-    if(ENV{EDITABLE_REBUILD} STREQUAL "true")
-        install(
-            TARGETS finufft
-            LIBRARY DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/finufft/finufft
-            RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/finufft/finufft
-        )
-        set_target_properties(finufft PROPERTIES INSTALL_RPATH "$ORIGIN" BUILD_WITH_INSTALL_RPATH TRUE)
-    endif()
 endif()
 
 if(FINUFFT_USE_CUDA)
     install(TARGETS cufinufft LIBRARY DESTINATION cufinufft RUNTIME DESTINATION cufinufft)
-    if(ENV{EDITABLE_REBUILD} STREQUAL "true")
-        install(
-            TARGETS cufinufft
-            LIBRARY DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/cufinufft/cufinufft
-            RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/cufinufft/cufinufft
-        )
-        set_target_properties(cufinufft PROPERTIES INSTALL_RPATH "$ORIGIN" BUILD_WITH_INSTALL_RPATH TRUE)
-    endif()
 endif()
 
 # Warn if the user invokes CMake directly

--- a/python/cufinufft/cufinufft/_cufinufft.py
+++ b/python/cufinufft/cufinufft/_cufinufft.py
@@ -43,15 +43,33 @@ library_names = ["libcufinufft", "cufinufft"]
 if reset_log_level:
     logging.root.setLevel(log_level)
 
-# First attempt: try from package directory
+# First attempt: resolve the packaged library through the import system rather
+# than by path. This also works for editable installs, where the library is not
+# next to this file and where the lookup is what triggers scikit-build-core's
+# on-demand rebuild (installed with -Ceditable.rebuild=true), so a stale library
+# can never be loaded. Returns None on Windows, where the .dll suffix is not an
+# importable one - the by-path search below covers that.
+try:
+    _spec = importlib.util.find_spec("cufinufft.libcufinufft")
+except (ImportError, AttributeError, ValueError):
+    _spec = None
+if _spec is not None and _spec.origin is not None:
+    try:
+        lib = ctypes.CDLL(_spec.origin)
+    except OSError:
+        lib = None
+
+# Second attempt: try from package directory
 for lib_name in library_names:
+    if lib is not None:
+        break
     try:
         lib = np.ctypeslib.load_library(lib_name, path)
         break
     except (OSError, AttributeError):
         pass
 
-# Second attempt: try from system path
+# Third attempt: try from system path
 if lib is None:
     libname = find_library('cufinufft')
     if libname is None:

--- a/python/finufft/finufft/_finufft.py
+++ b/python/finufft/finufft/_finufft.py
@@ -6,6 +6,7 @@ Seperate bindings are provided for single and double precision libraries,
 differentiated by 'f' suffix.
 """
 import ctypes
+import importlib.util
 import pathlib
 from ctypes.util import find_library
 from ctypes import c_double
@@ -37,13 +38,31 @@ if reset_log_level:
 
 # TODO: See if there is a way to improve this so it is less hacky.
 lib = None
-# Try to load finufft installed from the python package.
+# Resolve the packaged library through the import system rather than by path.
+# This also works for editable installs, where the library is not next to this
+# file and where the lookup is what triggers scikit-build-core's on-demand
+# rebuild (installed with -Ceditable.rebuild=true), so a stale library can
+# never be loaded. Returns None on Windows, where the .dll suffix is not an
+# importable one - the by-path search below covers that.
+try:
+    _spec = importlib.util.find_spec('finufft.libfinufft')
+except (ImportError, AttributeError, ValueError):
+    _spec = None
+if _spec is not None and _spec.origin is not None:
+    try:
+        lib = ctypes.CDLL(_spec.origin)
+    except OSError:
+        lib = None
+
+# Try to load finufft installed next to this file (wheel layout).
 path = pathlib.Path(__file__).parent.resolve()
 # Ignoring the exceptions to avoid the print
 # exception, during the process of an exception another exception occurred
 # unix systems have lib prefix, non unix systems do not
 library_names = ['libfinufft', 'finufft']
 for lib_name in library_names:
+    if lib is not None:
+        break
     try:
         lib = np.ctypeslib.load_library(lib_name, path)
         break

--- a/src/cuda/setpts.cu
+++ b/src/cuda/setpts.cu
@@ -14,7 +14,13 @@
 
 #include <finufft_common/constants.h>
 #include <finufft_errors.h>
+#include <thrust/copy.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/transform.h>
+#include <thrust/tuple.h>
 
 template<typename T>
 void cufinufft_plan_t<T>::setpts_type12(int M_, const T *d_kx, const T *d_ky,

--- a/src/cuda/spread_blockgather_inst.cu
+++ b/src/cuda/spread_blockgather_inst.cu
@@ -1,6 +1,7 @@
 // Per-dim instantiation TU: 3D block-gather spread (gpu_method = 4), Ndim = 3.
 
 #include <cufinufft/spreadinterp.hpp>
+#include <iostream>
 #include <poet/poet.hpp>
 
 namespace cufinufft {


### PR DESCRIPTION
Three build/packaging fixes that had been sitting unpushed.

**`fix: build cufinufft against the CUDA toolkit's CCCL`** — CUDA 13 ships CCCL under `<toolkit>/include/cccl`, which CMake places ahead of any CPM include dir, so fetching CCCL compiled the toolkit's thrust/cub against the fetched libcudacxx. Resolve with `CPMFindPackage` (major-only version request, explicit `FIND_PACKAGE_ARGUMENTS` paths, since the toolkit's config lives in `<libdir>/cmake/cccl`). `setpts.cu` also relied on transitive thrust includes that CCCL 3.3 dropped.

**`fix: make editable installs load a rebuilt library`** — `_finufft.py`/`_cufinufft.py` looked for the shared library next to themselves, which is the wheel layout, not the editable one, so C++/CUDA edits were silently ignored. Resolving through the import system fixes both layouts and is what triggers scikit-build-core's on-demand rebuild.

**`chore: update pinned dependencies`** — POET v0.0.0 → v0.0.1, ducc0 0.39.1 → 0.41.1, CCCL for CUDA ≥ 12 3.0.2 → 3.4.2. CPM, xsimd, FFTW and the CUDA 11 CCCL are already at their newest upstream releases.

Test plan:
- [ ] GitHub Actions matrix (linux/macos/windows, CPU + CUDA wheels)
- [x] CUDA build + full `test/cuda` ctest suite locally on CUDA 12.4 and 13.0 (containers, sm_89)

**`fix: fetch CCCL non-SYSTEM so cuda/std matches thrust/cub`** — the CPM package was added with `SYSTEM YES`; nvcc searches its own include directory before every `-isystem` path but after `-I`, so `cuda/std/*` resolved to the toolkit's older libcudacxx while thrust/cub came from the fetched tree. CUDA 11 failed to build outright, and on CUDA 12 toolkits shipping thrust/cub the pinned CCCL version was silently not the one compiled against. Fetching it non-SYSTEM exposed missing `<cuda/std/tuple>`, `<cuda/std/array>` and `<iostream>` includes. Validated in containers on an sm_89 GPU: CUDA 11.8 and 12.4 both build and pass 289/289 `test/cuda` ctest plus the Python suite on pycuda/numba/cupy/torch; CUDA 12.8 compiles clean for sm_120.
