### PR TITLE
fix: respect affinity map

### DIFF
--- a/devel/CMakeLists.txt
+++ b/devel/CMakeLists.txt
@@ -28,6 +28,11 @@ target_compile_options(padding PRIVATE -march=native)
 add_executable(guru_benchmark guru_benchmark.cpp)
 target_link_libraries(guru_benchmark finufft benchmark)
 
+# reports the detected thread count for the current affinity mask; run it under taskset
+add_executable(thread_count_affinity thread_count_affinity.cpp)
+target_compile_features(thread_count_affinity PRIVATE cxx_std_17)
+target_link_libraries(thread_count_affinity finufft)
+
 add_executable(binsort_gbench binsort_bench.cpp)
 target_link_libraries(binsort_gbench finufft benchmark xsimd)
 target_compile_options(binsort_gbench PRIVATE ${FINUFFT_ARCH_FLAGS})

--- a/devel/thread_count_affinity.cpp
+++ b/devel/thread_count_affinity.cpp
@@ -1,0 +1,56 @@
+/* Manual check that the default thread count follows the CPU affinity mask.
+   Devel-only: it needs an externally applied mask, so it is not a CI test.
+
+   Usage (Linux; 6 P-cores with SMT + 8 E-cores + 2 LP-E shown):
+
+     cmake -S . -B build -DFINUFFT_BUILD_DEVEL=ON && cmake --build build -j
+     ./build/devel/thread_count_affinity              # whole machine: nthr=16
+     taskset -c 0-11 ./build/devel/thread_count_affinity   # 6 cores, SMT: expect 6
+     taskset -c 0,5  ./build/devel/thread_count_affinity   # 1 core, both siblings: 1
+     taskset -c 12-19 ./build/devel/thread_count_affinity  # 8 E-cores: 8
+
+   Before the mask was honoured, `taskset -c 0-11` reported 12: physical cores of the
+   whole machine were compared against logical CPUs in the mask, so an SMT pair counted
+   twice and 12 threads shared 6 cores. The interesting masks are the ones holding both
+   siblings of a core - a mask of distinct cores gives the right answer either way.
+
+   opts.nthreads is left 0, so makeplan takes the detected count and prints it with
+   debug=1 as "nthr=".
+*/
+
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <finufft.h>
+#include <vector>
+#ifdef __linux__
+#include <sched.h>
+#endif
+
+int main() {
+#ifdef __linux__
+  cpu_set_t mask;
+  CPU_ZERO(&mask);
+  if (sched_getaffinity(0, sizeof(mask), &mask) == 0) {
+    printf("affinity mask: ");
+    for (int c = 0; c < CPU_SETSIZE; ++c)
+      if (CPU_ISSET(c, &mask)) printf("%d ", c);
+    printf("(%d CPUs)\n", CPU_COUNT(&mask));
+  }
+#else
+  printf("no affinity API on this platform; reporting the unmasked count\n");
+#endif
+
+  finufft_opts opts;
+  finufft_default_opts(&opts);
+  opts.debug = 1; // prints "nthr=" - the count under test
+  finufft_plan plan;
+  int64_t N[3] = {32, 32, 32};
+  if (finufft_makeplan(1, 3, N, 1, 1, 1e-6, &plan, &opts)) return 1;
+  std::vector<double> x(1000, 0.0);
+  std::vector<std::complex<double>> c(1000), F(32 * 32 * 32);
+  finufft_setpts(plan, 1000, x.data(), x.data(), x.data(), 0, nullptr, nullptr, nullptr);
+  finufft_execute(plan, c.data(), F.data());
+  finufft_destroy(plan);
+  return 0;
+}

--- a/devel/thread_count_affinity.cpp
+++ b/devel/thread_count_affinity.cpp
@@ -1,0 +1,45 @@
+/* Manual check that the default thread count follows the CPU affinity mask; needs an
+   externally applied mask, so it is not a CI test. opts.nthreads stays 0, so debug=1
+   prints the detected count as "nthr=".
+
+     taskset -c $(cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list) \
+         ./build/devel/thread_count_affinity     # one core, both siblings: expect nthr=1
+
+   Masks holding both SMT siblings of a core are the interesting ones; a mask of distinct
+   cores was already right before the fix.
+*/
+
+#include <cstdint>
+#include <cstdio>
+#include <finufft.h>
+#include <vector>
+#ifdef __linux__
+#include <sched.h>
+#endif
+
+int main() {
+#ifdef __linux__
+  cpu_set_t mask;
+  CPU_ZERO(&mask);
+  if (sched_getaffinity(0, sizeof(mask), &mask) == 0) {
+    printf("affinity mask: ");
+    for (int c = 0; c < CPU_SETSIZE; ++c)
+      if (CPU_ISSET(c, &mask)) printf("%d ", c);
+    printf("(%d CPUs)\n", CPU_COUNT(&mask));
+  }
+#else
+  printf("no affinity API on this platform; reporting the unmasked count\n");
+#endif
+
+  finufft_opts opts;
+  finufft_default_opts(&opts);
+  opts.debug = 1; // prints "nthr=" - the count under test
+  finufft_plan plan;
+  int64_t N[3] = {32, 32, 32};
+  if (finufft_makeplan(1, 3, N, 1, 1, 1e-6, &plan, &opts)) return 1;
+  // nthr is chosen when setpts sizes the grid, so the transform itself is not needed
+  std::vector<double> x(1000, 0.0);
+  finufft_setpts(plan, 1000, x.data(), x.data(), x.data(), 0, nullptr, nullptr, nullptr);
+  finufft_destroy(plan);
+  return 0;
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -7,18 +7,17 @@
 #include <finufft/utils.hpp>
 
 #include <cinttypes>
+#include <climits>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
-#include <utility>
 
 #include <chrono>
 #include <iostream>
-#include <sstream>
-#include <string>
 
 #if defined(_WIN32)
+#include <random> // for the rand_r shim at the bottom
 #include <vector>
 #include <windows.h>
 #elif defined(__APPLE__)
@@ -30,7 +29,6 @@
 #endif
 #include <fstream>
 #include <sched.h>
-#include <set>
 #endif
 
 namespace finufft::utils {
@@ -64,189 +62,104 @@ double CNTime::elapsedsec() const
 
 #ifdef _OPENMP
 namespace { // helpers local to this TU
-#if defined(_WIN32)
-// Returns the number of physical CPU cores on Windows (excluding hyper-threaded cores)
-unsigned getPhysicalCoreCount() {
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
-  int physicalCoreCount = 0;
 
-  // Determine the required buffer size.
+// Physical cores this process may run on (0 if unknown): one thread per core within the
+// affinity mask, counting an SMT pair once. A cgroup CPU quota (docker --cpus) is not
+// visible here.
+
+#if defined(_WIN32)
+
+unsigned getAllowedPhysicalCoreCount() {
+  // both APIs see only our own processor group, so >64 logical CPUs counts within one
+  // group, as before
+  DWORD_PTR processMask, systemMask;
+  if (!GetProcessAffinityMask(GetCurrentProcess(), &processMask, &systemMask)) return 0;
+
+  // one RelationProcessorCore entry per core: count those owning an allowed CPU
   DWORD bufferSize = 0;
   if (GetLogicalProcessorInformation(nullptr, &bufferSize) == FALSE &&
-      GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-    return physicalCoreCount;
-  }
-
-  // Calculate the number of entries and allocate a vector.
-  size_t entryCount = bufferSize / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
-  std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> procInfo(entryCount);
-  if (GetLogicalProcessorInformation(procInfo.data(), &bufferSize) != FALSE) {
-    for (const auto &info : procInfo) {
-      if (info.Relationship == RelationProcessorCore) ++physicalCoreCount;
+      GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+    std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> procInfo(
+        bufferSize / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
+    if (GetLogicalProcessorInformation(procInfo.data(), &bufferSize) != FALSE) {
+      unsigned cores = 0;
+      for (const auto &info : procInfo)
+        cores += (info.Relationship == RelationProcessorCore &&
+                  (info.ProcessorMask & processMask));
+      if (cores) return cores;
     }
   }
-
-  if (physicalCoreCount == 0) {
-    return MY_OMP_GET_MAX_THREADS();
-  }
-  return physicalCoreCount;
-#else
-  // On non-x86 architectures, there should be no hyper-threading
-  return MY_OMP_GET_MAX_THREADS();
-#endif
-}
-
-unsigned getAllowedCoreCount() {
-  DWORD_PTR processMask, systemMask;
-  if (!GetProcessAffinityMask(GetCurrentProcess(), &processMask, &systemMask)) {
-    return 0; // API call failed (should rarely happen for the current process)
-  }
-  // Count bits in processMask
-  int count = 0;
-  while (processMask) {
-    count += static_cast<int>(processMask & 1U);
-    processMask >>= 1;
-  }
+  // no topology: count logical CPUs
+  unsigned count = 0;
+  for (DWORD_PTR m = processMask; m; m >>= 1) count += unsigned(m & 1U);
   return count;
 }
 
 #elif defined(__APPLE__)
 
-// Returns the number of physical CPU cores on macOS (excluding hyper-threaded cores)
-unsigned getPhysicalCoreCount() {
-  int physicalCoreCount = 0;
-  int cores             = 0;
-  size_t size           = sizeof(cores);
-  if (sysctlbyname("hw.physicalcpu", &cores, &size, nullptr, 0) == 0) {
-    physicalCoreCount = cores;
-  }
-
-  if (physicalCoreCount == 0) {
-    return MY_OMP_GET_MAX_THREADS();
-  }
-  return physicalCoreCount;
-}
-
-unsigned getAllowedCoreCount() {
-  // MacOS does not support CPU affinity, so we return the maximum number of threads.
-  return MY_OMP_GET_MAX_THREADS();
+unsigned getAllowedPhysicalCoreCount() {
+  // no affinity API on macOS: the whole machine is always allowed
+  int cores = 0;
+  size_t size = sizeof(cores);
+  if (sysctlbyname("hw.physicalcpu", &cores, &size, nullptr, 0) != 0) return 0;
+  return cores > 0 ? unsigned(cores) : 0; // never let a bogus value wrap
 }
 
 #elif defined(__linux__)
-// Returns the number of physical CPU cores on Linux (excluding hyper-threaded cores)
-// Compatibility:
-// - Linux kernels 2.6 and later (provides /sys/devices/system/cpu topology interface)
-// - Any CPU architecture supported by the kernel (Intel, AMD, ARM, POWER, etc.)
-// - Works in containers or cgroups (reflects host topology)
-unsigned getPhysicalCoreCount() {
-  // only x86_64 and x86_32 architectures support HT (hyper-threading)
-  // in all other cases, we assume no HT and return MY_OMP_GET_MAX_THREADS()
-#if defined(__i386__) || defined(__x86_64__)
-  // Parse strings like "0-3,5,7-9" → {0,1,2,3,5,7,8,9}
-  auto parseCpuList = [](const std::string &s) {
-    std::vector<int> cpus;
-    std::istringstream iss(s);
-    for (std::string tok; std::getline(iss, tok, ',');) {
-      auto dash = tok.find('-');
-      if (dash == std::string::npos) {
-        cpus.push_back(std::stoi(tok));
-      } else {
-        int start = std::stoi(tok.substr(0, dash));
-        int end   = std::stoi(tok.substr(dash + 1));
-        for (int i = start; i <= end; ++i) cpus.push_back(i);
-      }
-    }
-    return cpus;
-  };
 
-  // Read a single integer from the given sysfs file
-  auto readInt = [&](const std::string &path, int &out) -> bool {
-    std::ifstream f(path);
-    if (!f.is_open()) return false;
-    f >> out;
-    return !f.fail();
-  };
+unsigned getAllowedPhysicalCoreCount() {
+  cpu_set_t mask;
+  CPU_ZERO(&mask);
+  if (sched_getaffinity(0, sizeof(mask), &mask) != 0) return 0;
 
-  // 1) Read list of present CPUs
-  std::ifstream presentF("/sys/devices/system/cpu/present");
-  if (!presentF.is_open()) {
-    return MY_OMP_GET_MAX_THREADS();
-  }
-  std::string presentLine;
-  std::getline(presentF, presentLine);
-  auto cpus = parseCpuList(presentLine);
-
-  // 2) For each CPU, read its package & core IDs
-  std::set<std::pair<int, int>> physicalCores;
-  for (int cpu : cpus) {
-    std::string topoBase =
-        "/sys/devices/system/cpu/cpu" + std::to_string(cpu) + "/topology/";
-    int pkg = -1, core = -1;
-    if (!readInt(topoBase + "physical_package_id", pkg)) continue;
-    if (!readInt(topoBase + "core_id", core)) continue;
-    physicalCores.emplace(pkg, core);
-  }
-
-  // 3) Return count if successful, else fallback
-  if (!physicalCores.empty()) {
-    return static_cast<unsigned>(physicalCores.size());
-  }
-#endif
-  // in ARM and RISKV we only need this
-  return MY_OMP_GET_MAX_THREADS();
-}
-
-unsigned getAllowedCoreCount() {
-  cpu_set_t cpuSet;
-  CPU_ZERO(&cpuSet);
-  if (sched_getaffinity(0, sizeof(cpu_set_t), &cpuSet) != 0) {
-    return 0; // Error (e.g., not supported or failed)
-  }
-  int count = 0;
+  // sysfs prints a CPU mask in ascending order, so the first sibling id names the core:
+  // both SMT siblings map to the same one and the core is counted once. A CPU with no
+  // such file (no sysfs topology at all) is its own core.
+  // (core_id is unusable: arm64/riscv without firmware topology report -1 for every CPU,
+  // which would collapse the whole machine to one core.)
+  cpu_set_t cores;
+  CPU_ZERO(&cores);
   for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
-    if (CPU_ISSET(cpu, &cpuSet)) {
-      ++count;
-    }
+    if (!CPU_ISSET(cpu, &mask)) continue;
+    char path[64];
+    snprintf(path, sizeof path,
+             "/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", cpu);
+    std::ifstream f(path);
+    int first; // stops at the ',' or '-' of a multi-sibling list
+    if (!(f >> first) || first < 0 || first >= CPU_SETSIZE) first = cpu;
+    CPU_SET(first, &cores);
   }
-  return count;
+  return unsigned(CPU_COUNT(&cores));
 }
 
 #else
 
 #warning "Unknown platform. Impossible to detect the number of physical cores."
-// Fallback version if none of the above platforms is detected.
-unsigned getPhysicalCoreCount() { return MY_OMP_GET_MAX_THREADS(); }
-unsigned getAllowedCoreCount() { return MY_OMP_GET_MAX_THREADS(); }
+unsigned getAllowedPhysicalCoreCount() { return 0; }
 
 #endif
 } // anonymous namespace
 
 unsigned getOptimalThreadCount() {
-  // if the user has set the OMP_NUM_THREADS environment variable, use that value
   static const auto cached_threads = []() -> unsigned {
-    const auto OMP_THREADS = std::getenv("OMP_NUM_THREADS");
-    if (OMP_THREADS) {
-      try {
-        return std::stoi(OMP_THREADS);
-      } catch (...) {
-        std::cerr << "Invalid OMP_NUM_THREADS value: " << OMP_THREADS
-                  << ". using default thread count." << std::endl;
-      }
+    // an explicit OMP_NUM_THREADS wins over anything we detect
+    if (const auto env = std::getenv("OMP_NUM_THREADS")) {
+      char *end;
+      const auto nthr = std::strtoll(env, &end, 10); // end==env if it does not parse
+      // 0 and negatives are not usable: 0 aborts makeplan, a negative wraps to a huge
+      // unsigned and crashes the FFT setup. Warn and detect instead. (INT_MAX, not
+      // numeric_limits: windows.h makes max() a macro.)
+      if (end != env && nthr > 0 && nthr <= INT_MAX) return unsigned(nthr);
+      std::cerr << "Invalid OMP_NUM_THREADS value: " << env
+                << ". using default thread count." << std::endl;
     }
-    // otherwise, use the min between number of physical cores or the number of allowed
-    // cores (e.g. by taskset)
     try {
-      const auto physicalCores = getPhysicalCoreCount();
-      const auto allowedCores  = getAllowedCoreCount();
-      if (physicalCores < allowedCores) {
-        return physicalCores;
-      }
-      return allowedCores;
+      if (const auto cores = getAllowedPhysicalCoreCount()) return cores;
     } catch (const std::exception &e) {
       std::cerr << "Error determining optimal thread count: " << e.what()
                 << ". Using OpenMP default thread count." << std::endl;
     }
-    return MY_OMP_GET_MAX_THREADS();
+    return MY_OMP_GET_MAX_THREADS(); // detection failed
   }();
 
   return cached_threads;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -25,6 +25,7 @@
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #elif defined(__linux__)
+#include <vector>
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE // Enable GNU extensions for sched_getaffinity
 #endif
@@ -96,17 +97,37 @@ unsigned getPhysicalCoreCount() {
 #endif
 }
 
+// Physical cores this process may run on: cores with at least one logical CPU in the
+// affinity mask, so an SMT sibling pair counts once and the count is comparable with
+// getPhysicalCoreCount(). Counting mask bits instead would count that pair twice, and the
+// min() of the two then picks the SMT number, which oversubscribes.
+// Only the process's own processor group is visible through GetProcessAffinityMask, so
+// above 64 logical CPUs this describes one group; that limit is unchanged from before.
 unsigned getAllowedCoreCount() {
   DWORD_PTR processMask, systemMask;
   if (!GetProcessAffinityMask(GetCurrentProcess(), &processMask, &systemMask)) {
     return 0; // API call failed (should rarely happen for the current process)
   }
-  // Count bits in processMask
-  int count = 0;
-  while (processMask) {
-    count += static_cast<int>(processMask & 1U);
-    processMask >>= 1;
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+  DWORD bufferSize = 0;
+  if (GetLogicalProcessorInformation(nullptr, &bufferSize) == FALSE &&
+      GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+    std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> procInfo(
+        bufferSize / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
+    if (GetLogicalProcessorInformation(procInfo.data(), &bufferSize) != FALSE) {
+      unsigned cores = 0;
+      for (const auto &info : procInfo) {
+        if (info.Relationship == RelationProcessorCore &&
+            (info.ProcessorMask & processMask))
+          ++cores;
+      }
+      if (cores) return cores;
+    }
   }
+#endif
+  // no topology available: fall back to counting the logical CPUs in the mask
+  unsigned count = 0;
+  for (DWORD_PTR m = processMask; m; m >>= 1) count += static_cast<unsigned>(m & 1U);
   return count;
 }
 
@@ -133,82 +154,89 @@ unsigned getAllowedCoreCount() {
 }
 
 #elif defined(__linux__)
-// Returns the number of physical CPU cores on Linux (excluding hyper-threaded cores)
+// Highest CPU index the kernel knows about, from /sys/devices/system/cpu/present (e.g.
+// "0-21", or "0-3,8-11" when indices are sparse - the last number is what matters). -1 if
+// sysfs is unavailable. Only the bound is needed, so there is no list to parse: the
+// per-CPU topology read below skips indices that do not exist.
+int maxCpuIndex() {
+  std::ifstream f("/sys/devices/system/cpu/present");
+  std::string present;
+  if (!(f >> present)) return -1;
+  const auto last = present.find_last_of("-,");
+  return std::atoi(present.c_str() + (last == std::string::npos ? 0 : last + 1));
+}
+
+// Which physical core a CPU belongs to, as (package, core). {-1, -1} when sysfs has no
+// topology for it, which is also how absent CPU indices are skipped.
 // Compatibility:
-// - Linux kernels 2.6 and later (provides /sys/devices/system/cpu topology interface)
+// - Linux kernels 2.6 and later (provides /sys/devices/system/cpu topology interface);
+//   older kernels or architectures without the interface make countCores() return 0 and
+//   the callers fall back
 // - Any CPU architecture supported by the kernel (Intel, AMD, ARM, POWER, etc.)
-// - Works in containers or cgroups (reflects host topology)
+std::pair<int, int> coreOfCpu(int cpu) {
+  const std::string topo =
+      "/sys/devices/system/cpu/cpu" + std::to_string(cpu) + "/topology/";
+  std::ifstream pkgF(topo + "physical_package_id"), coreF(topo + "core_id");
+  int pkg = -1, core = -1;
+  if (pkgF >> pkg && coreF >> core) return {pkg, core};
+  return {-1, -1};
+}
+
+// CPU index -> its (package, core), for every index the kernel reports; {-1, -1} for
+// indices that do not exist. Read once: the two counts below differ only by which CPUs
+// they look at, so re-reading sysfs per count would double the file opens at plan
+// creation.
+const std::vector<std::pair<int, int>> &cpuTopology() {
+  static const std::vector<std::pair<int, int>> topo = [] {
+    std::vector<std::pair<int, int>> t;
+    const int maxCpu = maxCpuIndex();
+    for (int cpu = 0; cpu <= maxCpu && cpu < CPU_SETSIZE; ++cpu)
+      t.push_back(coreOfCpu(cpu));
+    return t;
+  }();
+  return topo;
+}
+
+// How many distinct physical cores the CPUs in the mask cover (all CPUs if it is null),
+// so an SMT sibling pair counts once. 0 if the topology cannot be read at all.
+unsigned countCores(const cpu_set_t *mask) {
+  const auto &topo = cpuTopology();
+  std::set<std::pair<int, int>> cores;
+  for (int cpu = 0; cpu < int(topo.size()); ++cpu) {
+    if (mask && !CPU_ISSET(cpu, mask)) continue;
+    if (topo[cpu].first >= 0) cores.insert(topo[cpu]);
+  }
+  return static_cast<unsigned>(cores.size());
+}
+
+// Physical cores on the machine, ignoring any affinity restriction.
 unsigned getPhysicalCoreCount() {
   // only x86_64 and x86_32 architectures support HT (hyper-threading)
   // in all other cases, we assume no HT and return MY_OMP_GET_MAX_THREADS()
 #if defined(__i386__) || defined(__x86_64__)
-  // Parse strings like "0-3,5,7-9" → {0,1,2,3,5,7,8,9}
-  auto parseCpuList = [](const std::string &s) {
-    std::vector<int> cpus;
-    std::istringstream iss(s);
-    for (std::string tok; std::getline(iss, tok, ',');) {
-      auto dash = tok.find('-');
-      if (dash == std::string::npos) {
-        cpus.push_back(std::stoi(tok));
-      } else {
-        int start = std::stoi(tok.substr(0, dash));
-        int end   = std::stoi(tok.substr(dash + 1));
-        for (int i = start; i <= end; ++i) cpus.push_back(i);
-      }
-    }
-    return cpus;
-  };
-
-  // Read a single integer from the given sysfs file
-  auto readInt = [&](const std::string &path, int &out) -> bool {
-    std::ifstream f(path);
-    if (!f.is_open()) return false;
-    f >> out;
-    return !f.fail();
-  };
-
-  // 1) Read list of present CPUs
-  std::ifstream presentF("/sys/devices/system/cpu/present");
-  if (!presentF.is_open()) {
-    return MY_OMP_GET_MAX_THREADS();
-  }
-  std::string presentLine;
-  std::getline(presentF, presentLine);
-  auto cpus = parseCpuList(presentLine);
-
-  // 2) For each CPU, read its package & core IDs
-  std::set<std::pair<int, int>> physicalCores;
-  for (int cpu : cpus) {
-    std::string topoBase =
-        "/sys/devices/system/cpu/cpu" + std::to_string(cpu) + "/topology/";
-    int pkg = -1, core = -1;
-    if (!readInt(topoBase + "physical_package_id", pkg)) continue;
-    if (!readInt(topoBase + "core_id", core)) continue;
-    physicalCores.emplace(pkg, core);
-  }
-
-  // 3) Return count if successful, else fallback
-  if (!physicalCores.empty()) {
-    return static_cast<unsigned>(physicalCores.size());
-  }
+  if (const unsigned n = countCores(nullptr)) return n;
 #endif
   // in ARM and RISKV we only need this
   return MY_OMP_GET_MAX_THREADS();
 }
 
+// Physical cores this process may actually run on. Counted in cores, not logical CPUs, so
+// that it is comparable with getPhysicalCoreCount(): counting CPUs lets an SMT sibling
+// pair count twice, and the min() of the two then picks the SMT number, which
+// oversubscribes (taskset -c 0-11 on a 6P+8E machine asked 12 threads to share 6 cores).
+// Covers taskset and cgroup/cpuset pinning, which all land in the mask. NOT cgroup CPU
+// quota (cpu.max, i.e. docker --cpus=2): that throttles bandwidth without restricting the
+// mask, so a quota-limited container still reports every core here.
 unsigned getAllowedCoreCount() {
   cpu_set_t cpuSet;
   CPU_ZERO(&cpuSet);
-  if (sched_getaffinity(0, sizeof(cpu_set_t), &cpuSet) != 0) {
+  if (sched_getaffinity(0, sizeof(cpuSet), &cpuSet) != 0) {
     return 0; // Error (e.g., not supported or failed)
   }
-  int count = 0;
-  for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
-    if (CPU_ISSET(cpu, &cpuSet)) {
-      ++count;
-    }
-  }
-  return count;
+#if defined(__i386__) || defined(__x86_64__)
+  if (const unsigned n = countCores(&cpuSet)) return n;
+#endif
+  return static_cast<unsigned>(CPU_COUNT(&cpuSet)); // no topology: logical CPUs
 }
 
 #else
@@ -234,14 +262,13 @@ unsigned getOptimalThreadCount() {
       }
     }
     // otherwise, use the min between number of physical cores or the number of allowed
-    // cores (e.g. by taskset)
+    // cores (e.g. by taskset). Both are counted in cores, so the min is meaningful; 0
+    // means that detection failed, and must not become the thread count.
     try {
       const auto physicalCores = getPhysicalCoreCount();
       const auto allowedCores  = getAllowedCoreCount();
-      if (physicalCores < allowedCores) {
-        return physicalCores;
-      }
-      return allowedCores;
+      if (allowedCores && allowedCores < physicalCores) return allowedCores;
+      if (physicalCores) return physicalCores;
     } catch (const std::exception &e) {
       std::cerr << "Error determining optimal thread count: " << e.what()
                 << ". Using OpenMP default thread count." << std::endl;


### PR DESCRIPTION
the old way of detecting the physical threads was not checking if only a subset of threads was allowed by for example taskset. This fixes it. 