### PR TITLE
Reuse the type-1 spread scratch across batches within one execute

### DIFF
--- a/include/finufft/execute.hpp
+++ b/include/finufft/execute.hpp
@@ -240,7 +240,8 @@ void FINUFFT_PLAN_T<T>::deconvolveshuffle3d(int dir, T prefac, T *fk,
 
 template<typename T>
 int FINUFFT_PLAN_T<T>::spreadinterpSortedBatch(
-    int batchSize, std::complex<T> *fwBatch, std::complex<T> *cBatch, bool adjoint) const
+    int batchSize, std::complex<T> *fwBatch, std::complex<T> *cBatch, bool adjoint,
+    std::vector<SpreadScratch<T>> &scratch) const
 /*
   Spreads (or interpolates) a batch of batchSize strength vectors in cBatch
   to (or from) the batch of fine working grids fwBatch, using the same set of
@@ -264,7 +265,7 @@ int FINUFFT_PLAN_T<T>::spreadinterpSortedBatch(
   // folding it in would expose no parallelism. Both beat the old nested case.
   if ((m.spopts.spread_direction == 1) != adjoint) {
     spreadSorted(reinterpret_cast<T *>(fwBatch), reinterpret_cast<const T *>(cBatch),
-                 batchSize);
+                 batchSize, scratch);
     return 0;
   }
   for (int i = 0; i < batchSize; i++) {
@@ -370,6 +371,10 @@ int FINUFFT_PLAN_T<TF>::execute_internal(TC *cj, TC *fk, bool adjoint, int ntran
              adjoint ? " adjoint" : "", ntrans_actual, nbatch, batchSize);
     // allocate temporary buffers
     bool scratch_provided = scratch_size >= size_t(nf() * batchSize);
+    // Lives for the whole execute, so the spreader's per-thread buffers are
+    // allocated once here rather than once per batch. Automatic storage: two
+    // threads executing this plan at the same time get one each.
+    std::vector<SpreadScratch<TF>> spread_scratch;
     std::vector<TC, xsimd::aligned_allocator<TC, 64>> fwBatch_(
         scratch_provided ? 0 : nf() * batchSize);
     TC *fwBatch = scratch_provided ? aligned_scratch : fwBatch_.data();
@@ -388,7 +393,8 @@ int FINUFFT_PLAN_T<TF>::execute_internal(TC *cj, TC *fk, bool adjoint, int ntran
       // usually spread/interp to/from fwBatch (vs spreadinterponly: to/from user grid)
       TC *fwBatch_or_fkb = opts.spreadinterponly ? fkb : fwBatch;
       if ((type == 1) != adjoint) { // spread NU pts X, weights cj, to fw grid
-        spreadinterpSortedBatch(thisBatchSize, fwBatch_or_fkb, cjb, adjoint);
+        spreadinterpSortedBatch(thisBatchSize, fwBatch_or_fkb, cjb, adjoint,
+                                spread_scratch);
         t_sprint += timer.elapsedsec();
         if (opts.spreadinterponly) // we're done (skip to next iteration of loop)
           continue;
@@ -411,7 +417,8 @@ int FINUFFT_PLAN_T<TF>::execute_internal(TC *cj, TC *fk, bool adjoint, int ntran
         deconvolveBatch(thisBatchSize, fkb, fwBatch, adjoint);
         t_deconv += timer.elapsedsec();
       } else { // interpolate unif fw grid to NU target pts
-        spreadinterpSortedBatch(thisBatchSize, fwBatch_or_fkb, cjb, adjoint);
+        spreadinterpSortedBatch(thisBatchSize, fwBatch_or_fkb, cjb, adjoint,
+                                spread_scratch);
         t_sprint += timer.elapsedsec();
       }
     } // ........end b loop
@@ -446,6 +453,8 @@ int FINUFFT_PLAN_T<TF>::execute_internal(TC *cj, TC *fk, bool adjoint, int ntran
     // so that it doesn't need to be reallocated for every batch.
     std::vector<TC, xsimd::aligned_allocator<TC, 64>> buf1, buf2, buf3;
     TC *CpBatch, *fwBatch, *fwBatch_inner;
+    // as for types 1 and 2: one scratch for the whole execute, reused per batch
+    std::vector<SpreadScratch<TF>> spread_scratch;
     if (!adjoint) { // we can combine CpBatch and fwBatch_inner!
       buf1.resize(
           std::max(m.nj * batchSize, m.innerT2plan->nf() * m.innerT2plan->batchSize));
@@ -493,8 +502,8 @@ int FINUFFT_PLAN_T<TF>::execute_internal(TC *cj, TC *fk, bool adjoint, int ntran
 
         // STEP 1: spread c'_j batch (x'_j NU pts) into internal fw batch grid...
         timer.restart();
-        spreadinterpSortedBatch(thisBatchSize, fwBatch, CpBatch,
-                                adjoint); // X are primed
+        spreadinterpSortedBatch(thisBatchSize, fwBatch, CpBatch, adjoint,
+                                spread_scratch); // X are primed
         t_sprint += timer.elapsedsec();
 
         // STEP 2: type 2 NUFFT from fw batch to user output fk array batch...
@@ -528,8 +537,8 @@ int FINUFFT_PLAN_T<TF>::execute_internal(TC *cj, TC *fk, bool adjoint, int ntran
         t_inner += timer.elapsedsec();
         // STEP 2: interpolate fwBatch into user output array ...
         timer.restart();
-        spreadinterpSortedBatch(thisBatchSize, fwBatch, cjb,
-                                adjoint); // X are primed
+        spreadinterpSortedBatch(thisBatchSize, fwBatch, cjb, adjoint,
+                                spread_scratch); // X are primed
         t_sprint += timer.elapsedsec();
         // STEP 3: post-phase (possibly) the c_j output strengths (in place) ...
         timer.restart();

--- a/include/finufft/plan.hpp
+++ b/include/finufft/plan.hpp
@@ -4,6 +4,7 @@
 #include <complex>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "finufft_common/common.h"
 #include "finufft_errors.h"
@@ -55,6 +56,16 @@ inline void MY_OMP_SET_LOCK [[maybe_unused]] (my_omp_lock_t *) {}
 inline void MY_OMP_UNSET_LOCK [[maybe_unused]] (my_omp_lock_t *) {}
 #endif
 
+// One thread's scratch for the subproblem loop in spreadSorted. Owned by the
+// caller, so its capacity survives from one batch to the next: du0 is a whole
+// padded subgrid, which is large enough that some allocators hand it back to the
+// OS on free, and doing that once per transform can cost more than the spreading
+// itself. Automatic storage in execute_internal, so concurrent executes on one
+// plan each get their own and nothing has to be cleaned up.
+template<typename TF> struct SpreadScratch {
+  std::vector<TF> kx0, ky0, kz0, dd0, du0;
+};
+
 // Forward declaration only. Full definition in src/fft.cpp.
 template<typename T> class Finufft_FFT_plan;
 
@@ -86,7 +97,8 @@ private:
   };
 
   int spreadinterpSortedBatch(int batchSize, std::complex<TF> *fwBatch,
-                              std::complex<TF> *cBatch, bool adjoint) const;
+                              std::complex<TF> *cBatch, bool adjoint,
+                              std::vector<SpreadScratch<TF>> &scratch) const;
   int deconvolveBatch(int batchSize, std::complex<TF> *fkBatch, std::complex<TF> *fwBatch,
                       bool adjoint) const;
   void deconvolveshuffle1d(int dir, TF prefac, TF *fk, std::complex<TF> *fw) const;
@@ -238,7 +250,7 @@ private:
   // assigned (vector, subprob) pairs out of the batchSize*nb of them. The per-vector
   // strides are the plan's own 2*nf() and 2*nj.
   int spreadSorted(TF *FINUFFT_RESTRICT data_uniform, const TF *data_nonuniform,
-                   int batchSize = 1) const;
+                   int batchSize, std::vector<SpreadScratch<TF>> &scratch) const;
   int interpSorted(TF *FINUFFT_RESTRICT data_uniform,
                    TF *FINUFFT_RESTRICT data_nonuniform) const;
   int interpSorted_1d(TF *data_uniform, TF *data_nonuniform) const;

--- a/include/finufft/spreadinterp.hpp
+++ b/include/finufft/spreadinterp.hpp
@@ -300,16 +300,18 @@ int FINUFFT_PLAN_T<TF>::spreadinterpSorted(TF *data_uniform, TF *data_nonuniform
    Converted to class member, Barbone 2/24/26.
 */
 {
-  if ((m.spopts.spread_direction == 1) != adjoint) // ======== direction 1 (spreading)
-    spreadSorted(data_uniform, data_nonuniform);
-  else // ================= direction 2 (interpolation) ===========
+  if ((m.spopts.spread_direction == 1) != adjoint) { // ======== direction 1 (spreading)
+    std::vector<SpreadScratch<TF>> scratch;          // one vector, so nothing to reuse
+    spreadSorted(data_uniform, data_nonuniform, 1, scratch);
+  } else // ================= direction 2 (interpolation) ===========
     interpSorted(data_uniform, data_nonuniform);
   return 0;
 }
 
 template<typename TF>
 int FINUFFT_PLAN_T<TF>::spreadSorted(TF *FINUFFT_RESTRICT data_uniform,
-                                     const TF *data_nonuniform, int batchSize) const
+                                     const TF *data_nonuniform, int batchSize,
+                                     std::vector<SpreadScratch<TF>> &scratch) const
 /* Spread NU pts (in sort order) to a uniform grid. See spreadinterpSorted() for doc.
    Plan members used in place of the former free-function arguments:
    sortIndices, nfdim[0..2], nj, XYZ[0..2], spopts, didSort, horner_coeffs, nc.
@@ -411,10 +413,19 @@ int FINUFFT_PLAN_T<TF>::spreadSorted(TF *FINUFFT_RESTRICT data_uniform,
       printf("\tup to %d writers per output: add_wrapped switching to atomic (!)\n",
              (int)std::min((UBIGINT)nthr, nb));
 
+    // One scratch per thread, grown once and then reused. resize() below keeps
+    // whatever capacity the previous batch left behind, so the steady state asks
+    // the allocator for nothing.
+    if (scratch.size() < size_t(nthr)) scratch.resize(nthr);
 #pragma omp parallel num_threads(nthr)
     {
       // local copies of NU pts and data for each subproblem
-      std::vector<TF> kx0{}, ky0{}, kz0{}, dd0{}, du0{};
+      auto &sc  = scratch[MY_OMP_GET_THREAD_NUM()];
+      auto &kx0 = sc.kx0;
+      auto &ky0 = sc.ky0;
+      auto &kz0 = sc.kz0;
+      auto &dd0 = sc.dd0;
+      auto &du0 = sc.du0;
 #pragma omp for collapse(2) schedule(dynamic, 1) // each is big
       for (int ib = 0; ib < batchSize; ib++)
         for (BIGINT isub = 0; isub < BIGINT(nb); isub++) { // Main loop through

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -9,8 +9,8 @@ using FLT = double;
 #endif
 
 // Suppress re-instantiation of all spread/interp method templates.
-extern template int FINUFFT_PLAN_T<FLT>::spreadSorted(FLT *FINUFFT_RESTRICT, const FLT *,
-                                                      int) const;
+extern template int FINUFFT_PLAN_T<FLT>::spreadSorted(
+    FLT *FINUFFT_RESTRICT, const FLT *, int, std::vector<SpreadScratch<FLT>> &) const;
 extern template int FINUFFT_PLAN_T<FLT>::interpSorted(FLT *FINUFFT_RESTRICT,
                                                        FLT *FINUFFT_RESTRICT) const;
 extern template void FINUFFT_PLAN_T<FLT>::spread_subproblem_1d(BIGINT, UBIGINT, FLT *,

--- a/src/spreadinterp.cpp
+++ b/src/spreadinterp.cpp
@@ -24,8 +24,8 @@ extern template int FINUFFT_PLAN_T<FLT>::interpSorted_1d(FLT *, FLT *) const;
 extern template int FINUFFT_PLAN_T<FLT>::interpSorted_2d(FLT *, FLT *) const;
 extern template int FINUFFT_PLAN_T<FLT>::interpSorted_3d(FLT *, FLT *) const;
 
-template int FINUFFT_PLAN_T<FLT>::spreadSorted(FLT *FINUFFT_RESTRICT, const FLT *,
-                                               int) const;
+template int FINUFFT_PLAN_T<FLT>::spreadSorted(FLT *FINUFFT_RESTRICT, const FLT *, int,
+                                               std::vector<SpreadScratch<FLT>> &) const;
 template int FINUFFT_PLAN_T<FLT>::interpSorted(FLT *FINUFFT_RESTRICT,
                                                FLT *FINUFFT_RESTRICT) const;
 template int FINUFFT_PLAN_T<FLT>::spreadinterpSorted(FLT *, FLT *, bool) const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,16 @@ function(add_tests_with_prec PREC REQ_TOL CHECK_TOL SUFFIX)
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 
+    # maxbatchsize=1 forces nbatch=ntrans, so spreadSorted is called once per
+    # transform and the per-execute spread scratch is reused between calls. The
+    # other many-tests leave maxbatchsize=0, which gives nbatch=1 on any machine
+    # with >=3 threads and so never re-enters the spreader with a used scratch.
+    add_test(
+        NAME run_finufft1dmany_test_nbatch_${PREC}
+        COMMAND finufft1dmany_test${SUFFIX} 8 1e2 2e2 ${REQ_TOL} 0 1 2 0.0 ${CHECK_TOL}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+
     add_test(
         NAME run_finufft2d_test_${PREC}
         COMMAND finufft2d_test${SUFFIX} 1e2 1e1 1e3 ${REQ_TOL} 0 2 0.0 ${CHECK_TOL}
@@ -112,6 +122,12 @@ function(add_tests_with_prec PREC REQ_TOL CHECK_TOL SUFFIX)
     add_test(
         NAME run_finufft2dmany_test_${PREC}
         COMMAND finufft2dmany_test${SUFFIX} 3 1e2 1e1 1e3 ${REQ_TOL} 0 0 2 0.0 ${CHECK_TOL}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+
+    add_test(
+        NAME run_finufft2dmany_test_nbatch_${PREC}
+        COMMAND finufft2dmany_test${SUFFIX} 8 1e2 1e1 1e3 ${REQ_TOL} 0 1 2 0.0 ${CHECK_TOL}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 


### PR DESCRIPTION
Fixes [#902](https://github.com/flatironinstitute/finufft/issues/902).

## The problem

`spreadSorted` declares `kx0`, `ky0`, `kz0`, `dd0` and `du0` inside its `omp parallel` region, so all five are constructed and destroyed on every call.
With `opts.nthreads = 1` the batch size is 1, so that is one allocate-and-free of a subgrid-sized `du0` per transform, per calling thread.

On macOS such a block sits in the medium malloc magazine, and once the process heap has grown the allocator returns it to the kernel with `madvise` on free.
`madvise` takes the process-wide VM map lock, so the calling threads serialize on it.
The type-1 execute goes from a steady 24 ms to between 47 and 128 ms with no change to the transform, entirely in system time.
#902 has the full measurement, the `sample` call chain, and the `MallocMediumZone=0` control that attributes the cost to the allocator.

## The change

The scratch now lives for one `execute` call instead of one `spreadSorted` call.

- `SpreadScratch<TF>` in `plan.hpp` holds the five vectors for one thread.
- `execute_internal` declares one `std::vector<SpreadScratch<TF>>` per call, in both the type 1 and 2 branch and the type 3 branch.
- It is passed to `spreadinterpSortedBatch` and on to `spreadSorted`, which sizes it to `nthr` once and indexes it by thread number inside the parallel region.
- `resize` then keeps whatever capacity the previous batch left behind, so the steady state asks the allocator for nothing.

This is one allocation per execute rather than one per batch.
On the workload in the issue, `nbatch = ntrans = 410` per execute, so it removes 409 of every 410 allocate-and-free pairs.

The buffers are in automatic storage, so nothing has to be cleaned up, `execute` stays `const` with no `mutable` member, and two threads executing one plan concurrently each get their own scratch.
No new dependency and no platform-specific code.

## Testing

CTest did not cover the new behaviour as it stood.
Every many-transform test passes `maxbatchsize=0` with `ntrans=3`, which gives `nbatch=1` on any machine with three or more threads, so `spreadSorted` was called once per execute and never re-entered with a used scratch.

This PR adds four tests, 1D and 2D at both precisions, that pass `maxbatchsize=1` and so force `nbatch=ntrans`.
The many-tests compare each batched transform against repeated single transforms, which is exactly the check that stale scratch would fail.

Verified on macOS.

- 46 of 46 CTest targets pass on the `dev` preset, including `run_threadsafe_execute`.
- 45 of 45 pass on the `sanitizers` preset, ASan and UBSan, with no sanitizer reports.
- `threadsafe_execute` under ThreadSanitizer reports no race.
- The 659 Python tests pass against a wheel built from this branch.
- Both `float` and `double` instantiations build with `-Werror`.
- 1D, 2D and 3D many-tests with `maxbatchsize=1`, all three types, agree with repeated single transforms to between 0 and 7.6e-12.

Output is bit-identical, since only where the buffers live has changed.

The list above is macOS.
The same branch was also checked on Linux, since the bug itself does not reproduce there and the change should not cost anything on a platform that was never affected.
Debian bookworm, glibc 2.36, GCC 12, FFTW 3.3.10, aarch64 in a VM.

- 46 of 46 CTest targets pass, including the four new `maxbatchsize=1` tests and `run_threadsafe_execute`.
- 30 of 30 pass built with `-fsanitize=address,undefined`, with no sanitizer reports.
- `threadsafe_execute` under ThreadSanitizer exits clean with no warnings.
- Three interleaved baseline-versus-patched pairs of the issue's reproduction. Type 1 goes from 23.4, 23.5 and 23.5 ms to 22.9, 23.0 and 22.9 ms, with system time under 4 ms throughout on both builds. No regression, and a small consistent gain from the saved allocation.

## Performance

Same machine, same build, using the reproduction program from the issue, minimum of five, ms.

| build | phase | type | wall | user | sys |
|---|---|---|---|---|---|
| before | clean | 1 | 23.8 | 235.7 | 0.3 |
| before | after heap growth | 1 | 122.4 | 215.9 | 451.5 |
| after | clean | 1 | 23.1 | 229.8 | 0.3 |
| after | after heap growth | 1 | 24.5 | 230.0 | 2.2 |

After the change the type-1 execute returns to its clean-process value.
The clean-process numbers are unchanged, so this costs nothing when the allocator was not the problem.
Across repeated runs the patched system time stays between 2 and 8 ms, where the baseline ranged from 104 to 451 ms.

### With the in-tree benchmark

`perftest/guru_timing_test` reaches the same code path without any special setup.
`maxbatchsize=1` makes `nbatch = ntransf`, so `spreadSorted` runs once per transform.
Single-threaded, 1D type 1, `ntransf=200`, `N=M=4097`, `tol=1e-6`, guru exec time in seconds, four runs each.

```
guru_timing_test 200 1 1 4097 0 0 4097 1e-6 0 1
```

| build | run 1 | run 2 | run 3 | run 4 |
|---|---|---|---|---|
| before | 0.0199 | 0.0137 | 0.0133 | 0.0117 |
| after | 0.0142 | 0.0116 | 0.0114 | 0.0113 |

This is a clean process, so it measures only the saved allocation and zero-fill, not the `madvise` behaviour, which needs a grown heap.
The gain is largest on the first run of a process and shrinks as the allocator warms up.

Two cases where it correctly shows nothing.
The same test in 3D, `ntransf=50`, `64^3`, 200k points, is unchanged at 1.87 to 1.89 s in both builds, because spreading dominates and the scratch is a small fraction of it.
`perftest/manysmallprobs`, which uses `ntrans=1` and calls execute 20000 times, is unchanged at 1.00 to 1.03 s in both builds. There is no batch to reuse across, and no regression from the extra per-execute object either.

Peak RSS does not regress.
On a 3D case with 2M points and several batches it is slightly lower, 1275 MB against 1305 MB at 10 threads, and 1454 MB against 1492 MB at 14 threads.
The peak occurs during spreading, when both versions hold `nthr` subgrids anyway.

## The tuning alternative

`spread_max_sp_size` low enough to bring `du0` under the platform's size boundary removes the cost without any code change, and #902 reports the measurement.
It is not proposed as the answer because the value depends on dimension, tolerance and `upsampfac` through the subgrid size, and on where the boundary sits on the platform, which is 32 KiB on macOS here and 128 KiB by default under glibc.
It also leaves the per-transform allocate-and-free in place, and only the caller who knows to set it benefits.
It also changes the output. A different subproblem decomposition accumulates in a different order, so 3448 of 4097 values move by 3e-15 relative on the transform in the issue.
This patch fixes the default instead, and is bit-identical.