### PR TITLE
fix: keep the bin-sort placement loops scalar on icpx

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@ If not stated, FINUFFT is assumed (old cuFINUFFT <=1.3 is listed separately).
 
 v2.6.0-dev
 
+* icpx before 2026.0 miscompiles bin sorting by not recognizing a loop carried and
+  generating the wrong vectorization. Fixed by disabling vectorization on that
+  particular loop #914. (Menke)
 * Fixed CPU type 3 honoring `opts.spreadinterponly`: the option is documented to affect
   types 1 and 2 only, and cuFINUFFT already ignored it for type 3, but the CPU plan
   applied it, so a type-3 call with the flag set returned wrong values instead of the

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -80,8 +80,8 @@ set(FINUFFT_CXX_FLAGS_WARNINGS
 # clang 18 reports a lone -fcx-limited-range as overriding the empty option it compares
 # against; clang 19 fixed that comparison. GCC accepts the unknown -Wno- silently, which
 # then annotates every later diagnostic, so ask for it on clang alone.
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    list(APPEND FINUFFT_CXX_FLAGS_WARNINGS -Wno-overriding-option)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
+    list(APPEND FINUFFT_CXX_FLAGS_WARNINGS -Wno-overriding-option -Wno-overriding-complex-range)
 endif()
 filter_supported_compiler_flags(FINUFFT_CXX_FLAGS_WARNINGS FINUFFT_CXX_FLAGS_WARNINGS)
 message(STATUS "FINUFFT warning flags: ${FINUFFT_CXX_FLAGS_WARNINGS}")

--- a/include/finufft/spread.hpp
+++ b/include/finufft/spread.hpp
@@ -571,11 +571,13 @@ inline void bin_sort_singlethread_impl(std::vector<BIGINT> &ret, UBIGINT M, cons
   for (i = 0; i < simd_M; i += simd_size) {
     const auto bin       = compute_bins(i);
     const auto bin_array = to_array(bin);
+    FINUFFT_NO_VECTORIZE_ON_INTEL
     for (std::size_t j = 0; j < simd_size; ++j) {
       ret[counts[bin_array[j]]] = BIGINT(j + i);
       ++counts[bin_array[j]];
     }
   }
+  FINUFFT_NO_VECTORIZE_ON_INTEL
   for (; i < M; i++) {
     const auto bin   = compute_bin_scalar(i);
     ret[counts[bin]] = BIGINT(i);
@@ -726,11 +728,13 @@ inline void bin_sort_multithread_impl(std::vector<BIGINT> &ret, UBIGINT M, const
     for (i = chunk_start; i < chunk_simd; i += simd_size) {
       const auto bin       = compute_bins(i);
       const auto bin_array = to_array(bin);
+      FINUFFT_NO_VECTORIZE_ON_INTEL
       for (std::size_t j = 0; j < simd_size; ++j) {
         ret[my_counts[bin_array[j]]] = BIGINT(j + i);
         ++my_counts[bin_array[j]];
       }
     }
+    FINUFFT_NO_VECTORIZE_ON_INTEL
     for (; i < chunk_end; i++) {
       const auto bin      = compute_bin_scalar(i);
       ret[my_counts[bin]] = BIGINT(i);

--- a/include/finufft_common/defines.h
+++ b/include/finufft_common/defines.h
@@ -78,6 +78,16 @@ using UBIGINT = uint64_t;
 #define FINUFFT_LIKELY(x)   (x)
 #endif
 
+// Suppress auto-vectorization of the loop that follows. The bin-sort placement
+// loops (spread.hpp) carry a dependence through counts[] that icpx before 2026.0
+// vectorizes wrongly: it omits the AVX-512 conflict rank from the scatter index,
+// so lanes sharing a bin collide. g++ and icpx 2026.0 leave these loops scalar.
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20260000)
+#define FINUFFT_NO_VECTORIZE_ON_INTEL _Pragma("clang loop vectorize(disable)")
+#else
+#define FINUFFT_NO_VECTORIZE_ON_INTEL
+#endif
+
 // Portable diagnostic push/pop and deprecation-warning suppression.
 #if defined(__GNUC__)
 #define FINUFFT_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")


### PR DESCRIPTION
The placement pass walks `ret[counts[bin]] = i; ++counts[bin];`, which carries a dependence through counts[]: two points of one vector group falling in the same bin must land in consecutive slots, so vectorizing it means folding the AVX-512 conflict rank into the scatter index. icpx before 2026.0, at -O2/-O3 with -march=skylake-avx512, folds it into the counts[] update but not into the ret[] scatter, so conflicting lanes overwrite one slot and leave another unwritten. sortIndices then drops a point and duplicates another, which shows up as O(10%) errors in every dir=1 transform -- dumbinputs and tolsweep fail in both precisions for types 1 and 3, while type 2 escapes because 1D dir=2 is never sorted.

Checked on the loop in isolation: icpx 2023.1, 2024.0 and 2025.0-2025.3 all miscompile it; 2026.0 keeps the (correct) conflict-corrected histogram in the counting loops but no longer vectorizes the placement loops, and g++ 14-16 never did. Hence the new marker is armed only for icpx < 2026.0. The loops were already meant to be scalar and only their sub-SIMD-width tails were being vectorized, so a 2e7-point bin sort is unchanged within noise.

Assisted-by: Claude <noreply@anthropic.com>