### PR TITLE
Multigpu device fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,15 @@ v2.6.0-dev
   the kernel, replacing the per-target cosine quadrature in setpts. Users of
   spreadinterp_only now always see the PSWF kernel (consulted in discussion
   #881). (Barbone, Barnett #879)
+* Fixed cuFINUFFT `opts.gpu_device_id`: the plan constructor ran with the caller's
+  current device, so on any device other than that one `cufftPlanMany`, the fseries
+  kernel and the plain-allocator thrust vectors bound to the wrong device and the
+  transform died with `cudaErrorIllegalAddress`. It now switches device like `setpts`
+  and `execute` already did. New `cufinufft_multigpu` test runs a 2D type-1 double
+  transform on every visible device, with and without a caller-owned `gpu_stream`, and
+  checks that an unusable `gpu_device_id` returns `FINUFFT_ERR_CUDA_FAILURE`; with only
+  one device visible the cross-device half cannot run and the test reports a ctest SKIP.
+  (Barbone)
 * Fixed the cuFINUFFT build against a CPM-fetched CCCL: it was added as an
   include-SYSTEM package, and nvcc searches its own include directory before
   every `-isystem` path, so `cuda/std/*` resolved to the CUDA toolkit's older

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,15 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 v2.6.0-dev
 
+* Fixed cuFINUFFT `opts.gpu_device_id`: the plan constructor ran with the caller's
+  current device, so on any device other than that one `cufftPlanMany`, the fseries
+  kernel and the plain-allocator thrust vectors bound to the wrong device and the
+  transform died with `cudaErrorIllegalAddress`. It now switches device like `setpts`
+  and `execute` already did. New `cufinufft_multigpu` test runs a 2D type-1 double
+  transform on every visible device, with and without a caller-owned `gpu_stream`, and
+  checks that an unusable `gpu_device_id` returns `FINUFFT_ERR_CUDA_FAILURE`; with only
+  one device visible the cross-device half cannot run and the test reports a ctest SKIP.
+  (Barbone)
 * Fixed the cuFINUFFT build against a CPM-fetched CCCL: it was added as an
   include-SYSTEM package, and nvcc searches its own include directory before
   every `-isystem` path, so `cuda/std/*` resolved to the CUDA toolkit's older

--- a/docs/c_gpu.rst
+++ b/docs/c_gpu.rst
@@ -381,7 +381,7 @@ Data handling options
 As a reminder, ``modeord=0`` selects increasing frequencies (negative through positive) in each dimension,
 while ``modeord=1`` selects FFT-style ordering starting at zero and wrapping over to negative frequencies half way through.
 
-**gpu_device_id**: Sets the GPU device ID. Leave at default unless you know what you're doing. [To be documented]
+**gpu_device_id**: CUDA device ordinal (as in ``cudaSetDevice``) that the plan lives on. It defaults to ``0``, *not* to the caller's current device: if your code works on another device you must set this field, otherwise the plan is built and executed on device 0. Every library call (``makeplan``, ``setpts``, ``execute``, ``destroy``) makes this device current for its duration and restores the caller's device before returning, so the caller's device is never changed behind its back. All device pointers you hand to ``setpts`` and ``execute``, and ``opts.gpu_stream`` if you set it, must belong to this device; the plan's own memory is allocated there. Plans on different devices are independent and may be used concurrently from different host threads. An invalid or unusable device id makes ``cufinufft_makeplan`` return ``FINUFFT_ERR_CUDA_FAILURE``.
 
 **gpu_spreadinterponly**: [Only has effect for type 1 or 2.] For experts only. If ``0`` do the NUFFT as intended. If ``1``, do *only* spreading (if ``type=1``) or *only* interpolation (if ``type=2``), using kernel shape parameters set by ``tol`` and ``upsampfac``; the result is not upsampled and is not a NUFFT.
 It is analogous to the CPU option named :ref:`spreadinterponly<sionly>` (please read that documentation!). [This flag is also internally used for GPU type 3 transforms, although it was originally a debug flag.]

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -250,6 +250,11 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
   using namespace cufinufft::common;
   using namespace finufft::common;
 
+  // As in setpts/execute: everything below (cufftPlanMany, the fseries kernel, the
+  // plain-allocator thrust vectors) binds to the *current* device, not to
+  // opts.gpu_device_id, so the plan must be built with that device current.
+  DeviceSwitcher switcher(opts.gpu_device_id);
+
   if (type < 1 || type > 3) {
     fprintf(stderr, "[%s] Invalid type (%d): should be 1, 2, or 3.\n", __func__, type);
     throw finufft::exception(FINUFFT_ERR_TYPE_NOTVALID);

--- a/test/cuda/CMakeLists.txt
+++ b/test/cuda/CMakeLists.txt
@@ -224,6 +224,9 @@ add_test(NAME cufinufft_makeplan COMMAND test_makeplan)
 add_test(NAME cufinufft_error_handling COMMAND cufinufft_error_handling)
 add_test(NAME cufinufft_math_test COMMAND cufinufft_math_test)
 add_test(NAME cufinufft_simple_test COMMAND cufinufft_simple_test)
+add_test(NAME cufinufft_multigpu COMMAND cufinufft_multigpu_test)
+# Returns 77 when only one device is visible: the cross-device path cannot run.
+set_tests_properties(cufinufft_multigpu PROPERTIES SKIP_RETURN_CODE 77)
 add_test(
     NAME cufinufft1dspreadinterponly_double_test
     COMMAND cufinufft1dspreadinterponly_test 1e3 1e6 1e-6 1e-5 d 2.00

--- a/test/cuda/cufinufft_multigpu_test.cu
+++ b/test/cuda/cufinufft_multigpu_test.cu
@@ -1,0 +1,145 @@
+// Exercise opts.gpu_device_id and a caller-owned opts.gpu_stream.
+//
+// The same 2D type-1 problem is run on every visible device, with and without a
+// user stream; every result must match the device-0 default-stream one to a
+// tight relative L2 error. The call is always made with device 0 current, so it
+// also checks that cufinufft restores the caller's device. An unusable device id
+// must come back as an error code. With one visible device this still covers the
+// stream path, but the cross-device part needs two (a MIG pod exposes only one
+// instance per process), so it then exits 77 and ctest reports a SKIP.
+
+#include <cmath>
+#include <complex>
+#include <cstdio>
+#include <vector>
+
+#include <cuComplex.h>
+#include <cuda_runtime.h>
+
+#include <cufinufft.h>
+#include <finufft_common/common.h>
+#include <finufft_errors.h>
+
+#include "../utils/norms.hpp"
+
+using ::finufft::common::PI;
+
+namespace {
+
+constexpr int64_t M = 10000, N1 = 64, N2 = 32;
+constexpr size_t NK = size_t(N1) * N2;
+constexpr double REQ_TOL = 1e-9, CHECK_RTOL = 1e-9;
+
+// Run the transform on `device`, optionally through a caller-owned stream on
+// that device, with device 0 current across the call. Returns the modes, or an
+// empty vector on failure.
+// ponytail: device buffers are not freed - the process exits right after.
+std::vector<std::complex<double>> run_on_device(
+    int device, bool use_stream, const std::vector<double> &x,
+    const std::vector<double> &y, const std::vector<std::complex<double>> &c) {
+  double *dx, *dy;
+  cuDoubleComplex *dc, *dfk;
+  cudaStream_t stream{};
+  if (cudaSetDevice(device) || cudaMalloc(&dx, M * sizeof(*dx)) ||
+      cudaMalloc(&dy, M * sizeof(*dy)) || cudaMalloc(&dc, M * sizeof(*dc)) ||
+      cudaMalloc(&dfk, NK * sizeof(*dfk)) || (use_stream && cudaStreamCreate(&stream)) ||
+      cudaMemcpy(dx, x.data(), M * sizeof(*dx), cudaMemcpyHostToDevice) ||
+      cudaMemcpy(dy, y.data(), M * sizeof(*dy), cudaMemcpyHostToDevice) ||
+      cudaMemcpy(dc, c.data(), M * sizeof(*dc), cudaMemcpyHostToDevice)) {
+    std::fprintf(stderr, "setup failed on device %d: %s\n", device,
+                 cudaGetErrorString(cudaGetLastError()));
+    return {};
+  }
+
+  cufinufft_opts opts;
+  cufinufft_default_opts(&opts);
+  opts.gpu_device_id = device;
+  opts.gpu_stream = use_stream ? (void *)stream : nullptr;
+
+  cudaSetDevice(0); // the library must cope with, and restore, this
+  const int ier = cufinufft2d1(M, dx, dy, dc, 1, REQ_TOL, N1, N2, dfk, &opts);
+  int current = -1;
+  cudaGetDevice(&current);
+  if (ier || current != 0) {
+    std::fprintf(stderr, "device %d: ier %d, current device %d (expected 0)\n", device,
+                 ier, current);
+    return {};
+  }
+
+  cudaSetDevice(device);
+  if (use_stream) cudaStreamSynchronize(stream);
+  std::vector<std::complex<double>> fk(NK);
+  if (cudaMemcpy(fk.data(), dfk, NK * sizeof(*dfk), cudaMemcpyDeviceToHost)) {
+    std::fprintf(stderr, "readback failed on device %d: %s\n", device,
+                 cudaGetErrorString(cudaGetLastError()));
+    return {};
+  }
+  return fk;
+}
+
+// An unusable gpu_device_id must come back as an error code, not a crash: the
+// plan ctor's DeviceSwitcher throws and the C boundary maps it.
+bool bad_device_id_is_rejected(int ndev) {
+  cufinufft_opts opts;
+  cufinufft_default_opts(&opts);
+  opts.gpu_device_id = ndev; // one past the last valid device
+  cufinufft_plan plan;
+  const int64_t nmodes[3] = {N1, N2, 1};
+  const int ier = cufinufft_makeplan(1, 2, nmodes, 1, 1, REQ_TOL, &plan, &opts);
+  if (ier != FINUFFT_ERR_CUDA_FAILURE) {
+    std::fprintf(stderr, "gpu_device_id=%d gave ier %d, expected %d\n", ndev, ier,
+                 FINUFFT_ERR_CUDA_FAILURE);
+    return false;
+  }
+  cudaGetLastError(); // clear the sticky invalid-device error
+  return true;
+}
+
+} // namespace
+
+int main() {
+  int ndev = 0;
+  if (cudaGetDeviceCount(&ndev) != cudaSuccess) return 1;
+  std::printf("%d device(s) visible\n", ndev);
+
+  // Same inputs for every device: a fixed lattice-like point set, no RNG needed.
+  std::vector<double> x(M), y(M);
+  std::vector<std::complex<double>> c(M);
+  for (int64_t j = 0; j < M; ++j) {
+    x[j] = -PI + 2 * PI * double(j % 97) / 97.0;
+    y[j] = -PI + 2 * PI * double(j % 89) / 89.0;
+    c[j] = {std::cos(0.1 * double(j)), std::sin(0.07 * double(j))};
+  }
+
+  const auto ref = run_on_device(0, false, x, y, c);
+  if (ref.empty()) return 1;
+
+  int ret = 0;
+  for (int device = 0; device < ndev; ++device) {
+    for (const bool use_stream : {false, true}) {
+      if (device == 0 && !use_stream) continue; // that is the reference run
+      const auto fk = run_on_device(device, use_stream, x, y, c);
+      if (fk.empty()) return 1;
+
+      const double err = relerrtwonorm(int64_t(NK), ref.data(), fk.data());
+      std::printf("device %d (stream %s): rel l2 err vs device 0 = %.3g\n", device,
+                  use_stream ? "user" : "default", err);
+      if (!(err < CHECK_RTOL)) {
+        std::fprintf(stderr, "device %d: mismatch vs device 0\n", device);
+        ret = 1;
+      }
+    }
+  }
+
+  if (!bad_device_id_is_rejected(ndev)) ret = 1;
+  if (ret) return ret;
+
+  // The stream path ran, but with one device nothing above ever left device 0,
+  // so the cross-device part of this test did not run. Report that as a ctest
+  // SKIP (see SKIP_RETURN_CODE) rather than a green that overstates coverage.
+  if (ndev < 2) {
+    std::printf("only 1 device visible: cross-device coverage skipped\n");
+    return 77;
+  }
+  return 0;
+}


### PR DESCRIPTION
A 2D type-1 double transform runs on every visible device, with and without a
user stream, and every result must match the device-0 default-stream one to a
tight relative L2 error. The call is always made with device 0 current, so it
also checks that cufinufft restores the caller's device, and an unusable
gpu_device_id must come back as FINUFFT_ERR_CUDA_FAILURE rather than a crash.

With one visible device the loop never leaves device 0, so the cross-device
half does not run: the test then exits 77 and ctest reports a SKIP instead of a
green that overstates coverage. That is the common case in CI, and on a MIG pod,
which exposes one instance per process.

Fails before the last commit: with two devices the transform on device 1 dies
with cudaErrorIllegalAddress.

Spotted thanks to @dylex and the new jenkins that allows to run multiple GPUs :)

Assisted-by: Claude Opus 5 <noreply@anthropic.com>