### PR TITLE
fix(cuda): widen 32-bit nf, batch-offset and mode products

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,13 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 v2.6.0-dev
 
+* cuFINUFFT: fixed 32-bit overflows on large 3D fine grids. The `MAX_NF` guards
+  multiplied `int` operands, so `nf` and `nf*gpu_maxbatchsize` wrapped before the
+  comparison could reject them and the allocation came out undersized; `deconvolve_nd`
+  and the execute loops accumulated `nmodes`, `nftot` and the per-batch offsets
+  `i*batchsize*{M,nf,nmodes}` in `int`, which index device memory. `MAX_NF` itself is
+  unchanged, so this only makes the existing bound enforceable. The index types stay
+  32-bit; widening them is tracked in #890. (Barbone)
 * Fixed CPU type 3 honoring `opts.spreadinterponly`: the option is documented to affect
   types 1 and 2 only, and cuFINUFFT already ignored it for type 3, but the CPU plan
   applied it, so a type-3 call with the flag set returned wrong values instead of the

--- a/include/cufinufft/types.hpp
+++ b/include/cufinufft/types.hpp
@@ -65,7 +65,8 @@ struct GpuCapabilities {
   int max_smem_per_sm{};          // bytes
   int max_threads_per_sm{};
   int multiprocessor_count{};
-  int l2_cache_size{}; // bytes
+  int l2_cache_size{};        // bytes
+  int global_mem_bus_width{}; // bits; GDDR reports <= 512, HBM >= 4096
   int memory_pools_supported{};
 
   static GpuCapabilities query(int device_id) {
@@ -81,6 +82,7 @@ struct GpuCapabilities {
     get(&gpu.max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor);
     get(&gpu.multiprocessor_count, cudaDevAttrMultiProcessorCount);
     get(&gpu.l2_cache_size, cudaDevAttrL2CacheSize);
+    get(&gpu.global_mem_bus_width, cudaDevAttrGlobalMemoryBusWidth);
     get(&gpu.memory_pools_supported, cudaDevAttrMemoryPoolsSupported);
     return gpu;
   }

--- a/src/cuda/execute.cu
+++ b/src/cuda/execute.cu
@@ -2,6 +2,7 @@
 // plus the deconvolve kernel that only the execute path uses.
 // Mirrors CPU src/execute.cpp.
 
+#include <cstdint>
 #include <iostream>
 
 #include <cufinufft/contrib/helper_cuda.h>
@@ -72,7 +73,9 @@ void cufinufft_plan_t<T>::deconvolve_nd<modeord, ndim>(
     Melody Shih 11/21/21
 */
 {
-  int nmodes = 1, nftot = 1;
+  // 64-bit: each of these is at most nf, so it fits MAX_NF (INT32_MAX), but the
+  // batchsize * nftot and t * nmodes offsets below do not.
+  std::int64_t nmodes = 1, nftot = 1;
   for (int idim = 0; idim < ndim; ++idim) {
     nmodes *= mstu[idim];
     nftot *= nf123[idim];
@@ -83,8 +86,8 @@ void cufinufft_plan_t<T>::deconvolve_nd<modeord, ndim>(
     checkCudaErrors(
         cudaMemsetAsync(fw, 0, batchsize * nftot * sizeof(cuda_complex<T>), stream));
 
-  for (int t = 0; t < blksize; t++)
-    deconv_nd<T, modeord, ndim><<<(nmodes + 256 - 1) / 256, 256, 0, stream>>>(
+  for (std::int64_t t = 0; t < blksize; t++)
+    deconv_nd<T, modeord, ndim><<<uint((nmodes + 256 - 1) / 256), 256, 0, stream>>>(
         mstu, nf123, fw + t * nftot, fk + t * nmodes, dethrust(fwkerhalf), fw2fk);
 }
 
@@ -119,20 +122,20 @@ void cufinufft_plan_t<T>::execute_type1(cuda_complex<T> *d_c, cuda_complex<T> *d
 {
   assert(spopts.spread_direction == 1);
 
-  int nmodes = 1;
+  std::int64_t nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
   // Uninitialized: spread memsets fw below. Size 0 when spreading only, which spreads
   // straight into f.
   const bool spread_only = opts.gpu_spreadinterponly;
-  gpu_scratch<cuda_complex<T>> fwp(spread_only ? 0 : nf * batchsize, alloc);
-  for (int i = 0; i * batchsize < ntransf; i++) {
-    int blksize = std::min(ntransf - i * batchsize, batchsize);
+  gpu_scratch<cuda_complex<T>> fwp(spread_only ? 0 : std::size_t(nf) * batchsize, alloc);
+  for (std::int64_t i = 0; i * batchsize < ntransf; i++) {
+    int blksize = int(std::min<std::int64_t>(ntransf - i * batchsize, batchsize));
     const auto *c = d_c + i * batchsize * M;
     auto *fk = d_fk + i * batchsize * nmodes; // deconvolve writes user output f
     auto *fw = spread_only ? fk : fwp.data();
 
-    checkCudaErrors(
-        cudaMemsetAsync(fw, 0, blksize * nf * sizeof(cuda_complex<T>), stream));
+    checkCudaErrors(cudaMemsetAsync(
+        fw, 0, std::size_t(blksize) * nf * sizeof(cuda_complex<T>), stream));
 
     // Step 1: Spread
     spreadSorted(c, fw, blksize);
@@ -172,17 +175,21 @@ void cufinufft_plan_t<T>::execute_type2(cuda_complex<T> *d_c, cuda_complex<T> *d
   int ntransf_for_this_run = ntransf;
   if (ntransf_override) ntransf_for_this_run = *ntransf_override;
 
-  int nmodes = 1;
+  std::int64_t nmodes = 1;
   for (int idim = 0; idim < dim; ++idim) nmodes *= mstu[idim];
   // Uninitialized: deconvolve overwrites fw below. Size 0 when interpolating only, which
   // reads f directly.
   const bool interp_only = opts.gpu_spreadinterponly;
-  gpu_scratch<cuda_complex<T>> fwp(interp_only || fw_scratch ? 0 : nf * batchsize, alloc);
+  gpu_scratch<cuda_complex<T>> fwp(interp_only || fw_scratch
+                                       ? 0
+                                       : std::size_t(nf) * batchsize,
+                                   alloc);
   auto *const fwbuf = fw_scratch ? fw_scratch : fwp.data();
   // cufft_ex transforms all `batchsize` grids even when blksize < batchsize; the extra
   // ones hold stale data and are discarded.
-  for (int i = 0; i * batchsize < ntransf_for_this_run; i++) {
-    int blksize = std::min(ntransf_for_this_run - i * batchsize, batchsize);
+  for (std::int64_t i = 0; i * batchsize < ntransf_for_this_run; i++) {
+    int blksize =
+        int(std::min<std::int64_t>(ntransf_for_this_run - i * batchsize, batchsize));
     auto *c = d_c + i * batchsize * M;
     auto *fk = d_fk + i * batchsize * nmodes;
     auto *fw = interp_only ? fk : fwbuf;
@@ -223,10 +230,10 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
   // and deconvolve_nd overwrites the whole batchsize*nf before reading it.
   gpu_scratch<cuda_complex<T>> CpBatch(std::size_t(std::max(M, t2_plan->nf)) * batchsize,
                                        alloc);
-  gpu_array<cuda_complex<T>> fwp(nf * batchsize, alloc);
+  gpu_array<cuda_complex<T>> fwp(std::size_t(nf) * batchsize, alloc);
   auto *fw = dethrust(fwp);
-  for (int i = 0; i * batchsize < ntransf; i++) {
-    int blksize = std::min(ntransf - i * batchsize, batchsize);
+  for (std::int64_t i = 0; i * batchsize < ntransf; i++) {
+    int blksize = int(std::min<std::int64_t>(ntransf - i * batchsize, batchsize));
     cuda_complex<T> *d_cstart  = d_c + i * batchsize * M;
     cuda_complex<T> *d_fkstart = d_fk + i * batchsize * N;
     // setting input for spreader
@@ -234,8 +241,8 @@ void cufinufft_plan_t<T>::execute_type3(cuda_complex<T> *d_c,
     // setting output for spreader
     auto *fk = fw;
     // NOTE: fw might need to be set to 0
-    checkCudaErrors(
-        cudaMemsetAsync(fw, 0, blksize * nf * sizeof(cuda_complex<T>), stream));
+    checkCudaErrors(cudaMemsetAsync(
+        fw, 0, std::size_t(blksize) * nf * sizeof(cuda_complex<T>), stream));
     // Step 0: pre-phase the input strengths
     for (int block = 0; block < blksize; block++) {
       thrust::transform(thrust::cuda::par.on(stream), dethrust(prephase),

--- a/src/cuda/heuristics.cu
+++ b/src/cuda/heuristics.cu
@@ -74,7 +74,8 @@ void GpuCapabilities::print_classification(int debug_level) const {
   printf("  Occupancy:\n");
   printf("    Max warps/SM: %d\n", max_warps_per_sm());
   printf("    Max threads/SM: %d\n", max_threads_per_sm);
-  printf("  L2: %.1f MB\n", l2_cache_size / 1048576.0);
+  printf("  L2: %.1f MB, memory bus: %d bits\n", l2_cache_size / 1048576.0,
+         global_mem_bus_width);
 
   if (debug_level >= 3) {
     printf("  Binsize Categories:\n");

--- a/src/cuda/makeplan.cu
+++ b/src/cuda/makeplan.cu
@@ -2,6 +2,7 @@
 // Mirrors CPU src/makeplan.cpp. Also hosts the cufft_plan RAII destructor,
 // which is tied to plan setup.
 
+#include <cstdint>
 #include <iostream>
 
 #include <cufinufft/contrib/helper_cuda.h>
@@ -350,7 +351,15 @@ cufinufft_plan_t<T>::cufinufft_plan_t(int type_, int dim_, const int *nmodes, in
         printf("[cufinufft] (nf1,nf2,nf3) = (%d, %d, %d)\n", nf123[0], nf123[1],
                nf123[2]);
     }
-    nf = nf123[0] * nf123[1] * nf123[2];
+    // Widen first: nf123 are CUFINUFFT_BIGINT (int), so a 3D grid past MAX_NF would
+    // overflow instead of being rejected.
+    const auto nf_wide = std::int64_t(nf123[0]) * nf123[1] * nf123[2];
+    if (nf_wide > MAX_NF) {
+      fprintf(stderr, "[%s] nf=%lld exceeds MAX_NF, not attempting malloc!\n", __func__,
+              (long long)nf_wide);
+      throw finufft::exception(FINUFFT_ERR_MAXNALLOC);
+    }
+    nf = CUFINUFFT_BIGINT(nf_wide);
 
     // The choice is L2-aware, so it waits for nf; type 3 stays 0 here and is resolved in
     // setpts, which owns the allocation it bounds (#846).

--- a/src/cuda/setpts.cu
+++ b/src/cuda/setpts.cu
@@ -1,6 +1,7 @@
 // "setpts" stage: cufinufft_plan_t<T>::setpts and the type-1/2 helper.
 // Mirrors CPU src/setpts.cpp.
 
+#include <cstdint>
 #include <iostream>
 
 #include <cufinufft/contrib/helper_cuda.h>
@@ -150,18 +151,20 @@ void cufinufft_plan_t<T>::setpts(int nj, const T *d_kx, const T *d_ky, const T *
              type3_params.gam[2], nf123[2], type3_params.h[2]);
     }
   }
-  nf = nf123[0] * nf123[1] * nf123[2];
-
   // FIXME: MAX_NF might be too small...
+  // Guard the fwBatch allocation, nf * batchsize. Widen first: CUFINUFFT_BIGINT is int
+  // and MAX_NF is INT32_MAX, so the product would overflow before tripping the guard.
+  const auto nf_wide = std::int64_t(nf123[0]) * nf123[1] * nf123[2];
   // Only known here: nf123 comes from the type-3 params computed above. The outer plan is
   // spread-only, so this resolves to 1 unless the user set gpu_maxbatchsize.
-  batchsize = cufinufft::common::choose_batchsize<T>(gpu, opts, ntransf, nf);
-  if (nf * batchsize > MAX_NF) {
+  batchsize = cufinufft::common::choose_batchsize<T>(gpu, opts, ntransf, nf_wide);
+  if (nf_wide * batchsize > MAX_NF) {
     fprintf(stderr,
             "[%s t3] fwBatch would be bigger than MAX_NF, not attempting malloc!\n",
             __func__);
     throw finufft::exception(FINUFFT_ERR_MAXNALLOC);
   }
+  nf = CUFINUFFT_BIGINT(nf_wide);
 
   for (int idim = 0; idim < dim; ++idim) {
     kxyzp[idim].resize(M);


### PR DESCRIPTION
Split out of #873, which is a perf change and should not carry correctness fixes. First scoped piece of #890.

Two overflow classes on large 3D fine grids, both independent of the batchsize work:

- **The `MAX_NF` guards were computed in `int`.** `nf = nf1*nf2*nf3` and `nf * gpu_maxbatchsize` wrapped before the comparison could reject them, so the guard passed and the allocation came out undersized. Widened to `int64` first, then compared. `makeplan` had no product guard at all for types 1/2 — it does now, which is the one behaviour change here rather than a pure type widening.
- **`deconvolve_nd` and the execute loops accumulated in `int`.** `nmodes`, `nftot` and the per-batch offsets `i*batchsize*{M,nf,nmodes}` overflow at `MAX_NF = 1e12`, and the offsets index into device memory, so this is a silent wrong-address write rather than a failed allocation.

`MAX_NF` itself is unchanged: this only makes the existing bound enforceable. The index *types* stay 32-bit — widening `CUFINUFFT_BIGINT`, the public `N` argument, and the cuFFT extents is #890, and needs an ABI decision plus a register-pressure measurement.

## Test plan

- [x] `ctest -R cufinufft` 288/288 on RTX 4070 Laptop, CUDA 13.3, sm_89, g++-15 host, `-DFINUFFT_USE_CPU=OFF`.
- [ ] No test exercises `nf` or `M` past 2^31 — that needs a large-memory device and is listed as item 5 of #890. Everything here is reasoned from the arithmetic, not from a reproducer.
- [ ] Second GPU / older CUDA toolkit via CI.

Draft until the above is filled in. Claude assisted with splitting this out of #873 and with the review of the arithmetic.