### PR TITLE
fix: warn on unknown MATLAB opts fields instead of ignoring them

### DIFF
--- a/docs/matlab_gpu.rst
+++ b/docs/matlab_gpu.rst
@@ -77,9 +77,10 @@ The interfaces are the same as the GPU ones except preceded by "cu".
 The options descriptions are rather abbreviated in the below;
 for full documentation see :ref:`opts_gpu`.
 Only the options listed below reach the library; any other field of ``opts``
-is ignored without warning. In particular ``gpu_stream`` cannot be set from
-MATLAB, which does not expose the CUDA stream backing a ``gpuArray``; see the
-timing note above for how to wait for a transform to finish.
+is ignored, with a ``FINUFFT:unknownOpt`` warning naming it. In particular
+``gpu_stream`` cannot be set from MATLAB, which does not expose the CUDA stream
+backing a ``gpuArray``; see the timing note above for how to wait for a
+transform to finish.
 Informative warnings and errors are raised in MATLAB style with unique
 codes (see sources ``errhandler.m``, ``cufinufft.mw``, and
 ``valid_*.m`` found `here <https://github.com/flatironinstitute/finufft/tree/master/matlab/>`_).

--- a/makefile
+++ b/makefile
@@ -521,6 +521,7 @@ octave: matlab/finufft.cpp $(STATICLIB)
 	$(OCTAVE) test/fullmathtest.m ;\
 	$(OCTAVE) test/check_finufft.m ;\
 	$(OCTAVE) test/check_finufft_single.m ;\
+	$(OCTAVE) test/check_opts.m ;\
 	$(OCTAVE) examples/guru1d1.m ;\
 	$(OCTAVE) examples/guru1d1_single.m ;\
 	$(OCTAVE) examples/guru1d1_adjoint.m)

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -179,6 +179,7 @@ if(FINUFFT_BUILD_OCTAVE)
             test/fullmathtest.m
             test/check_finufft.m
             test/check_finufft_single.m
+            test/check_opts.m
             examples/guru1d1.m
             examples/guru1d1_single.m
             examples/guru1d1_adjoint.m

--- a/matlab/cufinufft.cu
+++ b/matlab/cufinufft.cu
@@ -1163,6 +1163,15 @@ typedef std::complex<float> fcomplex;
      else if (strcmp(fname[ifield],"gpu_binsizez") == 0) {
        oc->gpu_binsizez = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
      }
+     else if (strcmp(fname[ifield],"gpu_obinsizex") == 0) {
+       oc->gpu_obinsizex = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
+     }
+     else if (strcmp(fname[ifield],"gpu_obinsizey") == 0) {
+       oc->gpu_obinsizey = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
+     }
+     else if (strcmp(fname[ifield],"gpu_obinsizez") == 0) {
+       oc->gpu_obinsizez = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
+     }
      else if (strcmp(fname[ifield],"gpu_device_id") == 0) {
        oc->gpu_device_id = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
      }

--- a/matlab/cufinufft.cu
+++ b/matlab/cufinufft.cu
@@ -1169,8 +1169,14 @@ typedef std::complex<float> fcomplex;
      else if (strcmp(fname[ifield],"gpu_np") == 0) {
        oc->gpu_np = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
      }
-     else
+     /* matlab-only field, handled in cufinufft_plan.m... */
+     else if (strcmp(fname[ifield],"floatprec") == 0) {
        continue;
+     }
+     else
+       mexWarnMsgIdAndTxt("FINUFFT:unknownOpt",
+                          "copy_cufinufft_opts: unknown option \"%s\" ignored.",
+                          fname[ifield]);
    }
    mxFree(fname);
  }

--- a/matlab/cufinufft.mw
+++ b/matlab/cufinufft.mw
@@ -92,6 +92,15 @@ $     }
 $     else if (strcmp(fname[ifield],"gpu_binsizez") == 0) {
 $       oc->gpu_binsizez = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
 $     }
+$     else if (strcmp(fname[ifield],"gpu_obinsizex") == 0) {
+$       oc->gpu_obinsizex = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
+$     }
+$     else if (strcmp(fname[ifield],"gpu_obinsizey") == 0) {
+$       oc->gpu_obinsizey = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
+$     }
+$     else if (strcmp(fname[ifield],"gpu_obinsizez") == 0) {
+$       oc->gpu_obinsizez = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
+$     }
 $     else if (strcmp(fname[ifield],"gpu_device_id") == 0) {
 $       oc->gpu_device_id = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
 $     }

--- a/matlab/cufinufft.mw
+++ b/matlab/cufinufft.mw
@@ -98,8 +98,14 @@ $     }
 $     else if (strcmp(fname[ifield],"gpu_np") == 0) {
 $       oc->gpu_np = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
 $     }
-$     else
+$     /* matlab-only field, handled in cufinufft_plan.m... */
+$     else if (strcmp(fname[ifield],"floatprec") == 0) {
 $       continue;
+$     }
+$     else
+$       mexWarnMsgIdAndTxt("FINUFFT:unknownOpt",
+$                          "copy_cufinufft_opts: unknown option \"%s\" ignored.",
+$                          fname[ifield]);
 $   }
 $   mxFree(fname);
 $ }

--- a/matlab/finufft.cpp
+++ b/matlab/finufft.cpp
@@ -1168,8 +1168,17 @@ typedef std::complex<float> fcomplex;
      else if (strcmp(fname[ifield],"showwarn") == 0) {
        oc->showwarn = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
      }
-     else
+     /* matlab-only or deprecated fields, handled in finufft_plan.m... */
+     else if (strcmp(fname[ifield],"floatprec") == 0 ||
+              strcmp(fname[ifield],"chkbnds") == 0 ||
+              strcmp(fname[ifield],"spread_kerevalmeth") == 0 ||
+              strcmp(fname[ifield],"spread_kerpad") == 0) {
        continue;
+     }
+     else
+       mexWarnMsgIdAndTxt("FINUFFT:unknownOpt",
+                          "copy_finufft_opts: unknown option \"%s\" ignored.",
+                          fname[ifield]);
    }
    mxFree(fname);
  }

--- a/matlab/finufft.mw
+++ b/matlab/finufft.mw
@@ -109,8 +109,17 @@ $     }
 $     else if (strcmp(fname[ifield],"showwarn") == 0) {
 $       oc->showwarn = (int)round(*mxGetPr(mxGetFieldByNumber(om,idx,ifield)));
 $     }
-$     else
+$     /* matlab-only or deprecated fields, handled in finufft_plan.m... */
+$     else if (strcmp(fname[ifield],"floatprec") == 0 ||
+$              strcmp(fname[ifield],"chkbnds") == 0 ||
+$              strcmp(fname[ifield],"spread_kerevalmeth") == 0 ||
+$              strcmp(fname[ifield],"spread_kerpad") == 0) {
 $       continue;
+$     }
+$     else
+$       mexWarnMsgIdAndTxt("FINUFFT:unknownOpt",
+$                          "copy_finufft_opts: unknown option \"%s\" ignored.",
+$                          fname[ifield]);
 $   }
 $   mxFree(fname);
 $ }

--- a/matlab/test/check_opts.m
+++ b/matlab/test/check_opts.m
@@ -1,0 +1,23 @@
+% Checks that a mistyped opts field warns rather than being silently ignored,
+% and that the fields the .m layer legitimately forwards stay silent. See #895.
+
+M = 10; N = 8;
+x = 2*pi*rand(M,1); c = randn(M,1) + 1i*randn(M,1);
+
+lastwarn('');
+o = struct('upsampfact', 2.0);              % typo for upsampfac
+finufft1d1(x, c, +1, 1e-6, N, o);
+[~, id] = lastwarn();
+if ~strcmp(id, 'FINUFFT:unknownOpt')
+  error('check_opts: mistyped opts field did not warn (id was "%s")', id);
+end
+
+lastwarn('');
+o = struct('upsampfac', 2.0, 'debug', 0);   % floatprec is added by finufft1d1
+finufft1d1(x, c, +1, 1e-6, N, o);
+[~, id] = lastwarn();
+if ~isempty(id)
+  error('check_opts: valid opts warned unexpectedly ("%s")', id);
+end
+
+fprintf('check_opts: passed\n');


### PR DESCRIPTION
Closes #895.

Both MEX opts parsers ended in a catch-all `continue`, so a mistyped field was dropped without a word and the transform ran with defaults:

```matlab
opts.gpu_methhod = 2;                       % typo
f = cufinufft2d1(x,y,c,+1,tol,N1,N2,opts);  % ran with gpu_method = 0, silently
```

They now warn with id `FINUFFT:unknownOpt`, naming the field:

```
warning: finufft: copy_finufft_opts: unknown option "upsampfact" ignored.
```

**Warning, not error.** The option is still ignored and execution continues. The plan classes forward the user's struct verbatim, so the parsers legitimately receive fields they must not act on — `floatprec`, which `finufft1d1.m` sets unconditionally and `{cu}finufft_plan.m` consumes, and the deprecated CPU options `chkbnds`, `spread_kerevalmeth`, `spread_kerpad`, which already warn in `finufft_plan.m`. Those stay silent. Erroring instead would break code that shares one opts struct across CPU and GPU calls, where each parser sees the other's field names; it would also need those names whitelisted in both parsers, which is more surface to drift. Happy to switch to `mexErrMsgIdAndTxt` (one line, same spot) if we would rather match the Python interface, which raises `TypeError: Invalid option '...'`.

Both the `.mw` sources and the mwrap-generated `finufft.cpp` / `cufinufft.cu` are edited, since the generated files are checked in and mwrap is not needed to build. The inserted block is byte-identical in each pair. The whitespace pre-commit hooks are skipped for this commit so `cufinufft.cu` stays byte-identical to mwrap's output — it carries pre-existing trailing whitespace in mwrap boilerplate that the hooks would otherwise rewrite across ~20 unrelated hunks.

The second commit wires up `gpu_obinsizex/y/z`, which are real `cufinufft_opts` members documented as `gpu_{o}binsize{x,y,z}` but had no branch in `copy_cufinufft_opts`; without it the new warning would report a documented option as unknown. Every field of both `finufft_opts` and `cufinufft_opts` now has a parser branch, checked mechanically against the headers. `docs/matlab_gpu.rst`, which said unrecognised fields are "ignored without warning", is updated in the same branch.

## Test plan

`matlab/test/check_opts.m` checks both directions — a typo'd field warns with the expected id, and a valid opts struct (which picks up `floatprec` on the way through) warns not at all. Registered in the octave ctest list (`matlab/CMakeLists.txt`) and the makefile `octave` target, so it runs in the Octave workflow.

- [x] Passes under Octave against the patched MEX: `check_opts: passed`
- [x] Fails against a MEX built from the parent commit: `error: check_opts: mistyped opts field did not warn (id was "")`
- [x] GPU half built and run for real: `cufinufft.mexa64` via the `matlab` CMake preset (CUDA 13.3, `sm_89`, `g++-12` as host and CUDA host compiler), exercised from MATLAB R2025b on an RTX 4070:
  - `opts.gpu_methhod = 2` → `id = FINUFFT:unknownOpt`, `copy_cufinufft_opts: unknown option "gpu_methhod" ignored.`
  - `opts.gpu_obinsizex = 8, opts.gpu_method = 1` → no warning, i.e. the newly wired option is accepted rather than reported unknown.

Note unrelated to this PR: that ad-hoc build makes MATLAB abort at exit with `free(): chunks in smallbin corrupted`, *after* the transform returns correct results. It reproduces identically with `matlab/cufinufft.cu` restored from `master`, so it is not this change — most likely the unsupported build combination (MATLAB R2025b ships its own CUDA, this MEX links CUDA 13.3, linked with mold). CI builds with CUDA 12.4 against R2023b and does not hit it.

